### PR TITLE
feat: preserve last chat order after sync

### DIFF
--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -85,22 +85,53 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
-    public async Task RunSync_NormalizesRolloutLastWriteTimeToLatestActivity()
+    public async Task RunSync_NormalizesRolloutLastWriteTimeToSqliteUpdatedAtMs()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
         await fixture.WriteConfigAsync("model_provider = \"openai\"");
         string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
-        const string latestActivityIso = "2026-03-22T15:45:30.000Z";
+        const string rolloutActivityIso = "2026-03-22T15:45:30.000Z";
+        const string sqliteActivityIso = "2026-03-21T09:10:11.123Z";
         await fixture.WriteRolloutLinesAsync(
             sessionPath,
             """
             {"timestamp":"2026-03-19T00:00:20.000Z","type":"session_meta","payload":{"id":"thread-a","timestamp":"2026-03-19T00:00:00.000Z","cwd":"C:\\AITemp","source":"cli","cli_version":"0.115.0","model_provider":"apigather"}}
             """,
             $$$"""
-            {"timestamp":"{{{latestActivityIso}}}","type":"event_msg","payload":{"type":"assistant_message","message":"latest"}}
+            {"timestamp":"{{{rolloutActivityIso}}}","type":"event_msg","payload":{"type":"assistant_message","message":"latest"}}
             """);
         DateTime wrongTimestamp = new(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
         File.SetLastWriteTimeUtc(sessionPath, wrongTimestamp);
+        DateTimeOffset sqliteActivity = DateTimeOffset.Parse(sqliteActivityIso, null, System.Globalization.DateTimeStyles.RoundtripKind).ToUniversalTime();
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-a", "apigather", false, sqliteActivity.ToUnixTimeSeconds(), sqliteActivity.ToUnixTimeMilliseconds())
+        ]);
+
+        CodexSyncService service = new();
+        await service.RunSyncAsync(fixture.CodexHome);
+
+        DateTime expectedUtc = sqliteActivity.UtcDateTime;
+        DateTime actualUtc = File.GetLastWriteTimeUtc(sessionPath);
+        Assert.InRange(Math.Abs((actualUtc - expectedUtc).TotalSeconds), 0, 2);
+    }
+
+    [Fact]
+    public async Task RunSync_PreservesRolloutLastWriteTime_WhenSqliteActivityIsUnavailable()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutLinesAsync(
+            sessionPath,
+            """
+            {"timestamp":"2026-03-19T00:00:20.000Z","type":"session_meta","payload":{"id":"thread-a","timestamp":"2026-03-19T00:00:00.000Z","cwd":"C:\\AITemp","source":"cli","cli_version":"0.115.0","model_provider":"apigather"}}
+            """,
+            """
+            {"timestamp":"2026-03-25T12:00:00.000Z","type":"event_msg","payload":{"type":"assistant_message","message":"later in rollout only"}}
+            """);
+        DateTime preservedTimestamp = new(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(sessionPath, preservedTimestamp);
         await fixture.WriteStateDbAsync(
         [
             ("thread-a", "apigather", false)
@@ -109,9 +140,8 @@ public sealed class CoreIntegrationTests
         CodexSyncService service = new();
         await service.RunSyncAsync(fixture.CodexHome);
 
-        DateTime expectedUtc = DateTime.Parse(latestActivityIso, null, System.Globalization.DateTimeStyles.RoundtripKind).ToUniversalTime();
         DateTime actualUtc = File.GetLastWriteTimeUtc(sessionPath);
-        Assert.InRange(Math.Abs((actualUtc - expectedUtc).TotalSeconds), 0, 2);
+        Assert.InRange(Math.Abs((actualUtc - preservedTimestamp).TotalSeconds), 0, 2);
     }
 
     [Fact]

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -85,6 +85,36 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSync_NormalizesRolloutLastWriteTimeToLatestActivity()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        const string latestActivityIso = "2026-03-22T15:45:30.000Z";
+        await fixture.WriteRolloutLinesAsync(
+            sessionPath,
+            """
+            {"timestamp":"2026-03-19T00:00:20.000Z","type":"session_meta","payload":{"id":"thread-a","timestamp":"2026-03-19T00:00:00.000Z","cwd":"C:\\AITemp","source":"cli","cli_version":"0.115.0","model_provider":"apigather"}}
+            """,
+            $$$"""
+            {"timestamp":"{{{latestActivityIso}}}","type":"event_msg","payload":{"type":"assistant_message","message":"latest"}}
+            """);
+        DateTime wrongTimestamp = new(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(sessionPath, wrongTimestamp);
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-a", "apigather", false)
+        ]);
+
+        CodexSyncService service = new();
+        await service.RunSyncAsync(fixture.CodexHome);
+
+        DateTime expectedUtc = DateTime.Parse(latestActivityIso, null, System.Globalization.DateTimeStyles.RoundtripKind).ToUniversalTime();
+        DateTime actualUtc = File.GetLastWriteTimeUtc(sessionPath);
+        Assert.InRange(Math.Abs((actualUtc - expectedUtc).TotalSeconds), 0, 2);
+    }
+
+    [Fact]
     public async Task GetStatus_ReportsImplicitDefaultProviderAndCounts()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -77,6 +77,11 @@ internal sealed class TestCodexHomeFixture
         await File.WriteAllTextAsync(filePath, $"{first}\n{second}\n");
     }
 
