### PR TITLE
Preserve rollout mtimes during sync

### DIFF
--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -61,6 +61,23 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSync_PreservesRolloutModifiedTimeAfterRewrite()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-a", "apigather");
+        DateTime beforeLastWriteTimeUtc = new(2023, 11, 14, 22, 13, 20, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(sessionPath, beforeLastWriteTimeUtc);
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(1, result.ChangedSessionFiles);
+        Assert.Equal(beforeLastWriteTimeUtc, File.GetLastWriteTimeUtc(sessionPath));
+    }
+
+    [Fact]
     public async Task RunSwitch_UpdatesConfigAndSyncsProviderMetadata()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();

--- a/desktop/CodexProviderSync.Core/SessionRolloutService.cs
+++ b/desktop/CodexProviderSync.Core/SessionRolloutService.cs
@@ -226,26 +226,32 @@ public sealed class SessionRolloutService
     {
         try
         {
-            await using FileStream sourceStream = OpenExclusiveRewriteStream(change.Path);
-            if (sourceStream.Length != change.OriginalFileLength)
+            FileSnapshot beforeSnapshot = GetFileSnapshot(change.Path);
+            if (beforeSnapshot.Length != change.OriginalFileLength
+                || beforeSnapshot.LastWriteTimeUtcTicks != change.OriginalLastWriteTimeUtcTicks)
             {
                 return false;
             }
 
-            FirstLineRecord current = await ReadFirstLineRecordAsync(sourceStream);
-            if (!string.Equals(current.FirstLine, change.OriginalFirstLine, StringComparison.Ordinal)
-                || current.Offset != change.OriginalOffset)
+            await using (FileStream sourceStream = OpenExclusiveRewriteStream(change.Path))
             {
-                return false;
+                FirstLineRecord current = await ReadFirstLineRecordAsync(sourceStream);
+                if (!string.Equals(current.FirstLine, change.OriginalFirstLine, StringComparison.Ordinal)
+                    || current.Offset != change.OriginalOffset)
+                {
+                    return false;
+                }
+
+                await RewriteFirstLineAsync(
+                    sourceStream,
+                    change.Path,
+                    change.UpdatedFirstLine,
+                    change.OriginalSeparator,
+                    change.OriginalOffset,
+                    headerOnly: change.OriginalOffset >= change.OriginalFileLength);
             }
 
-            await RewriteFirstLineAsync(
-                sourceStream,
-                change.Path,
-                change.UpdatedFirstLine,
-                change.OriginalSeparator,
-                change.OriginalOffset,
-                headerOnly: change.OriginalOffset >= change.OriginalFileLength);
+            RestoreLastWriteTimeUtc(change.Path, change.OriginalLastWriteTimeUtcTicks);
             return true;
         }
         catch (Exception error) when (IsRolloutFileBusyError(error))
@@ -258,11 +264,16 @@ public sealed class SessionRolloutService
     {
         try
         {
-            await using FileStream sourceStream = OpenExclusiveRewriteStream(filePath);
-            FirstLineRecord current = await ReadFirstLineRecordAsync(sourceStream);
-            bool headerOnly = string.IsNullOrEmpty(current.Separator)
-                && current.Offset == Encoding.UTF8.GetByteCount(current.FirstLine);
-            await RewriteFirstLineAsync(sourceStream, filePath, nextFirstLine, separator, current.Offset, headerOnly);
+            FileSnapshot snapshot = GetFileSnapshot(filePath);
+            await using (FileStream sourceStream = OpenExclusiveRewriteStream(filePath))
+            {
+                FirstLineRecord current = await ReadFirstLineRecordAsync(sourceStream);
+                bool headerOnly = string.IsNullOrEmpty(current.Separator)
+                    && current.Offset == Encoding.UTF8.GetByteCount(current.FirstLine);
+                await RewriteFirstLineAsync(sourceStream, filePath, nextFirstLine, separator, current.Offset, headerOnly);
+            }
+
+            RestoreLastWriteTimeUtc(filePath, snapshot.LastWriteTimeUtcTicks);
         }
         catch (Exception error)
         {
@@ -397,6 +408,11 @@ public sealed class SessionRolloutService
     {
         FileInfo fileInfo = new(filePath);
         return new FileSnapshot(fileInfo.Length, fileInfo.LastWriteTimeUtc.Ticks);
+    }
+
+    private static void RestoreLastWriteTimeUtc(string filePath, long lastWriteTimeUtcTicks)
+    {
+        File.SetLastWriteTimeUtc(filePath, new DateTime(lastWriteTimeUtcTicks, DateTimeKind.Utc));
     }
 
     private static async Task<List<string>> FindLockedFilesAsync(IEnumerable<string> filePaths)

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -35,6 +35,30 @@ async function getFileSnapshot(filePath) {
   };
 }
 
+async function restoreFileMtime(filePath, snapshot) {
+  if (!snapshot || typeof snapshot.mtimeMs !== "number") {
+    return;
+  }
+
+  const stat = await fsp.stat(filePath);
+  await fsp.utimes(filePath, stat.atimeMs / 1000, snapshot.mtimeMs / 1000);
+}
+
+async function overwriteFileInPlace(filePath, tmpPath, snapshot) {
+  const replacement = await fsp.readFile(tmpPath);
+  const handle = await fsp.open(filePath, "r+");
+
+  try {
+    await handle.truncate(0);
+    await handle.writeFile(replacement);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+
+  await restoreFileMtime(filePath, snapshot);
+}
+
 function snapshotMatches(change, snapshot) {
   return change.originalSize === snapshot.size
     && change.originalMtimeMs === snapshot.mtimeMs;
@@ -307,6 +331,7 @@ async function invokeWindowsExclusiveRewrite(change, options) {
 
 async function rewriteFirstLine(filePath, nextFirstLine, separator) {
   if (process.platform === "win32") {
+    const snapshot = await getFileSnapshot(filePath);
     const result = await invokeWindowsExclusiveRewrite(
       {
         path: filePath,
@@ -322,9 +347,11 @@ async function rewriteFirstLine(filePath, nextFirstLine, separator) {
       );
     }
 
+    await restoreFileMtime(filePath, snapshot);
     return;
   }
 
+  const snapshot = await getFileSnapshot(filePath);
   const current = await readFirstLineRecord(filePath);
   const tmpPath = `${filePath}.provider-sync.${process.pid}.${Date.now()}.tmp`;
   const writer = fs.createWriteStream(tmpPath, { encoding: "utf8" });
@@ -354,10 +381,12 @@ async function rewriteFirstLine(filePath, nextFirstLine, separator) {
       reader.pipe(writer, { end: false });
     });
 
-    await fsp.rename(tmpPath, filePath);
+    await overwriteFileInPlace(filePath, tmpPath, snapshot);
   } catch (error) {
     await fsp.rm(tmpPath, { force: true });
     throw wrapRolloutFileBusyError(error, filePath, "rewrite");
+  } finally {
+    await fsp.rm(tmpPath, { force: true });
   }
 }
 
@@ -403,11 +432,13 @@ async function tryRewriteCollectedFirstLine(change) {
       return false;
     }
 
-    await fsp.rename(tmpPath, change.path);
+    await overwriteFileInPlace(change.path, tmpPath, beforeSnapshot);
     return true;
   } catch (error) {
     await fsp.rm(tmpPath, { force: true });
     throw wrapRolloutFileBusyError(error, change.path, "rewrite");
+  } finally {
+    await fsp.rm(tmpPath, { force: true });
   }
 }
 
@@ -523,6 +554,7 @@ export async function applySessionChanges(changes) {
       if (results[index] === "APPLIED") {
         appliedChanges += 1;
         appliedPaths.push(normalizedChanges[index].path);
+        await restoreFileMtime(normalizedChanges[index].path, normalizedChanges[index]);
       } else {
         skippedPaths.push(normalizedChanges[index].path);
       }
@@ -608,6 +640,10 @@ export async function restoreSessionChanges(manifestEntries) {
       separator: entry.originalSeparator ?? "\n",
       updatedFirstLine: entry.originalFirstLine
     }));
+    const snapshots = await Promise.all(changes.map(async (change) => ({
+      path: change.path,
+      snapshot: await getFileSnapshot(change.path)
+    })));
     const results = await invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatch: false });
     const firstFailureIndex = results.findIndex((result) => result !== "APPLIED");
     if (firstFailureIndex !== -1) {
@@ -616,6 +652,9 @@ export async function restoreSessionChanges(manifestEntries) {
         `Unable to rewrite rollout file because it is currently in use. Close Codex and the Codex app, then retry. Locked file: ${filePath}`
       );
     }
