### PR TITLE
[codex] Improve Windows sync performance and resiliency

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -59,6 +59,7 @@ function summarizeSync(result, label) {
     `${label} provider: ${result.targetProvider}`,
     `Codex home: ${result.codexHome}`,
     `Backup: ${result.backupDir}`,
+    `Backup creation time: ${formatDuration(result.backupDurationMs ?? 0)}`,
     `Updated rollout files: ${result.changedSessionFiles}`,
     `Updated SQLite rows: ${result.sqliteRowsUpdated}${result.sqlitePresent ? "" : " (state_5.sqlite not found)"}`
   ];
@@ -99,6 +100,53 @@ function formatBytes(bytes) {
   return unitIndex === 0 ? `${bytes} B` : `${value.toFixed(value >= 10 ? 1 : 2).replace(/\.0$/, "")} ${units[unitIndex]}`;
 }
 
+function formatDuration(durationMs) {
+  if (!Number.isFinite(durationMs) || durationMs < 1000) {
+    return `${Math.max(0, Math.round(durationMs ?? 0))} ms`;
+  }
+
+  const seconds = durationMs / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(seconds >= 10 ? 1 : 2).replace(/\.0$/, "")} s`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds - (minutes * 60);
+  return `${minutes}m ${remainingSeconds.toFixed(remainingSeconds >= 10 ? 0 : 1).replace(/\.0$/, "")}s`;
+}
+
+const SYNC_PROGRESS_STAGES = [
+  ["scan_rollout_files", "Scanning rollout files..."],
+  ["check_locked_rollout_files", "Checking locked rollout files..."],
+  ["create_backup", "Creating backup..."],
+  ["update_sqlite", "Updating SQLite..."],
+  ["rewrite_rollout_files", "Rewriting rollout files..."],
+  ["clean_backups", "Cleaning backups..."]
+];
+
+const SYNC_PROGRESS_STAGE_INDEX = new Map(
+  SYNC_PROGRESS_STAGES.map(([stage], index) => [stage, index + 1])
+);
+
+function createSyncProgressReporter() {
+  return (event) => {
+    if (event?.stage === "update_config" && event.status === "start") {
+      console.log(`Updating config.toml root model_provider to ${event.provider}...`);
+      return;
+    }
+
+    const stageIndex = SYNC_PROGRESS_STAGE_INDEX.get(event?.stage);
+    if (!stageIndex || event.status !== "start") {
+      if (event?.stage === "create_backup" && event.status === "complete") {
+        console.log(`     Backup created in ${formatDuration(event.durationMs)}: ${event.backupDir}`);
+      }
+      return;
+    }
+
+    console.log(`[${stageIndex}/${SYNC_PROGRESS_STAGES.length}] ${SYNC_PROGRESS_STAGES[stageIndex - 1][1]}`);
+  };
+}
+
 function parseKeepCount(rawValue, { allowZero = false } = {}) {
   if (rawValue === undefined) {
     return DEFAULT_BACKUP_RETENTION_COUNT;
@@ -135,7 +183,8 @@ async function main() {
     const result = await runSync({
       codexHome: flags["codex-home"],
       provider: flags.provider,
-      keepCount: parseKeepCount(flags.keep)
+      keepCount: parseKeepCount(flags.keep),
+      onProgress: createSyncProgressReporter()
     });
     console.log(summarizeSync(result, "Synchronized"));
     return;
@@ -146,7 +195,8 @@ async function main() {
     const result = await runSwitch({
       codexHome: flags["codex-home"],
       provider,
-      keepCount: parseKeepCount(flags.keep)
+      keepCount: parseKeepCount(flags.keep),
+      onProgress: createSyncProgressReporter()
     });
     console.log(summarizeSync(result, "Switched to"));
     return;

--- a/src/locking.js
+++ b/src/locking.js
@@ -3,17 +3,59 @@ import path from "node:path";
 
 import { DEFAULT_LOCK_NAME } from "./constants.js";
 
-export async function acquireLock(codexHome, label = "codex-provider-sync") {
-  const lockDir = path.join(codexHome, "tmp", DEFAULT_LOCK_NAME);
-  await fs.mkdir(path.dirname(lockDir), { recursive: true });
-  try {
-    await fs.mkdir(lockDir);
-  } catch (error) {
-    if (error && error.code === "EEXIST") {
-      throw new Error(`Lock already exists at ${lockDir}. Close Codex/App and retry, or remove the stale lock if you are sure no sync is running.`);
+const DEFAULT_LOCK_CREATE_RETRY_COUNT = 3;
+const DEFAULT_LOCK_CREATE_RETRY_DELAY_MS = 75;
+
+function isTransientLockCreateError(error) {
+  return error?.code === "EPERM";
+}
+
+async function sleep(delayMs) {
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function createLockDirectory(lockDir, {
+  fsImpl,
+  retryCount,
+  retryDelayMs,
+  sleepImpl
+}) {
+  let attempts = 0;
+  while (true) {
+    try {
+      await fsImpl.mkdir(lockDir);
+      return;
+    } catch (error) {
+      if (error && error.code === "EEXIST") {
+        throw new Error(`Lock already exists at ${lockDir}. Close Codex/App and retry, or remove the stale lock if you are sure no sync is running.`);
+      }
+
+      // Windows can briefly surface EPERM after a previous run releases the lock directory.
+      if (!isTransientLockCreateError(error) || attempts >= retryCount) {
+        throw error;
+      }
+
+      attempts += 1;
+      await sleepImpl(retryDelayMs);
     }
-    throw error;
   }
+}
+
+export async function acquireLock(codexHome, label = "codex-provider-sync", options = {}) {
+  const {
+    fsImpl = fs,
+    retryCount = DEFAULT_LOCK_CREATE_RETRY_COUNT,
+    retryDelayMs = DEFAULT_LOCK_CREATE_RETRY_DELAY_MS,
+    sleepImpl = sleep
+  } = options;
+  const lockDir = path.join(codexHome, "tmp", DEFAULT_LOCK_NAME);
+  await fsImpl.mkdir(path.dirname(lockDir), { recursive: true });
+  await createLockDirectory(lockDir, {
+    fsImpl,
+    retryCount,
+    retryDelayMs,
+    sleepImpl
+  });
 
   const ownerPath = path.join(lockDir, "owner.json");
   const owner = {
@@ -22,7 +64,7 @@ export async function acquireLock(codexHome, label = "codex-provider-sync") {
     label,
     cwd: process.cwd()
   };
-  await fs.writeFile(ownerPath, JSON.stringify(owner, null, 2), "utf8");
+  await fsImpl.writeFile(ownerPath, JSON.stringify(owner, null, 2), "utf8");
 
   let released = false;
   return async function releaseLock() {
@@ -30,6 +72,6 @@ export async function acquireLock(codexHome, label = "codex-provider-sync") {
       return;
     }
     released = true;
-    await fs.rm(lockDir, { recursive: true, force: true });
+    await fsImpl.rm(lockDir, { recursive: true, force: true });
   };
 }

--- a/src/service.js
+++ b/src/service.js
@@ -61,6 +61,12 @@ function formatBytes(bytes) {
   return unitIndex === 0 ? `${bytes} B` : `${value.toFixed(value >= 10 ? 1 : 2).replace(/\.0$/, "")} ${units[unitIndex]}`;
 }
 
+function emitProgress(onProgress, event) {
+  if (typeof onProgress === "function") {
+    onProgress(event);
+  }
+}
+
 export async function getStatus({ codexHome: explicitCodexHome } = {}) {
   const codexHome = normalizeCodexHome(explicitCodexHome);
   await ensureCodexHome(codexHome);
@@ -115,7 +121,8 @@ export async function runSync({
   provider,
   configBackupText,
   keepCount = DEFAULT_BACKUP_RETENTION_COUNT,
-  sqliteBusyTimeoutMs
+  sqliteBusyTimeoutMs,
+  onProgress
 } = {}) {
   if (!Number.isInteger(keepCount) || keepCount < 1) {
     throw new Error(`Invalid automatic keep count: ${keepCount}. Expected an integer greater than or equal to 1.`);
@@ -130,21 +137,45 @@ export async function runSync({
 
   const releaseLock = await acquireLock(codexHome, "sync");
   let backupDir = null;
+  let backupDurationMs = 0;
   try {
+    emitProgress(onProgress, { stage: "scan_rollout_files", status: "start" });
     const {
       changes,
       lockedPaths: lockedReadPaths,
       providerCounts
     } = await collectSessionChanges(codexHome, targetProvider, { skipLockedReads: true });
+    emitProgress(onProgress, {
+      stage: "scan_rollout_files",
+      status: "complete",
+      scannedChanges: changes.length,
+      lockedReadCount: lockedReadPaths.length
+    });
+
+    emitProgress(onProgress, { stage: "check_locked_rollout_files", status: "start" });
     const {
       writableChanges,
       lockedChanges
     } = await splitLockedSessionChanges(changes);
+    emitProgress(onProgress, {
+      stage: "check_locked_rollout_files",
+      status: "complete",
+      writableCount: writableChanges.length,
+      lockedCount: lockedChanges.length + lockedReadPaths.length
+    });
+
     const skippedRolloutFiles = [...new Set([
       ...lockedReadPaths,
       ...lockedChanges.map((change) => change.path)
     ])].sort((left, right) => left.localeCompare(right));
     await assertSqliteWritable(codexHome, { busyTimeoutMs: sqliteBusyTimeoutMs });
+
+    emitProgress(onProgress, {
+      stage: "create_backup",
+      status: "start",
+      writableCount: writableChanges.length
+    });
+    const backupStartedAt = Date.now();
     backupDir = await createBackup({
       codexHome,
       targetProvider,
@@ -152,11 +183,24 @@ export async function runSync({
       configPath,
       configBackupText
     });
+    backupDurationMs = Date.now() - backupStartedAt;
+    emitProgress(onProgress, {
+      stage: "create_backup",
+      status: "complete",
+      backupDir,
+      durationMs: backupDurationMs
+    });
 
     let sessionRestoreNeeded = false;
     let appliedSessionChanges = [];
     try {
       let applyResult = { appliedChanges: 0, appliedPaths: [], skippedPaths: [] };
+      emitProgress(onProgress, { stage: "update_sqlite", status: "start" });
+      emitProgress(onProgress, {
+        stage: "rewrite_rollout_files",
+        status: "start",
+        writableCount: writableChanges.length
+      });
       const sqliteResult = await updateSqliteProvider(
         codexHome,
         targetProvider,
@@ -172,22 +216,45 @@ export async function runSync({
         },
         { busyTimeoutMs: sqliteBusyTimeoutMs }
       );
+      emitProgress(onProgress, {
+        stage: "rewrite_rollout_files",
+        status: "complete",
+        appliedChanges: applyResult.appliedChanges,
+        skippedChanges: applyResult.skippedPaths.length
+      });
+      emitProgress(onProgress, {
+        stage: "update_sqlite",
+        status: "complete",
+        updatedRows: sqliteResult.updatedRows
+      });
       const skippedLockedRolloutFiles = [...new Set([
         ...skippedRolloutFiles,
         ...applyResult.skippedPaths
       ])].sort((left, right) => left.localeCompare(right));
       let autoPruneResult = null;
       let autoPruneWarning = null;
+      emitProgress(onProgress, {
+        stage: "clean_backups",
+        status: "start",
+        keepCount
+      });
       try {
         autoPruneResult = await pruneBackups(codexHome, keepCount);
       } catch (pruneError) {
         autoPruneWarning = `Automatic backup cleanup failed: ${pruneError instanceof Error ? pruneError.message : String(pruneError)}`;
       }
+      emitProgress(onProgress, {
+        stage: "clean_backups",
+        status: "complete",
+        deletedCount: autoPruneResult?.deletedCount ?? 0,
+        warning: autoPruneWarning
+      });
       return {
         codexHome,
         targetProvider,
         previousProvider: current.provider,
         backupDir,
+        backupDurationMs,
         changedSessionFiles: applyResult.appliedChanges,
         skippedLockedRolloutFiles,
         sqliteRowsUpdated: sqliteResult.updatedRows,
@@ -220,7 +287,8 @@ export async function runSync({
 export async function runSwitch({
   codexHome: explicitCodexHome,
   provider,
-  keepCount = DEFAULT_BACKUP_RETENTION_COUNT
+  keepCount = DEFAULT_BACKUP_RETENTION_COUNT,
+  onProgress
 }) {
   if (!provider) {
     throw new Error("Missing provider id. Usage: codex-provider switch <provider-id>");
@@ -235,14 +303,25 @@ export async function runSwitch({
   }
 
   const nextConfigText = setRootProviderInConfigText(originalConfigText, provider);
+  emitProgress(onProgress, {
+    stage: "update_config",
+    status: "start",
+    provider
+  });
   await writeConfigText(configPath, nextConfigText);
+  emitProgress(onProgress, {
+    stage: "update_config",
+    status: "complete",
+    provider
+  });
 
   try {
     const syncResult = await runSync({
       codexHome,
       provider,
       configBackupText: originalConfigText,
-      keepCount
+      keepCount,
+      onProgress
     });
     return {
       ...syncResult,

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -108,9 +108,35 @@ function parseSessionMetaRecord(firstLine) {
   }
 }
 
-async function invokeWindowsExclusiveRewrite(change, { requireOriginalMatch }) {
+function isValidWindowsRewriteResult(result) {
+  return result === "APPLIED" || result === "SKIP_BUSY" || result === "SKIP_CHANGED";
+}
+
+function parseWindowsRewriteResults(stdout, changes) {
+  const trimmed = stdout.trim();
+  const parsed = trimmed ? JSON.parse(trimmed) : [];
+  const results = Array.isArray(parsed) ? parsed : [parsed];
+
+  if (results.length !== changes.length) {
+    throw new Error(`Unexpected rewrite result count. Expected ${changes.length}, received ${results.length}.`);
+  }
+
+  return results.map((entry, index) => {
+    const expectedPath = changes[index].path;
+    if (entry?.path !== expectedPath || !isValidWindowsRewriteResult(entry?.result)) {
+      throw new Error(`Unexpected rewrite result for ${expectedPath}: ${JSON.stringify(entry)}`);
+    }
+    return entry.result;
+  });
+}
+
+async function invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatch }) {
+  if (!changes.length) {
+    return [];
+  }
+
   const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "codex-provider-rewrite-"));
-  const manifestPath = path.join(tempDir, "change.json");
+  const manifestPath = path.join(tempDir, "changes.json");
   const script = `
 & {
   param([string]$manifestPath)
@@ -148,95 +174,110 @@ async function invokeWindowsExclusiveRewrite(change, { requireOriginalMatch }) {
     }
   }
 