+    public Task WriteRolloutLinesAsync(string filePath, params string[] lines)
+    {
+        return File.WriteAllTextAsync(filePath, string.Join("\n", lines) + "\n");
+    }
+
     public async Task<long> WriteBackupAsync(string directoryName, params (string RelativePath, string Content)[] files)
     {
         string backupDir = BackupPath(directoryName);

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -119,6 +119,26 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
     {
+        await WriteStateDbRowsAsync(rows.Select(static row => new ThreadStateRow(
+            row.Id,
+            row.ModelProvider,
+            row.Archived,
+            null,
+            null)));
+    }
+
+    public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived, long? UpdatedAt, long? UpdatedAtMs)> rows)
+    {
+        await WriteStateDbRowsAsync(rows.Select(static row => new ThreadStateRow(
+            row.Id,
+            row.ModelProvider,
+            row.Archived,
+            row.UpdatedAt,
+            row.UpdatedAtMs)));
+    }
+
+    private async Task WriteStateDbRowsAsync(IEnumerable<ThreadStateRow> rows)
+    {
         string dbPath = Path.Combine(CodexHome, "state_5.sqlite");
         await using SqliteConnection connection = OpenSqliteConnection();
         await connection.OpenAsync();
@@ -126,6 +146,10 @@ internal sealed class TestCodexHomeFixture
         create.CommandText = """
             CREATE TABLE threads (
               id TEXT PRIMARY KEY,
+              rollout_path TEXT,
+              created_at INTEGER,
+              updated_at INTEGER,
+              updated_at_ms INTEGER,
               model_provider TEXT,
               archived INTEGER NOT NULL DEFAULT 0,
               first_user_message TEXT NOT NULL DEFAULT ''
@@ -133,16 +157,27 @@ internal sealed class TestCodexHomeFixture
             """;
         await create.ExecuteNonQueryAsync();
 
-        foreach ((string id, string modelProvider, bool archived) in rows)
+        foreach (ThreadStateRow row in rows)
         {
             SqliteCommand insert = connection.CreateCommand();
             insert.CommandText = """
-                INSERT INTO threads (id, model_provider, archived, first_user_message)
-                VALUES ($id, $provider, $archived, 'hello')
+                INSERT INTO threads (
+                  id,
+                  rollout_path,
+                  created_at,
+                  updated_at,
+                  updated_at_ms,
+                  model_provider,
+                  archived,
+                  first_user_message
+                )
+                VALUES ($id, '', NULL, $updatedAt, $updatedAtMs, $provider, $archived, 'hello')
                 """;
-            insert.Parameters.AddWithValue("$id", id);
-            insert.Parameters.AddWithValue("$provider", modelProvider);
-            insert.Parameters.AddWithValue("$archived", archived ? 1 : 0);
+            insert.Parameters.AddWithValue("$id", row.Id);
+            insert.Parameters.AddWithValue("$updatedAt", (object?)row.UpdatedAt ?? DBNull.Value);
+            insert.Parameters.AddWithValue("$updatedAtMs", (object?)row.UpdatedAtMs ?? DBNull.Value);
+            insert.Parameters.AddWithValue("$provider", row.ModelProvider);
+            insert.Parameters.AddWithValue("$archived", row.Archived ? 1 : 0);
             await insert.ExecuteNonQueryAsync();
         }
     }
@@ -151,4 +186,11 @@ internal sealed class TestCodexHomeFixture
     {
         return new SqliteConnection($"Data Source={Path.Combine(CodexHome, "state_5.sqlite")};Mode=ReadWriteCreate;Pooling=False");
     }
+
+    private sealed record ThreadStateRow(
+        string Id,
+        string ModelProvider,
+        bool Archived,
+        long? UpdatedAt,
+        long? UpdatedAtMs);
 }

--- a/desktop/CodexProviderSync.Core/BackupService.cs
+++ b/desktop/CodexProviderSync.Core/BackupService.cs
@@ -57,7 +57,8 @@ public sealed class BackupService
             {
                 Path = change.Path,
                 OriginalFirstLine = change.OriginalFirstLine,
-                OriginalSeparator = change.OriginalSeparator
+                OriginalSeparator = change.OriginalSeparator,
+                NormalizedLastWriteTimeUtcTicks = change.NormalizedLastWriteTimeUtcTicks
             }).ToList()
         };
         await File.WriteAllTextAsync(
@@ -177,7 +178,8 @@ public sealed class BackupService
             {
                 Path = change.Path,
                 OriginalFirstLine = change.OriginalFirstLine,
-                OriginalSeparator = change.OriginalSeparator
+                OriginalSeparator = change.OriginalSeparator,
+                NormalizedLastWriteTimeUtcTicks = change.NormalizedLastWriteTimeUtcTicks
             }).ToList()
         };
         metadata = new BackupMetadataFile

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -93,6 +93,17 @@ public sealed class CodexSyncService
         await using LockHandle _ = await _lockService.AcquireLockAsync(codexHome, "sync");
 
         SessionChangeCollection sessionInfo = await _sessionRolloutService.CollectSessionChangesAsync(codexHome, targetProvider, skipLockedReads: true);
+        IReadOnlyDictionary<string, long> threadActivityUtcTicks = await _sqliteStateService.ReadThreadActivityUtcTicksByIdAsync(
+            codexHome,
+            sessionInfo.Changes.Select(static change => change.ThreadId));
+        foreach (SessionChange change in sessionInfo.Changes)
+        {
+            if (change.ThreadId is not null
+                && threadActivityUtcTicks.TryGetValue(change.ThreadId, out long normalizedTicks))
+            {
+                change.NormalizedLastWriteTimeUtcTicks = normalizedTicks;
+            }
+        }
         (IReadOnlyList<SessionChange> writableChanges, IReadOnlyList<SessionChange> lockedChanges) =
             await _sessionRolloutService.SplitLockedSessionChangesAsync(sessionInfo.Changes);
 

--- a/desktop/CodexProviderSync.Core/Models.cs
+++ b/desktop/CodexProviderSync.Core/Models.cs
@@ -46,7 +46,7 @@ public sealed class SessionChange
     public required int OriginalOffset { get; init; }
     public required long OriginalFileLength { get; init; }
     public required long OriginalLastWriteTimeUtcTicks { get; init; }
-    public required long NormalizedLastWriteTimeUtcTicks { get; init; }
+    public required long NormalizedLastWriteTimeUtcTicks { get; set; }
     public required string UpdatedFirstLine { get; init; }
 }
 

--- a/desktop/CodexProviderSync.Core/Models.cs
+++ b/desktop/CodexProviderSync.Core/Models.cs
@@ -46,6 +46,7 @@ public sealed class SessionChange
     public required int OriginalOffset { get; init; }
     public required long OriginalFileLength { get; init; }
     public required long OriginalLastWriteTimeUtcTicks { get; init; }
+    public required long NormalizedLastWriteTimeUtcTicks { get; init; }
     public required string UpdatedFirstLine { get; init; }
 }
 