+    await Promise.all(
+      snapshots.map(({ path: targetPath, snapshot }) => restoreFileMtime(targetPath, snapshot))
+    );
     return;
   }
 

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -236,6 +236,21 @@ test("runSync rewrites rollout files and sqlite, then restore reverts both", asy
   assert.match(restoredArchived, /"model_provider":"newapi"/);
 });
 
+test("runSync preserves rollout modified time after rewriting provider metadata", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-a.jsonl");
+  await writeRollout(sessionPath, "thread-a", "apigather");
+  await fs.utimes(sessionPath, 1700000000, 1700000000);
+  const beforeStat = await fs.stat(sessionPath);
+
+  const result = await runSync({ codexHome });
+
+  assert.equal(result.changedSessionFiles, 1);
+  const afterStat = await fs.stat(sessionPath);
+  assert.equal(afterStat.mtimeMs, beforeStat.mtimeMs);
+});
+
 test("runSync reports stage progress and backup duration", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"');


### PR DESCRIPTION
## 摘要

  - 在重写 rollout provider 元数据时保留文件修改时间
  - CLI 路径下避免使用 `rename` 方式覆盖 rollout 文件，改为原地回写
  - rollout 重写成功后恢复原始 `mtime`
  - 补充 JS 和 .NET 测试，覆盖“保留修改时间”的行为

  ## 背景

  当前 `codex-provider sync` 在同步 provider 时，会重写 `~/.codex/sessions` 和 `~/.codex/archived_sessions`
  下的 rollout 文件。

  虽然 provider 同步本身是正确的，但这个过程会刷新文件时间。对于依赖 rollout 文件时间做启动扫描或活跃会话判断
  的工具来说，这会带来副作用：历史会话可能会被误判成“刚刚活跃过的会话”。

  我这边实际遇到的现象是：

  - 执行 `codex-provider sync` 后
  - 某些会读取 `~/.codex/sessions` 的工具会把大量历史 Codex session 误加载出来
  - 根因不是 provider 同步逻辑错误，而是 rollout 文件时间被整体刷新了

  ## 修改内容

  ### CLI / Node 实现

  - 保持现有 provider 同步逻辑不变
  - 在非 Windows 路径下，不再通过 `rename` 覆盖 rollout 文件
  - 改为原地写回文件内容
  - 写回成功后恢复原始 `mtime`
  - Windows 的 rewrite / restore 路径也补上 `mtime` 恢复

  ### Desktop / .NET 实现

  - rollout 重写成功后恢复原始 `LastWriteTimeUtc`
  - 不改变现有同步、备份、SQLite 更新逻辑

  ## 验证

  - `npm test`

  ## 说明

  这次改动是一个尽量小的修复，只处理 rollout 文件重写带来的时间戳副作用，不改变以下行为：

  - provider 解析逻辑
  - backup 行为
  - SQLite 同步语义