-  $change = Get-Content -Raw -Path $manifestPath | ConvertFrom-Json
-  $path = [string]$change.path
-  $tmpPath = "$path.provider-sync.$PID.$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()).tmp"
-  $encoding = [System.Text.UTF8Encoding]::new($false)
-  $source = $null
-  $writer = $null
-  $tempReader = $null
-
-  try {
-    try {
-      $source = [System.IO.File]::Open($path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
-    } catch {
-      if (Test-Path $path) {
-        Write-Output "SKIP_BUSY"
-      } else {
-        Write-Output "SKIP_CHANGED"
-      }
-      return
-    }
-
-    if ([bool]$change.requireOriginalMatch) {
-      if ($source.Length -ne [int64]$change.originalSize) {
-        Write-Output "SKIP_CHANGED"
-        return
-      }
-
-      $record = Read-FirstLineRecord $source
-      if ($record.firstLine -ne [string]$change.originalFirstLine -or $record.offset -ne [int]$change.originalOffset) {
-        Write-Output "SKIP_CHANGED"
-        return
-      }
-
-      $separator = [string]$change.originalSeparator
-      $sourceOffset = [int64]$change.originalOffset
-      $headerOnly = $sourceOffset -ge [int64]$change.originalSize
-    } else {
-      $record = Read-FirstLineRecord $source
-      $separator = [string]$change.separator
-      $sourceOffset = [int64]$record.offset
-      $headerOnly = $record.offset -ge $source.Length
-    }
-
-    $writer = [System.IO.File]::Open($tmpPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
-    $firstLineBytes = $encoding.GetBytes([string]$change.updatedFirstLine)
-    $writer.Write($firstLineBytes, 0, $firstLineBytes.Length)
-
-    if (-not [string]::IsNullOrEmpty($separator)) {
-      $separatorBytes = $encoding.GetBytes($separator)
-      $writer.Write($separatorBytes, 0, $separatorBytes.Length)
-    }
-
-    if (-not $headerOnly) {
-      $source.Seek($sourceOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
-      $source.CopyTo($writer)
-    }
-
-    $writer.Flush()
-    $writer.Dispose()
+  function Invoke-RewriteChange($change) {
+    $path = [string]$change.path
+    $tmpPath = "$path.provider-sync.$PID.$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()).tmp"
+    $encoding = [System.Text.UTF8Encoding]::new($false)
+    $source = $null
     $writer = $null
+    $tempReader = $null
 
-    $tempReader = [System.IO.File]::OpenRead($tmpPath)
-    $source.SetLength(0)
-    $source.Seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
-    $tempReader.CopyTo($source)
-    $source.Flush()
+    try {
+      try {
+        $source = [System.IO.File]::Open($path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+      } catch {
+        if (Test-Path $path) {
+          return "SKIP_BUSY"
+        }
+        return "SKIP_CHANGED"
+      }
 
-    Write-Output "APPLIED"
-  } finally {
-    if ($tempReader) {
-      $tempReader.Dispose()
-    }
-    if ($writer) {
+      if ([bool]$change.requireOriginalMatch) {
+        if ($source.Length -ne [int64]$change.originalSize) {
+          return "SKIP_CHANGED"
+        }
+
+        $record = Read-FirstLineRecord $source
+        if ($record.firstLine -ne [string]$change.originalFirstLine -or $record.offset -ne [int]$change.originalOffset) {
+          return "SKIP_CHANGED"
+        }
+
+        $separator = [string]$change.originalSeparator
+        $sourceOffset = [int64]$change.originalOffset
+        $headerOnly = $sourceOffset -ge [int64]$change.originalSize
+      } else {
+        $record = Read-FirstLineRecord $source
+        $separator = [string]$change.separator
+        $sourceOffset = [int64]$record.offset
+        $headerOnly = $record.offset -ge $source.Length
+      }
+
+      $writer = [System.IO.File]::Open($tmpPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+      $firstLineBytes = $encoding.GetBytes([string]$change.updatedFirstLine)
+      $writer.Write($firstLineBytes, 0, $firstLineBytes.Length)
+
+      if (-not [string]::IsNullOrEmpty($separator)) {
+        $separatorBytes = $encoding.GetBytes($separator)
+        $writer.Write($separatorBytes, 0, $separatorBytes.Length)
+      }
+
+      if (-not $headerOnly) {
+        $source.Seek($sourceOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $source.CopyTo($writer)
+      }
+
+      $writer.Flush()
       $writer.Dispose()
+      $writer = $null
+
+      $tempReader = [System.IO.File]::OpenRead($tmpPath)
+      $source.SetLength(0)
+      $source.Seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
+      $tempReader.CopyTo($source)
+      $source.Flush()
+
+      return "APPLIED"
+    } finally {
+      if ($tempReader) {
+        $tempReader.Dispose()
+      }
+      if ($writer) {
+        $writer.Dispose()
+      }
+      if ($source) {
+        $source.Dispose()
+      }
+      Remove-Item -Path $tmpPath -Force -ErrorAction SilentlyContinue
     }
-    if ($source) {
-      $source.Dispose()
-    }
-    Remove-Item -Path $tmpPath -Force -ErrorAction SilentlyContinue
   }
+
+  $changes = Get-Content -Raw -Encoding UTF8 -Path $manifestPath | ConvertFrom-Json
+  if ($null -eq $changes) {
+    $changes = @()
+  } elseif ($changes -is [string] -or $changes -isnot [System.Collections.IEnumerable]) {
+    $changes = @($changes)
+  } else {
+    $changes = @($changes)
+  }
+
+  $results = @(foreach ($change in $changes) {
+    [pscustomobject]@{
+      path = [string]$change.path
+      result = Invoke-RewriteChange $change
+    }
+  })
+
+  $results | ConvertTo-Json -Compress
 }
 `.trim();
 
   try {
     await fsp.writeFile(
       manifestPath,
-      JSON.stringify({
+      JSON.stringify(changes.map((change) => ({
         ...change,
         requireOriginalMatch
-      }),
+      }))),
       "utf8"
     );
 
@@ -247,24 +288,21 @@ async function invokeWindowsExclusiveRewrite(change, { requireOriginalMatch }) {
       "-Command",
       script,
       manifestPath
-    ]);
+    ], {
+      maxBuffer: 16 * 1024 * 1024
+    });
 
-    const result = stdout
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .at(-1);
-
-    if (result === "APPLIED" || result === "SKIP_BUSY" || result === "SKIP_CHANGED") {
-      return result;
-    }
-
-    throw new Error(`Unexpected rewrite result for ${change.path}: ${stdout.trim() || "(empty output)"}`);
+    return parseWindowsRewriteResults(stdout, changes);
   } catch (error) {
-    throw wrapRolloutFileBusyError(error, change.path, "rewrite");
+    throw wrapRolloutFileBusyError(error, changes[0]?.path, "rewrite");
   } finally {
     await fsp.rm(tempDir, { recursive: true, force: true });
   }
+}
+
+async function invokeWindowsExclusiveRewrite(change, options) {
+  const [result] = await invokeWindowsExclusiveRewriteBatch([change], options);
+  return result;
 }
 
 async function rewriteFirstLine(filePath, nextFirstLine, separator) {
@@ -324,11 +362,6 @@ async function rewriteFirstLine(filePath, nextFirstLine, separator) {
 }
 
 async function tryRewriteCollectedFirstLine(change) {
-  if (process.platform === "win32") {
-    const result = await invokeWindowsExclusiveRewrite(change, { requireOriginalMatch: true });
-    return result === "APPLIED";
-  }
-
   const beforeSnapshot = await getFileSnapshot(change.path);
   if (!snapshotMatches(change, beforeSnapshot)) {
     return false;
@@ -387,7 +420,7 @@ async function findLockedFilesOnWindows(filePaths) {
   const script = `
 & {
   param([string]$manifestPath)
-  $paths = Get-Content -Raw -Path $manifestPath | ConvertFrom-Json
+  $paths = Get-Content -Raw -Encoding UTF8 -Path $manifestPath | ConvertFrom-Json
   foreach ($path in $paths) {
     try {
       $stream = [System.IO.File]::Open($path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
@@ -479,16 +512,29 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
 }
 
 export async function applySessionChanges(changes) {
+  const normalizedChanges = changes ?? [];
   const skippedPaths = [];
   const appliedPaths = [];
   let appliedChanges = 0;
 
-  for (const change of changes) {
-    if (await tryRewriteCollectedFirstLine(change)) {
-      appliedChanges += 1;
-      appliedPaths.push(change.path);
-    } else {
-      skippedPaths.push(change.path);
+  if (process.platform === "win32") {
+    const results = await invokeWindowsExclusiveRewriteBatch(normalizedChanges, { requireOriginalMatch: true });
+    for (let index = 0; index < normalizedChanges.length; index += 1) {
+      if (results[index] === "APPLIED") {
+        appliedChanges += 1;
+        appliedPaths.push(normalizedChanges[index].path);
+      } else {
+        skippedPaths.push(normalizedChanges[index].path);
+      }
+    }
+  } else {
+    for (const change of normalizedChanges) {
+      if (await tryRewriteCollectedFirstLine(change)) {
+        appliedChanges += 1;
+        appliedPaths.push(change.path);
+      } else {
+        skippedPaths.push(change.path);
+      }
     }
   }
 
@@ -552,6 +598,27 @@ export async function splitLockedSessionChanges(changes) {
 }
 
 export async function restoreSessionChanges(manifestEntries) {
+  if (!manifestEntries?.length) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    const changes = manifestEntries.map((entry) => ({
+      path: entry.path,
+      separator: entry.originalSeparator ?? "\n",
+      updatedFirstLine: entry.originalFirstLine
+    }));
+    const results = await invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatch: false });
+    const firstFailureIndex = results.findIndex((result) => result !== "APPLIED");
+    if (firstFailureIndex !== -1) {
+      const filePath = changes[firstFailureIndex].path;
+      throw new Error(
+        `Unable to rewrite rollout file because it is currently in use. Close Codex and the Codex app, then retry. Locked file: ${filePath}`
+      );
+    }
+    return;
+  }
+
   for (const entry of manifestEntries) {
     await rewriteFirstLine(entry.path, entry.originalFirstLine, entry.originalSeparator ?? "\n");
   }

--- a/test/locking.test.js
+++ b/test/locking.test.js
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { acquireLock } from "../src/locking.js";
+import { DEFAULT_LOCK_NAME } from "../src/constants.js";
+
+test("acquireLock retries transient EPERM when creating the lock directory", async () => {
+  const codexHome = "C:\\CodexHome";
+  const lockDir = path.join(codexHome, "tmp", DEFAULT_LOCK_NAME);
+  const calls = [];
+  const sleepCalls = [];
+  let lockMkdirAttempts = 0;
+
+  const fsImpl = {
+    async mkdir(targetPath, options) {
+      calls.push({ fn: "mkdir", targetPath, options });
+      if (targetPath === lockDir) {
+        lockMkdirAttempts += 1;
+        if (lockMkdirAttempts < 3) {
+          const error = new Error("operation not permitted");
+          error.code = "EPERM";
+          throw error;
+        }
+      }
+    },
+    async writeFile(targetPath, content, encoding) {
+      calls.push({ fn: "writeFile", targetPath, content, encoding });
+    },
+    async rm(targetPath, options) {
+      calls.push({ fn: "rm", targetPath, options });
+    }
+  };
+
+  const releaseLock = await acquireLock(codexHome, "sync", {
+    fsImpl,
+    retryCount: 3,
+    retryDelayMs: 25,
+    sleepImpl: async (delayMs) => {
+      sleepCalls.push(delayMs);
+    }
+  });
+
+  assert.equal(lockMkdirAttempts, 3);
+  assert.deepEqual(sleepCalls, [25, 25]);
+  assert.equal(calls.filter((call) => call.fn === "writeFile").length, 1);
+
+  await releaseLock();
+  assert.equal(calls.at(-1).fn, "rm");
+  assert.equal(calls.at(-1).targetPath, lockDir);
+});
+
+test("acquireLock does not retry when the lock directory already exists", async () => {
+  const codexHome = "C:\\CodexHome";
+  const lockDir = path.join(codexHome, "tmp", DEFAULT_LOCK_NAME);
+  let lockMkdirAttempts = 0;
+  const sleepCalls = [];
+
+  const fsImpl = {
+    async mkdir(targetPath) {
+      if (targetPath === lockDir) {
+        lockMkdirAttempts += 1;
+        const error = new Error("already exists");
+        error.code = "EEXIST";
+        throw error;
+      }
+    },
+    async writeFile() {
+      throw new Error("writeFile should not be called");
+    },
+    async rm() {
+      throw new Error("rm should not be called");
+    }
+  };
+
+  await assert.rejects(
+    () => acquireLock(codexHome, "sync", {
+      fsImpl,
+      retryCount: 3,
+      retryDelayMs: 25,
+      sleepImpl: async (delayMs) => {
+        sleepCalls.push(delayMs);
+      }
+    }),
+    /Lock already exists/
+  );
+
+  assert.equal(lockMkdirAttempts, 1);
+  assert.deepEqual(sleepCalls, []);
+});

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -41,6 +41,14 @@ async function writeRollout(filePath, id, provider) {
   await fs.writeFile(filePath, `${lines.join("\n")}\n`, "utf8");
 }
 
+async function writeCustomRollout(filePath, payload, message = "hi") {
+  const lines = [
+    JSON.stringify({ timestamp: payload.timestamp, type: "session_meta", payload }),
+    JSON.stringify({ timestamp: payload.timestamp, type: "event_msg", payload: { type: "user_message", message } })
+  ];
+  await fs.writeFile(filePath, `${lines.join("\n")}\n`, "utf8");
+}
+
 function backupRoot(codexHome) {
   return path.join(codexHome, "backups_state", "provider-sync");
 }
@@ -195,6 +203,8 @@ test("runSync rewrites rollout files and sqlite, then restore reverts both", asy
 
   const syncResult = await runSync({ codexHome });
   assert.equal(syncResult.targetProvider, "openai");
+  assert.equal(typeof syncResult.backupDurationMs, "number");
+  assert.ok(syncResult.backupDurationMs >= 0);
   assert.equal(syncResult.changedSessionFiles, 2);
   assert.deepEqual(syncResult.skippedLockedRolloutFiles, []);
   assert.equal(syncResult.sqliteRowsUpdated, 2);
@@ -224,6 +234,44 @@ test("runSync rewrites rollout files and sqlite, then restore reverts both", asy
   const restoredArchived = await fs.readFile(archivedPath, "utf8");
   assert.match(restoredSession, /"model_provider":"apigather"/);
   assert.match(restoredArchived, /"model_provider":"newapi"/);
+});
+
+test("runSync reports stage progress and backup duration", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-a.jsonl");
+  await writeRollout(sessionPath, "thread-a", "apigather");
+  await writeStateDb(codexHome, [
+    { id: "thread-a", model_provider: "apigather", archived: false }
+  ]);
+
+  const progressEvents = [];
+  const result = await runSync({
+    codexHome,
+    onProgress(event) {
+      progressEvents.push(event);
+    }
+  });
+
+  assert.ok(result.backupDurationMs >= 0);
+  assert.deepEqual(
+    progressEvents
+      .filter((event) => event.status === "start")
+      .map((event) => event.stage),
+    [
+      "scan_rollout_files",
+      "check_locked_rollout_files",
+      "create_backup",
+      "update_sqlite",
+      "rewrite_rollout_files",
+      "clean_backups"
+    ]
+  );
+
+  const backupCompleteEvent = progressEvents.find((event) => event.stage === "create_backup" && event.status === "complete");
+  assert.ok(backupCompleteEvent);
+  assert.equal(backupCompleteEvent.backupDir, result.backupDir);
+  assert.ok(backupCompleteEvent.durationMs >= 0);
 });
 
 test("runSwitch updates config and syncs provider metadata", async () => {
@@ -377,6 +425,69 @@ test("applySessionChanges skips rollout files that changed after collection", as
   assert.match(rollout, /"message":"later"/);
 });
 
+test("applySessionChanges preserves large UTF-8 session metadata", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-large.jsonl");
+  const payload = {
+    id: "thread-large",
+    timestamp: "2026-03-19T00:00:00.000Z",
+    cwd: "C:\\AITemp\\中文",
+    source: "cli",
+    cli_version: "0.115.0",
+    model_provider: "apigather",
+    title: "中文会话",
+    note: "保留 UTF-8 内容",
+    large_blob: "数据块".repeat(40000)
+  };
+  await writeCustomRollout(sessionPath, payload, "你好");
+
+  const { changes } = await collectSessionChanges(codexHome, "openai");
+  const result = await applySessionChanges(changes);
+
+  assert.equal(result.appliedChanges, 1);
+  assert.deepEqual(result.skippedPaths, []);
+
+  const rollout = await fs.readFile(sessionPath, "utf8");
+  assert.match(rollout, /"model_provider":"openai"/);
+  assert.match(rollout, /"title":"中文会话"/);
+  assert.match(rollout, /"note":"保留 UTF-8 内容"/);
+  assert.match(rollout, /"message":"你好"/);
+  assert.match(rollout, /"large_blob":"数据块数据块/);
+});
+
+test("applySessionChanges skips only the rollout file that becomes locked on Windows", async () => {
+  if (process.platform !== "win32") {
+    return;
+  }
+
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const lockedPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-locked.jsonl");
+  const writablePath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-writable.jsonl");
+  await writeRollout(lockedPath, "thread-locked", "apigather");
+  await writeRollout(writablePath, "thread-writable", "apigather");
+
+  const { changes } = await collectSessionChanges(codexHome, "openai");
+  const lockProcess = await lockRolloutFile(lockedPath);
+  let result;
+  try {
+    result = await applySessionChanges(changes);
+  } finally {
+    lockProcess.kill();
+    await new Promise((resolve) => lockProcess.once("exit", resolve));
+  }
+
+  assert.equal(result.appliedChanges, 1);
+  assert.deepEqual(result.appliedPaths, [writablePath]);
+  assert.deepEqual(result.skippedPaths, [lockedPath]);
+
+  const lockedRollout = await fs.readFile(lockedPath, "utf8");
+  const writableRollout = await fs.readFile(writablePath, "utf8");
+  assert.match(lockedRollout, /"model_provider":"apigather"/);
+  assert.match(writableRollout, /"model_provider":"openai"/);
+});
+
 test("restoreBackup only restores rollout files that were actually applied", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"');
@@ -495,4 +606,25 @@ test("cli rejects non-integer keep values", async () => {
   const result = await runCli(["prune-backups", "--keep", "1.5"]);
   assert.equal(result.code, 1);
   assert.match(result.stderr, /Invalid --keep value: 1\.5/);
+});
+
+test("cli sync prints stage progress and backup timing", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-a.jsonl");
+  await writeRollout(sessionPath, "thread-a", "apigather");
+  await writeStateDb(codexHome, [
+    { id: "thread-a", model_provider: "apigather", archived: false }
+  ]);
+
+  const result = await runCli(["sync", "--codex-home", codexHome]);
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /\[1\/6\] Scanning rollout files\.\.\./);
+  assert.match(result.stdout, /\[2\/6\] Checking locked rollout files\.\.\./);
+  assert.match(result.stdout, /\[3\/6\] Creating backup\.\.\./);
+  assert.match(result.stdout, /\[4\/6\] Updating SQLite\.\.\./);
+  assert.match(result.stdout, /\[5\/6\] Rewriting rollout files\.\.\./);
+  assert.match(result.stdout, /\[6\/6\] Cleaning backups\.\.\./);
+  assert.match(result.stdout, /Backup created in .*: .+/);
+  assert.match(result.stdout, /Backup creation time: /);
 });


### PR DESCRIPTION
## Summary

This PR improves the Windows sync path in three areas:

- batch rollout rewrites so the first full sync does not spawn one PowerShell process per file
- CLI stage progress output, including backup creation timing
- short retries for transient `EPERM` errors when creating the lock directory

Closes #4.

## What changed

- Reworked the Windows rollout rewrite path to execute a batch manifest in a single PowerShell run while preserving `APPLIED`, `SKIP_BUSY`, and `SKIP_CHANGED` semantics.
- Reused the same batch rewrite path for restore operations.
- Added CLI progress reporting for scan, lock check, backup creation, SQLite update, rollout rewrite, and backup cleanup.
- Included `Backup creation time` in the sync summary.
- Added a short retry loop for transient `EPERM` lock-directory creation failures without changing `EEXIST` behavior.
- Expanded regression coverage for:
  - large UTF-8 / Chinese `session_meta` first lines
  - mixed locked and writable rollout rewrites on Windows
  - progress callback ordering and CLI progress output
  - transient `EPERM` lock creation retries and non-retry `EEXIST`

## Why

The original Windows implementation launched `powershell.exe` once per rollout rewrite, which made large first-time syncs feel stalled. In addition, the CLI gave little stage visibility, and lock creation could fail on immediate reruns due to transient filesystem timing on Windows.

## Validation

- `npm test`
- Manual sync/status validation on a copied `.codex` home (`D:\codex-test\.codex`)
- Manual `switch sync_test` -> `switch openai` round-trip on the copied `.codex` home
- Manual real-environment validation on `C:\Users\Administrator\.codex`
  - `codex-provider sync` updated 500 rollout files and 500 SQLite rows
  - repeated `codex-provider sync` completed as a fast no-op
  - chats were visible again after provider normalization