@@ -159,4 +160,5 @@ internal sealed class SessionBackupManifestEntry
     public required string Path { get; init; }
     public required string OriginalFirstLine { get; init; }
     public required string OriginalSeparator { get; init; }
+    public long? NormalizedLastWriteTimeUtcTicks { get; init; }
 }

--- a/desktop/CodexProviderSync.Core/SessionRolloutService.cs
+++ b/desktop/CodexProviderSync.Core/SessionRolloutService.cs
@@ -1,5 +1,7 @@
 using System.Buffers;
+using System.Globalization;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace CodexProviderSync.Core;
@@ -52,6 +54,9 @@ public sealed class SessionRolloutService
                     && !string.Equals(currentProvider, targetProvider, StringComparison.Ordinal))
                 {
                     FileSnapshot snapshot = GetFileSnapshot(rolloutPath);
+                    long normalizedLastWriteTimeUtcTicks = await ReadLastActivityTimeUtcTicksAsync(
+                        rolloutPath,
+                        snapshot.LastWriteTimeUtcTicks);
                     payload["model_provider"] = targetProvider;
                     changes.Add(new SessionChange
                     {
@@ -63,6 +68,7 @@ public sealed class SessionRolloutService
                         OriginalOffset = record.Offset,
                         OriginalFileLength = snapshot.Length,
                         OriginalLastWriteTimeUtcTicks = snapshot.LastWriteTimeUtcTicks,
+                        NormalizedLastWriteTimeUtcTicks = normalizedLastWriteTimeUtcTicks,
                         UpdatedFirstLine = root!.ToJsonString()
                     });
                 }
@@ -157,7 +163,11 @@ public sealed class SessionRolloutService
     {
         foreach (SessionBackupManifestEntry entry in manifestEntries)
         {
-            await RewriteFirstLineAsync(entry.Path, entry.OriginalFirstLine, entry.OriginalSeparator);
+            await RewriteFirstLineAsync(
+                entry.Path,
+                entry.OriginalFirstLine,
+                entry.OriginalSeparator,
+                entry.NormalizedLastWriteTimeUtcTicks);
         }
     }
 
@@ -168,7 +178,8 @@ public sealed class SessionRolloutService
             {
                 Path = change.Path,
                 OriginalFirstLine = change.OriginalFirstLine,
-                OriginalSeparator = change.OriginalSeparator
+                OriginalSeparator = change.OriginalSeparator,
+                NormalizedLastWriteTimeUtcTicks = change.NormalizedLastWriteTimeUtcTicks
             }));
     }
 
@@ -226,26 +237,30 @@ public sealed class SessionRolloutService
     {
         try
         {
-            await using FileStream sourceStream = OpenExclusiveRewriteStream(change.Path);
-            if (sourceStream.Length != change.OriginalFileLength)
+            await using (FileStream sourceStream = OpenExclusiveRewriteStream(change.Path))
             {
-                return false;
+                if (sourceStream.Length != change.OriginalFileLength)
+                {
+                    return false;
+                }
+
+                FirstLineRecord current = await ReadFirstLineRecordAsync(sourceStream);
+                if (!string.Equals(current.FirstLine, change.OriginalFirstLine, StringComparison.Ordinal)
+                    || current.Offset != change.OriginalOffset)
+                {
+                    return false;
+                }
+
+                await RewriteFirstLineAsync(
+                    sourceStream,
+                    change.Path,
+                    change.UpdatedFirstLine,
+                    change.OriginalSeparator,
+                    change.OriginalOffset,
+                    headerOnly: change.OriginalOffset >= change.OriginalFileLength);
             }
 
-            FirstLineRecord current = await ReadFirstLineRecordAsync(sourceStream);
-            if (!string.Equals(current.FirstLine, change.OriginalFirstLine, StringComparison.Ordinal)
-                || current.Offset != change.OriginalOffset)
-            {
-                return false;
-            }
-
-            await RewriteFirstLineAsync(
-                sourceStream,
-                change.Path,
-                change.UpdatedFirstLine,
-                change.OriginalSeparator,
-                change.OriginalOffset,
-                headerOnly: change.OriginalOffset >= change.OriginalFileLength);
+            ApplyNormalizedLastWriteTime(change.Path, change.NormalizedLastWriteTimeUtcTicks);
             return true;
         }
         catch (Exception error) when (IsRolloutFileBusyError(error))
@@ -254,15 +269,23 @@ public sealed class SessionRolloutService
         }
     }
 
-    private async Task RewriteFirstLineAsync(string filePath, string nextFirstLine, string separator)
+    private async Task RewriteFirstLineAsync(
+        string filePath,
+        string nextFirstLine,
+        string separator,
+        long? normalizedLastWriteTimeUtcTicks = null)
     {
         try
         {
-            await using FileStream sourceStream = OpenExclusiveRewriteStream(filePath);
-            FirstLineRecord current = await ReadFirstLineRecordAsync(sourceStream);
-            bool headerOnly = string.IsNullOrEmpty(current.Separator)
-                && current.Offset == Encoding.UTF8.GetByteCount(current.FirstLine);
-            await RewriteFirstLineAsync(sourceStream, filePath, nextFirstLine, separator, current.Offset, headerOnly);
+            await using (FileStream sourceStream = OpenExclusiveRewriteStream(filePath))
+            {
+                FirstLineRecord current = await ReadFirstLineRecordAsync(sourceStream);
+                bool headerOnly = string.IsNullOrEmpty(current.Separator)
+                    && current.Offset == Encoding.UTF8.GetByteCount(current.FirstLine);
+                await RewriteFirstLineAsync(sourceStream, filePath, nextFirstLine, separator, current.Offset, headerOnly);
+            }
+
+            ApplyNormalizedLastWriteTime(filePath, normalizedLastWriteTimeUtcTicks);
         }
         catch (Exception error)
         {
@@ -397,6 +420,105 @@ public sealed class SessionRolloutService
     {
         FileInfo fileInfo = new(filePath);
         return new FileSnapshot(fileInfo.Length, fileInfo.LastWriteTimeUtc.Ticks);
+    }
+
+    private static void ApplyNormalizedLastWriteTime(string filePath, long? normalizedLastWriteTimeUtcTicks)
+    {
+        if (normalizedLastWriteTimeUtcTicks is null or <= 0)
+        {
+            return;
+        }
+
+        DateTime normalizedUtc = new(normalizedLastWriteTimeUtcTicks.Value, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(filePath, normalizedUtc);
+        File.SetLastAccessTimeUtc(filePath, normalizedUtc);
+    }
+
+    private static long? ParseTimestampUtcTicks(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return DateTimeOffset.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out DateTimeOffset parsed)
+            ? parsed.UtcDateTime.Ticks
+            : null;
+    }
+
+    private static long? UpdateLatestTimestampTicks(long? currentTicks, long? candidateTicks)
+    {
+        if (candidateTicks is null)
+        {
+            return currentTicks;
+        }
+
+        if (currentTicks is null)
+        {
+            return candidateTicks;
+        }
+
+        return Math.Max(currentTicks.Value, candidateTicks.Value);
+    }
+
+    private static async Task<long> ReadLastActivityTimeUtcTicksAsync(string filePath, long fallbackTicks)
+    {
+        try
+        {
+            using StreamReader reader = new(
+                filePath,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true,
+                bufferSize: 64 * 1024);
+
+            long? latestTicks = null;
+            string? line;
+            while ((line = await reader.ReadLineAsync()) is not null)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (JsonNode.Parse(line) is not JsonObject root)
+                    {
+                        continue;
+                    }
+
+                    latestTicks = UpdateLatestTimestampTicks(
+                        latestTicks,
+                        ParseTimestampUtcTicks(root["timestamp"]?.GetValue<string>()));
+
+                    if (string.Equals(root["type"]?.GetValue<string>(), "session_meta", StringComparison.Ordinal)
+                        && root["payload"] is JsonObject payload)
+                    {
+                        latestTicks = UpdateLatestTimestampTicks(
+                            latestTicks,
+                            ParseTimestampUtcTicks(payload["timestamp"]?.GetValue<string>()));
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore malformed lines and fall back to file metadata if needed.
+                }
+                catch (InvalidOperationException)
+                {
+                    // Ignore unexpected JSON value shapes and fall back to file metadata if needed.
+                }
+            }
+
+            return latestTicks ?? fallbackTicks;
+        }
+        catch
+        {
+            return fallbackTicks;
+        }
     }
 
     private static async Task<List<string>> FindLockedFilesAsync(IEnumerable<string> filePaths)

--- a/desktop/CodexProviderSync.Core/SessionRolloutService.cs
+++ b/desktop/CodexProviderSync.Core/SessionRolloutService.cs
@@ -1,5 +1,4 @@
 using System.Buffers;
-using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -54,9 +53,6 @@ public sealed class SessionRolloutService
                     && !string.Equals(currentProvider, targetProvider, StringComparison.Ordinal))
                 {
                     FileSnapshot snapshot = GetFileSnapshot(rolloutPath);
-                    long normalizedLastWriteTimeUtcTicks = await ReadLastActivityTimeUtcTicksAsync(
-                        rolloutPath,
-                        snapshot.LastWriteTimeUtcTicks);
                     payload["model_provider"] = targetProvider;
                     changes.Add(new SessionChange
                     {
@@ -68,7 +64,7 @@ public sealed class SessionRolloutService
                         OriginalOffset = record.Offset,
                         OriginalFileLength = snapshot.Length,
                         OriginalLastWriteTimeUtcTicks = snapshot.LastWriteTimeUtcTicks,
-                        NormalizedLastWriteTimeUtcTicks = normalizedLastWriteTimeUtcTicks,
+                        NormalizedLastWriteTimeUtcTicks = snapshot.LastWriteTimeUtcTicks,
                         UpdatedFirstLine = root!.ToJsonString()
                     });
                 }
@@ -432,93 +428,6 @@ public sealed class SessionRolloutService
         DateTime normalizedUtc = new(normalizedLastWriteTimeUtcTicks.Value, DateTimeKind.Utc);
         File.SetLastWriteTimeUtc(filePath, normalizedUtc);
         File.SetLastAccessTimeUtc(filePath, normalizedUtc);
-    }
-
-    private static long? ParseTimestampUtcTicks(string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return null;
-        }
-
-        return DateTimeOffset.TryParse(
-            value,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-            out DateTimeOffset parsed)
-            ? parsed.UtcDateTime.Ticks
-            : null;
-    }
-
-    private static long? UpdateLatestTimestampTicks(long? currentTicks, long? candidateTicks)
-    {
-        if (candidateTicks is null)
-        {
-            return currentTicks;
-        }
-
-        if (currentTicks is null)
-        {
-            return candidateTicks;
-        }
-
-        return Math.Max(currentTicks.Value, candidateTicks.Value);
-    }
-
-    private static async Task<long> ReadLastActivityTimeUtcTicksAsync(string filePath, long fallbackTicks)
-    {
-        try
-        {
-            using StreamReader reader = new(
-                filePath,
-                Encoding.UTF8,
-                detectEncodingFromByteOrderMarks: true,
-                bufferSize: 64 * 1024);
-
-            long? latestTicks = null;
-            string? line;
-            while ((line = await reader.ReadLineAsync()) is not null)
-            {
-                if (string.IsNullOrWhiteSpace(line))
-                {
-                    continue;
-                }
-
-                try
-                {
-                    if (JsonNode.Parse(line) is not JsonObject root)
-                    {
-                        continue;
-                    }
-
-                    latestTicks = UpdateLatestTimestampTicks(
-                        latestTicks,
-                        ParseTimestampUtcTicks(root["timestamp"]?.GetValue<string>()));
-
-                    if (string.Equals(root["type"]?.GetValue<string>(), "session_meta", StringComparison.Ordinal)
-                        && root["payload"] is JsonObject payload)
-                    {
-                        latestTicks = UpdateLatestTimestampTicks(
-                            latestTicks,
-                            ParseTimestampUtcTicks(payload["timestamp"]?.GetValue<string>()));
-                    }
-                }
-                catch (JsonException)
-                {
-                    // Ignore malformed lines and fall back to file metadata if needed.
-                }
-                catch (InvalidOperationException)
-                {
-                    // Ignore unexpected JSON value shapes and fall back to file metadata if needed.
-                }
-            }
-
-            return latestTicks ?? fallbackTicks;
-        }
-        catch
-        {
-            return fallbackTicks;
-        }
     }
 
     private static async Task<List<string>> FindLockedFilesAsync(IEnumerable<string> filePaths)

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -59,6 +59,78 @@ public sealed class SqliteStateService
         };
     }
 
+    public async Task<IReadOnlyDictionary<string, long>> ReadThreadActivityUtcTicksByIdAsync(
+        string codexHome,
+        IEnumerable<string?> threadIds)
+    {
+        string dbPath = StateDbPath(codexHome);
+        if (!File.Exists(dbPath))
+        {
+            return new Dictionary<string, long>(StringComparer.Ordinal);
+        }
+
+        string[] normalizedIds = threadIds
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .Select(static id => id!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (normalizedIds.Length == 0)
+        {
+            return new Dictionary<string, long>(StringComparer.Ordinal);
+        }
+
+        await using SqliteConnection connection = OpenConnection(dbPath);
+        try
+        {
+            await connection.OpenAsync();
+            string? activityColumn = await GetThreadActivityColumnAsync(connection);
+            if (activityColumn is null)
+            {
+                return new Dictionary<string, long>(StringComparer.Ordinal);
+            }
+
+            Dictionary<string, long> result = new(StringComparer.Ordinal);
+            foreach (string[] chunk in normalizedIds.Chunk(500))
+            {
+                await using SqliteCommand command = connection.CreateCommand();
+                string[] parameterNames = new string[chunk.Length];
+                for (int index = 0; index < chunk.Length; index += 1)
+                {
+                    parameterNames[index] = $"$id{index}";
+                    command.Parameters.AddWithValue(parameterNames[index], chunk[index]);
+                }
+
+                command.CommandText = $"""
+                    SELECT id, {activityColumn} AS activity_value
+                    FROM threads
+                    WHERE id IN ({string.Join(", ", parameterNames)})
+                    """;
+
+                await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    if (reader.IsDBNull(1))
+                    {
+                        continue;
+                    }
+
+                    long rawValue = reader.GetInt64(1);
+                    long? utcTicks = ToActivityUtcTicks(activityColumn, rawValue);
+                    if (utcTicks is not null)
+                    {
+                        result[reader.GetString(0)] = utcTicks.Value;
+                    }
+                }
+            }
+
+            return result;
+        }
+        catch
+        {
+            return new Dictionary<string, long>(StringComparer.Ordinal);
+        }
+    }
+
     public async Task<bool> AssertSqliteWritableAsync(string codexHome, int? busyTimeoutMs = null)
     {
         string dbPath = StateDbPath(codexHome);
@@ -166,6 +238,46 @@ public sealed class SqliteStateService
         await using SqliteCommand command = connection.CreateCommand();
         command.CommandText = commandText;
         await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<string?> GetThreadActivityColumnAsync(SqliteConnection connection)
+    {
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "PRAGMA table_info(threads)";
+
+        HashSet<string> columns = new(StringComparer.Ordinal);
+        await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            columns.Add(reader.GetString(1));
+        }
+
+        if (columns.Contains("updated_at_ms"))
+        {
+            return "updated_at_ms";
+        }
+
+        if (columns.Contains("updated_at"))
+        {
+            return "updated_at";
+        }
+
+        return null;
+    }
+
+    private static long? ToActivityUtcTicks(string activityColumn, long rawValue)
+    {
+        if (rawValue <= 0)
+        {
+            return null;
+        }
+
+        return activityColumn switch
+        {
+            "updated_at_ms" => DateTimeOffset.FromUnixTimeMilliseconds(rawValue).UtcDateTime.Ticks,
+            "updated_at" => DateTimeOffset.FromUnixTimeSeconds(rawValue).UtcDateTime.Ticks,
+            _ => null
+        };
     }
 
     private static Exception WrapSqliteBusyError(Exception error, string action)

--- a/src/backup.js
+++ b/src/backup.js
@@ -64,7 +64,8 @@ export async function createBackup({
     files: sessionChanges.map((change) => ({
       path: change.path,
       originalFirstLine: change.originalFirstLine,
-      originalSeparator: change.originalSeparator
+      originalSeparator: change.originalSeparator,
+      lastActivityTimestampMs: change.lastActivityTimestampMs ?? null
     }))
   };
   await fs.writeFile(
@@ -103,7 +104,8 @@ export async function updateSessionBackupManifest(backupDir, sessionChanges) {
   sessionManifest.files = sessionChanges.map((change) => ({
     path: change.path,
     originalFirstLine: change.originalFirstLine,
-    originalSeparator: change.originalSeparator
+    originalSeparator: change.originalSeparator,
+    lastActivityTimestampMs: change.lastActivityTimestampMs ?? null
   }));
   metadata.changedSessionFiles = sessionChanges.length;
 

--- a/src/service.js
+++ b/src/service.js
@@ -269,7 +269,8 @@ export async function runSync({
           await restoreSessionChanges(appliedSessionChanges.map((change) => ({
             path: change.path,
             originalFirstLine: change.originalFirstLine,
-            originalSeparator: change.originalSeparator
+            originalSeparator: change.originalSeparator,
+            lastActivityTimestampMs: change.lastActivityTimestampMs ?? null
           })));
         } catch (restoreError) {
           throw new Error(

--- a/src/service.js
+++ b/src/service.js
@@ -32,6 +32,7 @@ import {
 } from "./session-files.js";
 import {
   assertSqliteWritable,
+  readSqliteThreadActivityTimestamps,
   readSqliteProviderCounts,
   updateSqliteProvider
 } from "./sqlite-state.js";
@@ -145,6 +146,16 @@ export async function runSync({
       lockedPaths: lockedReadPaths,
       providerCounts
     } = await collectSessionChanges(codexHome, targetProvider, { skipLockedReads: true });
+    const threadActivityTimestamps = await readSqliteThreadActivityTimestamps(
+      codexHome,
+      changes.map((change) => change.threadId)
+    );
+    for (const change of changes) {
+      const timestampMs = threadActivityTimestamps.get(change.threadId);
+      if (Number.isFinite(timestampMs)) {
+        change.lastActivityTimestampMs = timestampMs;
+      }
+    }
     emitProgress(onProgress, {
       stage: "scan_rollout_files",
       status: "complete",

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -35,52 +35,6 @@ async function getFileSnapshot(filePath) {
   };
 }
 
-function parseTimestampMs(value) {
-  if (typeof value !== "string" || value.trim() === "") {
-    return null;
-  }
-
-  const timestampMs = Date.parse(value);
-  return Number.isFinite(timestampMs) ? timestampMs : null;
-}
-
-function updateLatestTimestamp(currentLatestMs, candidateMs) {
-  if (!Number.isFinite(candidateMs)) {
-    return currentLatestMs;
-  }
-  if (!Number.isFinite(currentLatestMs)) {
-    return candidateMs;
-  }
-  return Math.max(currentLatestMs, candidateMs);
-}
-
-async function readLastActivityTimestampMs(filePath, fallbackMs) {
-  try {
-    const content = await fsp.readFile(filePath, "utf8");
-    let latestTimestampMs = null;
-
-    for (const line of content.split(/\r?\n/)) {
-      if (!line) {
-        continue;
-      }
-
-      try {
-        const parsed = JSON.parse(line);
-        latestTimestampMs = updateLatestTimestamp(latestTimestampMs, parseTimestampMs(parsed?.timestamp));
-        if (parsed?.type === "session_meta") {
-          latestTimestampMs = updateLatestTimestamp(latestTimestampMs, parseTimestampMs(parsed?.payload?.timestamp));
-        }
-      } catch {
-        // Ignore malformed lines and fall back to file metadata if needed.
-      }
-    }
-
-    return Number.isFinite(latestTimestampMs) ? latestTimestampMs : fallbackMs;
-  } catch {
-    return fallbackMs;
-  }
-}
-
 async function applyNormalizedMtime(filePath, normalizedMtimeMs) {
   if (!Number.isFinite(normalizedMtimeMs)) {
     return;
@@ -549,7 +503,6 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
 
       if (targetProvider !== "__status_only__" && parsed.payload.model_provider !== targetProvider) {
         const snapshot = await getFileSnapshot(rolloutPath);
-        const lastActivityTimestampMs = await readLastActivityTimestampMs(rolloutPath, snapshot.mtimeMs);
         parsed.payload.model_provider = targetProvider;
         summaries.push({
           path: rolloutPath,
@@ -560,7 +513,7 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
           originalOffset: record.offset,
           originalSize: snapshot.size,
           originalMtimeMs: snapshot.mtimeMs,
-          lastActivityTimestampMs,
+          lastActivityTimestampMs: snapshot.mtimeMs,
           updatedFirstLine: JSON.stringify(parsed)
         });
       }

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -35,6 +35,61 @@ async function getFileSnapshot(filePath) {
   };
 }
 
+function parseTimestampMs(value) {
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? timestampMs : null;
+}
+
+function updateLatestTimestamp(currentLatestMs, candidateMs) {
+  if (!Number.isFinite(candidateMs)) {
+    return currentLatestMs;
+  }
+  if (!Number.isFinite(currentLatestMs)) {
+    return candidateMs;
+  }
+  return Math.max(currentLatestMs, candidateMs);
+}
+
+async function readLastActivityTimestampMs(filePath, fallbackMs) {
+  try {
+    const content = await fsp.readFile(filePath, "utf8");
+    let latestTimestampMs = null;
+
+    for (const line of content.split(/\r?\n/)) {
+      if (!line) {
+        continue;
+      }
+
+      try {
+        const parsed = JSON.parse(line);
+        latestTimestampMs = updateLatestTimestamp(latestTimestampMs, parseTimestampMs(parsed?.timestamp));
+        if (parsed?.type === "session_meta") {
+          latestTimestampMs = updateLatestTimestamp(latestTimestampMs, parseTimestampMs(parsed?.payload?.timestamp));
+        }
+      } catch {
+        // Ignore malformed lines and fall back to file metadata if needed.
+      }
+    }
+
+    return Number.isFinite(latestTimestampMs) ? latestTimestampMs : fallbackMs;
+  } catch {
+    return fallbackMs;
+  }
+}
+
+async function applyNormalizedMtime(filePath, normalizedMtimeMs) {
+  if (!Number.isFinite(normalizedMtimeMs)) {
+    return;
+  }
+
+  const normalizedDate = new Date(normalizedMtimeMs);
+  await fsp.utimes(filePath, normalizedDate, normalizedDate);
+}
+
 function snapshotMatches(change, snapshot) {
   return change.originalSize === snapshot.size
     && change.originalMtimeMs === snapshot.mtimeMs;
@@ -305,7 +360,7 @@ async function invokeWindowsExclusiveRewrite(change, options) {
   return result;
 }
 
-async function rewriteFirstLine(filePath, nextFirstLine, separator) {
+async function rewriteFirstLine(filePath, nextFirstLine, separator, normalizedMtimeMs = null) {
   if (process.platform === "win32") {
     const result = await invokeWindowsExclusiveRewrite(
       {
@@ -355,6 +410,7 @@ async function rewriteFirstLine(filePath, nextFirstLine, separator) {
     });
 
     await fsp.rename(tmpPath, filePath);
+    await applyNormalizedMtime(filePath, normalizedMtimeMs);
   } catch (error) {
     await fsp.rm(tmpPath, { force: true });
     throw wrapRolloutFileBusyError(error, filePath, "rewrite");
@@ -404,6 +460,7 @@ async function tryRewriteCollectedFirstLine(change) {
     }
 
     await fsp.rename(tmpPath, change.path);
+    await applyNormalizedMtime(change.path, change.lastActivityTimestampMs);
     return true;
   } catch (error) {
     await fsp.rm(tmpPath, { force: true });
@@ -492,6 +549,7 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
 
       if (targetProvider !== "__status_only__" && parsed.payload.model_provider !== targetProvider) {
         const snapshot = await getFileSnapshot(rolloutPath);
+        const lastActivityTimestampMs = await readLastActivityTimestampMs(rolloutPath, snapshot.mtimeMs);
         parsed.payload.model_provider = targetProvider;
         summaries.push({
           path: rolloutPath,
@@ -502,6 +560,7 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
           originalOffset: record.offset,
           originalSize: snapshot.size,
           originalMtimeMs: snapshot.mtimeMs,
+          lastActivityTimestampMs,
           updatedFirstLine: JSON.stringify(parsed)
         });
       }
@@ -521,6 +580,10 @@ export async function applySessionChanges(changes) {
     const results = await invokeWindowsExclusiveRewriteBatch(normalizedChanges, { requireOriginalMatch: true });
     for (let index = 0; index < normalizedChanges.length; index += 1) {
       if (results[index] === "APPLIED") {
+        await applyNormalizedMtime(
+          normalizedChanges[index].path,
+          normalizedChanges[index].lastActivityTimestampMs
+        );
         appliedChanges += 1;
         appliedPaths.push(normalizedChanges[index].path);
       } else {
@@ -606,7 +669,8 @@ export async function restoreSessionChanges(manifestEntries) {
     const changes = manifestEntries.map((entry) => ({
       path: entry.path,
       separator: entry.originalSeparator ?? "\n",
-      updatedFirstLine: entry.originalFirstLine
+      updatedFirstLine: entry.originalFirstLine,
+      lastActivityTimestampMs: entry.lastActivityTimestampMs
     }));
     const results = await invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatch: false });
     const firstFailureIndex = results.findIndex((result) => result !== "APPLIED");
@@ -616,11 +680,20 @@ export async function restoreSessionChanges(manifestEntries) {
         `Unable to rewrite rollout file because it is currently in use. Close Codex and the Codex app, then retry. Locked file: ${filePath}`
       );
     }
+
+    for (const change of changes) {
+      await applyNormalizedMtime(change.path, change.lastActivityTimestampMs);
+    }
     return;
   }
 
   for (const entry of manifestEntries) {
-    await rewriteFirstLine(entry.path, entry.originalFirstLine, entry.originalSeparator ?? "\n");
+    await rewriteFirstLine(
+      entry.path,
+      entry.originalFirstLine,
+      entry.originalSeparator ?? "\n",
+      entry.lastActivityTimestampMs ?? null
+    );
   }
 }
 

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -14,6 +14,40 @@ function openDatabase(dbPath) {
   return new DatabaseSync(dbPath);
 }
 
+function normalizeThreadIds(threadIds) {
+  return [...new Set(
+    (threadIds ?? [])
+      .filter((threadId) => typeof threadId === "string")
+      .map((threadId) => threadId.trim())
+      .filter(Boolean)
+  )];
+}
+
+function detectThreadActivityColumn(db) {
+  const rows = db.prepare("PRAGMA table_info(threads)").all();
+  const columns = new Set(rows.map((row) => row.name));
+  if (columns.has("updated_at_ms")) {
+    return "updated_at_ms";
+  }
+  if (columns.has("updated_at")) {
+    return "updated_at";
+  }
+  return null;
+}
+
+function toActivityTimestampMs(columnName, value) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  if (columnName === "updated_at_ms") {
+    return value;
+  }
+  if (columnName === "updated_at") {
+    return value * 1000;
+  }
+  return null;
+}
+
 function normalizeBusyTimeoutMs(busyTimeoutMs) {
   return Number.isInteger(busyTimeoutMs) && busyTimeoutMs >= 0
     ? busyTimeoutMs
@@ -69,6 +103,53 @@ export async function readSqliteProviderCounts(codexHome) {
       bucket[row.model_provider] = row.count;
     }
     return result;
+  } finally {
+    db.close();
+  }
+}
+
+export async function readSqliteThreadActivityTimestamps(codexHome, threadIds) {
+  const normalizedThreadIds = normalizeThreadIds(threadIds);
+  if (normalizedThreadIds.length === 0) {
+    return new Map();
+  }
+
+  const dbPath = stateDbPath(codexHome);
+  try {
+    await fs.access(dbPath);
+  } catch {
+    return new Map();
+  }
+
+  const db = openDatabase(dbPath);
+  try {
+    const activityColumn = detectThreadActivityColumn(db);
+    if (!activityColumn) {
+      return new Map();
+    }
+
+    const result = new Map();
+    const chunkSize = 500;
+    for (let index = 0; index < normalizedThreadIds.length; index += chunkSize) {
+      const chunk = normalizedThreadIds.slice(index, index + chunkSize);
+      const placeholders = chunk.map(() => "?").join(", ");
+      const rows = db.prepare(`
+        SELECT id, ${activityColumn} AS activity_value
+        FROM threads
+        WHERE id IN (${placeholders})
+      `).all(...chunk);
+
+      for (const row of rows) {
+        const timestampMs = toActivityTimestampMs(activityColumn, row.activity_value);
+        if (Number.isFinite(timestampMs)) {
+          result.set(row.id, timestampMs);
+        }
+      }
+    }
+
+    return result;
+  } catch {
+    return new Map();
   } finally {
     db.close();
   }

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -49,6 +49,10 @@ async function writeCustomRollout(filePath, payload, message = "hi") {
   await fs.writeFile(filePath, `${lines.join("\n")}\n`, "utf8");
 }
 
+async function writeRolloutLines(filePath, lines) {
+  await fs.writeFile(filePath, `${lines.join("\n")}\n`, "utf8");
+}
+
 function backupRoot(codexHome) {
   return path.join(codexHome, "backups_state", "provider-sync");
 }
@@ -272,6 +276,45 @@ test("runSync reports stage progress and backup duration", async () => {
   assert.ok(backupCompleteEvent);
   assert.equal(backupCompleteEvent.backupDir, result.backupDir);
   assert.ok(backupCompleteEvent.durationMs >= 0);
+});
+
+test("runSync normalizes rollout mtime to the thread's last activity time", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-a.jsonl");
+  const latestActivityIso = "2026-03-22T15:45:30.000Z";
+  await writeRolloutLines(sessionPath, [
+    JSON.stringify({
+      timestamp: "2026-03-19T00:00:20.000Z",
+      type: "session_meta",
+      payload: {
+        id: "thread-a",
+        timestamp: "2026-03-19T00:00:00.000Z",
+        cwd: "C:\\AITemp",
+        source: "cli",
+        cli_version: "0.115.0",
+        model_provider: "apigather"
+      }
+    }),
+    JSON.stringify({
+      timestamp: latestActivityIso,
+      type: "event_msg",
+      payload: {
+        type: "assistant_message",
+        message: "latest"
+      }
+    })
+  ]);
+  const wrongTimestamp = new Date("2026-04-01T00:00:00.000Z");
+  await fs.utimes(sessionPath, wrongTimestamp, wrongTimestamp);
+  await writeStateDb(codexHome, [
+    { id: "thread-a", model_provider: "apigather", archived: false }
+  ]);
+
+  await runSync({ codexHome });
+
+  const stat = await fs.stat(sessionPath);
+  assert.ok(Math.abs(stat.mtimeMs - Date.parse(latestActivityIso)) < 2000);
 });
 
 test("runSwitch updates config and syncs provider metadata", async () => {

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -98,14 +98,38 @@ async function writeStateDb(codexHome, rows) {
     db.exec(`
       CREATE TABLE threads (
         id TEXT PRIMARY KEY,
+        rollout_path TEXT,
+        created_at INTEGER,
+        updated_at INTEGER,
+        updated_at_ms INTEGER,
         model_provider TEXT,
         archived INTEGER NOT NULL DEFAULT 0,
         first_user_message TEXT NOT NULL DEFAULT ''
       )
     `);
-    const stmt = db.prepare("INSERT INTO threads (id, model_provider, archived, first_user_message) VALUES (?, ?, ?, ?)");
+    const stmt = db.prepare(`
+      INSERT INTO threads (
+        id,
+        rollout_path,
+        created_at,
+        updated_at,
+        updated_at_ms,
+        model_provider,
+        archived,
+        first_user_message
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
     for (const row of rows) {
-      stmt.run(row.id, row.model_provider, row.archived ? 1 : 0, row.first_user_message ?? "hello");
+      stmt.run(
+        row.id,
+        row.rollout_path ?? "",
+        row.created_at ?? null,
+        row.updated_at ?? null,
+        row.updated_at_ms ?? null,
+        row.model_provider,
+        row.archived ? 1 : 0,
+        row.first_user_message ?? "hello"
+      );
     }
   } finally {
     db.close();
@@ -278,11 +302,12 @@ test("runSync reports stage progress and backup duration", async () => {
   assert.ok(backupCompleteEvent.durationMs >= 0);
 });
 
-test("runSync normalizes rollout mtime to the thread's last activity time", async () => {
+test("runSync normalizes rollout mtime to sqlite thread updated_at_ms", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"');
   const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-a.jsonl");
-  const latestActivityIso = "2026-03-22T15:45:30.000Z";
+  const rolloutActivityIso = "2026-03-22T15:45:30.000Z";
+  const sqliteActivityIso = "2026-03-21T09:10:11.123Z";
   await writeRolloutLines(sessionPath, [
     JSON.stringify({
       timestamp: "2026-03-19T00:00:20.000Z",
@@ -297,7 +322,7 @@ test("runSync normalizes rollout mtime to the thread's last activity time", asyn
       }
     }),
     JSON.stringify({
-      timestamp: latestActivityIso,
+      timestamp: rolloutActivityIso,
       type: "event_msg",
       payload: {
         type: "assistant_message",
@@ -308,13 +333,57 @@ test("runSync normalizes rollout mtime to the thread's last activity time", asyn
   const wrongTimestamp = new Date("2026-04-01T00:00:00.000Z");
   await fs.utimes(sessionPath, wrongTimestamp, wrongTimestamp);
   await writeStateDb(codexHome, [
+    {
+      id: "thread-a",
+      model_provider: "apigather",
+      archived: false,
+      updated_at: Math.floor(Date.parse(sqliteActivityIso) / 1000),
+      updated_at_ms: Date.parse(sqliteActivityIso)
+    }
+  ]);
+
+  await runSync({ codexHome });
+
+  const stat = await fs.stat(sessionPath);
+  assert.ok(Math.abs(stat.mtimeMs - Date.parse(sqliteActivityIso)) < 2000);
+});
+
+test("runSync preserves original rollout mtime when sqlite thread activity is unavailable", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-a.jsonl");
+  await writeRolloutLines(sessionPath, [
+    JSON.stringify({
+      timestamp: "2026-03-19T00:00:20.000Z",
+      type: "session_meta",
+      payload: {
+        id: "thread-a",
+        timestamp: "2026-03-19T00:00:00.000Z",
+        cwd: "C:\\AITemp",
+        source: "cli",
+        cli_version: "0.115.0",
+        model_provider: "apigather"
+      }
+    }),
+    JSON.stringify({
+      timestamp: "2026-03-25T12:00:00.000Z",
+      type: "event_msg",
+      payload: {
+        type: "assistant_message",
+        message: "later in rollout only"
+      }
+    })
+  ]);
+  const preservedTimestamp = new Date("2026-04-01T00:00:00.000Z");
+  await fs.utimes(sessionPath, preservedTimestamp, preservedTimestamp);
+  await writeStateDb(codexHome, [
     { id: "thread-a", model_provider: "apigather", archived: false }
   ]);
 
   await runSync({ codexHome });
 
   const stat = await fs.stat(sessionPath);
-  assert.ok(Math.abs(stat.mtimeMs - Date.parse(latestActivityIso)) < 2000);
+  assert.ok(Math.abs(stat.mtimeMs - preservedTimestamp.getTime()) < 2000);
 });
 
 test("runSwitch updates config and syncs provider metadata", async () => {


### PR DESCRIPTION
## Summary
- normalize rewritten rollout file mtimes to each thread's latest activity timestamp
- persist the normalized timestamp in backup manifests so restore keeps the same ordering behavior
- add JS and .NET integration tests covering the latest-activity ordering case

## Why
After provider sync, Codex session visibility comes back, but the visible ordering can drift because the rollout file mtime changes during rewrite. Preserving the latest activity timestamp keeps transferred sessions sorted by the most recent chat instead of the sync time.

## Validation
- `npm test`
- `dotnet restore desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj --configfile ./NuGet.Config`
- `dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj --no-restore`