### PR TITLE
feat: 新增 macOS Avalonia 桌面端 GUI

### DIFF
--- a/CodexProviderSync.sln
+++ b/CodexProviderSync.sln
@@ -7,6 +7,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "desktop", "desktop", "{7A12
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodexProviderSync.App", "desktop\CodexProviderSync.App\CodexProviderSync.App.csproj", "{046C07E6-8117-4F19-B2CF-683D62D944C9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodexProviderSync.Mac", "desktop\CodexProviderSync.Mac\CodexProviderSync.Mac.csproj", "{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodexProviderSync.Core", "desktop\CodexProviderSync.Core\CodexProviderSync.Core.csproj", "{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,11 +33,37 @@ Global
 		{046C07E6-8117-4F19-B2CF-683D62D944C9}.Release|x64.Build.0 = Release|Any CPU
 		{046C07E6-8117-4F19-B2CF-683D62D944C9}.Release|x86.ActiveCfg = Release|Any CPU
 		{046C07E6-8117-4F19-B2CF-683D62D944C9}.Release|x86.Build.0 = Release|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Debug|x64.Build.0 = Debug|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Debug|x86.Build.0 = Debug|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Release|x64.ActiveCfg = Release|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Release|x64.Build.0 = Release|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Release|x86.ActiveCfg = Release|Any CPU
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901}.Release|x86.Build.0 = Release|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Debug|x64.Build.0 = Debug|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Debug|x86.Build.0 = Debug|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Release|x64.ActiveCfg = Release|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Release|x64.Build.0 = Release|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Release|x86.ActiveCfg = Release|Any CPU
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{046C07E6-8117-4F19-B2CF-683D62D944C9} = {7A1224A0-F22D-34FF-DE0A-A058FAFFD90C}
+		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901} = {7A1224A0-F22D-34FF-DE0A-A058FAFFD90C}
+		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B} = {7A1224A0-F22D-34FF-DE0A-A058FAFFD90C}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Windows 用户优先下载 Release 里的 `CodexProviderSync.exe`：
 3. 选择目标 Provider
 4. 点击 `Execute`
 
-macOS 等环境使用 CLI：
+macOS 用户可使用 Avalonia 桌面版，构建说明见 [README_MAC_GUI_ZH.md](docs/README_MAC_GUI_ZH.md)。
+
+其它环境使用 CLI：
 
 ```bash
 npm install -g git+https://github.com/Dailin521/codex-provider-sync.git
@@ -98,7 +100,7 @@ codex-provider prune-backups --keep 5
 - 如果活跃会话锁住 rollout 文件，工具会跳过该文件并继续处理其它历史会话。
 - 如果 EXE 双击无反应，先确认已解压，再查看 `%AppData%\codex-provider-sync\startup-error.log`，或在 PowerShell 里运行 `./CodexProviderSync.exe`。
 
-GUI 说明见 [README_GUI_ZH.md](docs/README_GUI_ZH.md)。AI / Agent 说明见 [AGENTS.md](AGENTS.md)。
+Windows GUI 说明见 [README_GUI_ZH.md](docs/README_GUI_ZH.md)，macOS GUI 说明见 [README_MAC_GUI_ZH.md](docs/README_MAC_GUI_ZH.md)。AI / Agent 说明见 [AGENTS.md](AGENTS.md)。
 
 ## 开发
 
@@ -108,6 +110,7 @@ cd codex-provider-sync
 npm test
 dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
 pwsh ./scripts/publish-gui.ps1
+./scripts/publish-gui-macos.sh
 ```
 
 ## License

--- a/desktop/CodexProviderSync.Core.Tests/LockServiceTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/LockServiceTests.cs
@@ -3,6 +3,22 @@ namespace CodexProviderSync.Core.Tests;
 public sealed class LockServiceTests
 {
     [Fact]
+    public async Task AcquireLockAsync_CreatesAndReleasesLockDirectory()
+    {
+        string codexHome = Path.Combine(Path.GetTempPath(), $"codex-provider-lock-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(codexHome);
+        string lockPath = AppConstants.LockPath(codexHome);
+
+        await using (await new LockService().AcquireLockAsync(codexHome, "test"))
+        {
+            Assert.True(Directory.Exists(lockPath));
+            Assert.True(File.Exists(Path.Combine(lockPath, "owner.json")));
+        }
+
+        Assert.False(Directory.Exists(lockPath));
+    }
+
+    [Fact]
     public async Task CreateLockDirectoryAsync_RetriesTransientAccessDeniedErrors()
     {
         int attempts = 0;

--- a/desktop/CodexProviderSync.Core.Tests/SettingsAndDiscoveryTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/SettingsAndDiscoveryTests.cs
@@ -13,7 +13,8 @@ public sealed class SettingsAndDiscoveryTests
             SavedProviders = ["apigather"],
             ManualProviders = ["custom-a"],
             LastSelectedProvider = "apigather",
-            BackupRetentionCount = 7
+            BackupRetentionCount = 7,
+            UiLanguage = "zh-Hans"
         };
 
         await service.SaveAsync(settings);
@@ -23,6 +24,7 @@ public sealed class SettingsAndDiscoveryTests
         Assert.Contains("custom-a", loaded.ManualProviders);
         Assert.Equal("apigather", loaded.LastSelectedProvider);
         Assert.Equal(7, loaded.BackupRetentionCount);
+        Assert.Equal("zh-Hans", loaded.UiLanguage);
     }
 
     [Fact]

--- a/desktop/CodexProviderSync.Core/LockService.cs
+++ b/desktop/CodexProviderSync.Core/LockService.cs
@@ -84,11 +84,37 @@ public sealed class LockService
 
     private static int TryCreateDirectory(string lockPath)
     {
+        return OperatingSystem.IsWindows()
+            ? TryCreateDirectoryWindows(lockPath)
+            : TryCreateDirectoryUnix(lockPath);
+    }
+
+    private static int TryCreateDirectoryWindows(string lockPath)
+    {
         return CreateDirectory(lockPath, IntPtr.Zero) ? 0 : Marshal.GetLastWin32Error();
+    }
+
+    private static int TryCreateDirectoryUnix(string lockPath)
+    {
+        if (Mkdir(lockPath, 448) == 0)
+        {
+            return 0;
+        }
+
+        int errorCode = Marshal.GetLastWin32Error();
+        return errorCode switch
+        {
+            17 => Win32ErrorAlreadyExists,
+            1 or 13 => Win32ErrorAccessDenied,
+            _ => errorCode
+        };
     }
 
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     private static extern bool CreateDirectory(string lpPathName, IntPtr lpSecurityAttributes);
+
+    [DllImport("libc", SetLastError = true, EntryPoint = "mkdir")]
+    private static extern int Mkdir(string pathname, uint mode);
 
     private sealed class LockOwner
     {

--- a/desktop/CodexProviderSync.Core/Models.cs
+++ b/desktop/CodexProviderSync.Core/Models.cs
@@ -159,6 +159,7 @@ public sealed class AppSettings
     public string? LastSelectedProvider { get; init; }
     public string? LastBackupDirectory { get; init; }
     public int BackupRetentionCount { get; init; } = AppConstants.DefaultBackupRetentionCount;
+    public string UiLanguage { get; init; } = "en";
     public WindowBoundsState? WindowBounds { get; init; }
 }
 

--- a/desktop/CodexProviderSync.Core/SessionRolloutService.cs
+++ b/desktop/CodexProviderSync.Core/SessionRolloutService.cs
@@ -738,7 +738,7 @@ public sealed class SessionRolloutService
         if (error is IOException ioException)
         {
             int code = ioException.HResult & 0xFFFF;
-            return code is 32 or 33;
+            return code is 32 or 33 or 35;
         }
 
         return false;

--- a/desktop/CodexProviderSync.Core/SettingsService.cs
+++ b/desktop/CodexProviderSync.Core/SettingsService.cs
@@ -66,6 +66,7 @@ public sealed class SettingsService
             LastSelectedProvider = settings.LastSelectedProvider,
             LastBackupDirectory = settings.LastBackupDirectory,
             BackupRetentionCount = NormalizeBackupRetentionCount(settings.BackupRetentionCount),
+            UiLanguage = NormalizeUiLanguage(settings.UiLanguage),
             WindowBounds = settings.WindowBounds
         };
     }
@@ -81,6 +82,7 @@ public sealed class SettingsService
             LastSelectedProvider = settings.LastSelectedProvider,
             LastBackupDirectory = settings.LastBackupDirectory,
             BackupRetentionCount = NormalizeBackupRetentionCount(settings.BackupRetentionCount),
+            UiLanguage = NormalizeUiLanguage(settings.UiLanguage),
             WindowBounds = settings.WindowBounds
         };
     }
@@ -96,6 +98,7 @@ public sealed class SettingsService
             LastSelectedProvider = providerId,
             LastBackupDirectory = settings.LastBackupDirectory,
             BackupRetentionCount = NormalizeBackupRetentionCount(settings.BackupRetentionCount),
+            UiLanguage = NormalizeUiLanguage(settings.UiLanguage),
             WindowBounds = settings.WindowBounds
         };
     }
@@ -111,6 +114,23 @@ public sealed class SettingsService
             LastSelectedProvider = string.Equals(settings.LastSelectedProvider, providerId, StringComparison.Ordinal) ? null : settings.LastSelectedProvider,
             LastBackupDirectory = settings.LastBackupDirectory,
             BackupRetentionCount = NormalizeBackupRetentionCount(settings.BackupRetentionCount),
+            UiLanguage = NormalizeUiLanguage(settings.UiLanguage),
+            WindowBounds = settings.WindowBounds
+        };
+    }
+
+    public AppSettings UpdateUiLanguage(AppSettings settings, string uiLanguage)
+    {
+        return new AppSettings
+        {
+            RecentCodexHomes = Deduplicate(settings.RecentCodexHomes).ToList(),
+            LastCodexHome = settings.LastCodexHome,
+            SavedProviders = Deduplicate(settings.SavedProviders).ToList(),
+            ManualProviders = Deduplicate(settings.ManualProviders).ToList(),
+            LastSelectedProvider = settings.LastSelectedProvider,
+            LastBackupDirectory = settings.LastBackupDirectory,
+            BackupRetentionCount = NormalizeBackupRetentionCount(settings.BackupRetentionCount),
+            UiLanguage = NormalizeUiLanguage(uiLanguage),
             WindowBounds = settings.WindowBounds
         };
     }
@@ -131,6 +151,7 @@ public sealed class SettingsService
             LastSelectedProvider = string.IsNullOrWhiteSpace(selectedProvider) ? settings.LastSelectedProvider : selectedProvider.Trim(),
             LastBackupDirectory = string.IsNullOrWhiteSpace(backupDirectory) ? settings.LastBackupDirectory : Path.GetFullPath(backupDirectory),
             BackupRetentionCount = NormalizeBackupRetentionCount(backupRetentionCount ?? settings.BackupRetentionCount),
+            UiLanguage = NormalizeUiLanguage(settings.UiLanguage),
             WindowBounds = bounds ?? settings.WindowBounds
         };
     }
@@ -146,6 +167,7 @@ public sealed class SettingsService
             LastSelectedProvider = string.IsNullOrWhiteSpace(settings.LastSelectedProvider) ? null : settings.LastSelectedProvider.Trim(),
             LastBackupDirectory = string.IsNullOrWhiteSpace(settings.LastBackupDirectory) ? null : Path.GetFullPath(settings.LastBackupDirectory),
             BackupRetentionCount = NormalizeBackupRetentionCount(settings.BackupRetentionCount),
+            UiLanguage = NormalizeUiLanguage(settings.UiLanguage),
             WindowBounds = settings.WindowBounds
         };
     }
@@ -171,5 +193,10 @@ public sealed class SettingsService
     private static int NormalizeBackupRetentionCount(int value)
     {
         return value < 1 ? AppConstants.DefaultBackupRetentionCount : value;
+    }
+
+    private static string NormalizeUiLanguage(string? value)
+    {
+        return string.Equals(value, "zh-Hans", StringComparison.Ordinal) ? "zh-Hans" : "en";
     }
 }

--- a/desktop/CodexProviderSync.Mac/App.cs
+++ b/desktop/CodexProviderSync.Mac/App.cs
@@ -1,0 +1,25 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+
+namespace CodexProviderSync.Mac;
+
+public sealed class App : Application
+{
+    public override void Initialize()
+    {
+        RequestedThemeVariant = ThemeVariant.Light;
+        Styles.Add(new FluentTheme());
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/desktop/CodexProviderSync.Mac/App.cs
+++ b/desktop/CodexProviderSync.Mac/App.cs
@@ -15,11 +15,14 @@ public sealed class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        MainWindow? mainWindow = null;
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            desktop.MainWindow = new MainWindow();
+            mainWindow = new MainWindow();
+            desktop.MainWindow = mainWindow;
         }
 
         base.OnFrameworkInitializationCompleted();
+        mainWindow?.Show();
     }
 }

--- a/desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj
+++ b/desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodexProviderSync.Core\CodexProviderSync.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>CodexProviderSync</AssemblyName>
+    <Product>Codex Provider Sync</Product>
+    <Company>Dailin521</Company>
+    <Version>0.2.5</Version>
+    <AssemblyVersion>0.2.5.0</AssemblyVersion>
+    <FileVersion>0.2.5.0</FileVersion>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+</Project>

--- a/desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj
+++ b/desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj
@@ -5,8 +5,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/desktop/CodexProviderSync.Mac/ConfirmationDialog.cs
+++ b/desktop/CodexProviderSync.Mac/ConfirmationDialog.cs
@@ -1,0 +1,62 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace CodexProviderSync.Mac;
+
+internal sealed class ConfirmationDialog : Window
+{
+    public ConfirmationDialog(string title, string message, string primaryText, string? secondaryText)
+    {
+        Title = title;
+        Width = 460;
+        SizeToContent = SizeToContent.Height;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        CanResize = false;
+        Background = Brushes.White;
+
+        StackPanel root = new()
+        {
+            Margin = new Thickness(20),
+            Spacing = 18
+        };
+
+        root.Children.Add(new TextBlock
+        {
+            Text = message,
+            TextWrapping = TextWrapping.Wrap,
+            LineHeight = 20,
+            Foreground = Brush.Parse("#18181b")
+        });
+
+        StackPanel buttons = new()
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 10
+        };
+
+        if (!string.IsNullOrWhiteSpace(secondaryText))
+        {
+            Button secondary = new()
+            {
+                Content = secondaryText,
+                MinWidth = 88
+            };
+            secondary.Click += (_, _) => Close(false);
+            buttons.Children.Add(secondary);
+        }
+
+        Button primary = new()
+        {
+            Content = primaryText,
+            MinWidth = 88
+        };
+        primary.Click += (_, _) => Close(true);
+        buttons.Children.Add(primary);
+        root.Children.Add(buttons);
+
+        Content = root;
+    }
+}

--- a/desktop/CodexProviderSync.Mac/MacDisplayFormatter.cs
+++ b/desktop/CodexProviderSync.Mac/MacDisplayFormatter.cs
@@ -1,0 +1,201 @@
+using CodexProviderSync.Core;
+
+namespace CodexProviderSync.Mac;
+
+internal static class MacDisplayFormatter
+{
+    public static string FormatStatus(StatusSnapshot status, string language)
+    {
+        if (!MacUiText.IsChinese(language))
+        {
+            return TextFormatter.FormatStatus(status);
+        }
+
+        List<string> lines =
+        [
+            $"Codex Home: {status.CodexHome}",
+            $"当前 Provider: {status.CurrentProvider.Provider}{(status.CurrentProvider.Implicit ? "（隐式默认）" : string.Empty)}",
+            $"配置中的 Provider: {string.Join(", ", status.ConfiguredProviders)}",
+            $"备份: {status.BackupSummary.Count}（{FormatBytes(status.BackupSummary.TotalBytes)}）",
+            $"备份目录: {status.BackupRoot}",
+            string.Empty,
+            "Rollout 文件:",
+            $"  sessions: {FormatCounts(status.RolloutCounts.Sessions)}",
+            $"  archived_sessions: {FormatCounts(status.RolloutCounts.ArchivedSessions)}",
+            $"  encrypted_content sessions: {FormatCounts(status.EncryptedContentCounts.Sessions)}",
+            $"  encrypted_content archived_sessions: {FormatCounts(status.EncryptedContentCounts.ArchivedSessions)}",
+            string.Empty,
+            "SQLite 状态:"
+        ];
+
+        if (!string.IsNullOrWhiteSpace(status.EncryptedContentWarning))
+        {
+            lines.Insert(11, $"  {status.EncryptedContentWarning}");
+        }
+
+        if (status.LockedRolloutFiles.Count > 0)
+        {
+            lines.Insert(11, $"  状态扫描时跳过 locked rollout 文件: {status.LockedRolloutFiles.Count}");
+        }
+
+        if (status.SqliteCounts?.Unreadable == true)
+        {
+            lines.Add($"  {status.SqliteCounts.Error ?? "state_5.sqlite 损坏或不可读"}");
+        }
+        else if (status.SqliteCounts is null)
+        {
+            lines.Add("  未找到 state_5.sqlite");
+        }
+        else
+        {
+            lines.Add($"  sessions: {FormatCounts(status.SqliteCounts.Sessions)}");
+            lines.Add($"  archived_sessions: {FormatCounts(status.SqliteCounts.ArchivedSessions)}");
+            if (status.SqliteRepairStats?.UserEventRowsNeedingRepair > 0)
+            {
+                lines.Add($"  需要修复的 user-event 标记: {status.SqliteRepairStats.UserEventRowsNeedingRepair}");
+            }
+            if (status.SqliteRepairStats?.CwdRowsNeedingRepair > 0)
+            {
+                lines.Add($"  需要修复的 cwd 路径: {status.SqliteRepairStats.CwdRowsNeedingRepair}");
+            }
+        }
+
+        if (status.ProjectThreadVisibility.Count > 0)
+        {
+            lines.Add(string.Empty);
+            lines.Add("项目可见性:");
+            foreach (ProjectThreadVisibility project in status.ProjectThreadVisibility)
+            {
+                string rankText = string.IsNullOrWhiteSpace(project.RankPreview) ? "（无）" : project.RankPreview;
+                lines.Add(
+                    $"  {project.Root}: interactive {project.InteractiveThreads}, 首屏 {project.FirstPageThreads}/50, ranks {rankText}, 精确 cwd {project.ExactCwdMatches}/{project.InteractiveThreads}, 原始 cwd 行 {project.VerbatimCwdRows}, providers {FormatCounts(project.ProviderCounts)}");
+            }
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static string FormatSyncResult(SyncResult result, string label, string language)
+    {
+        if (!MacUiText.IsChinese(language))
+        {
+            return TextFormatter.FormatSyncResult(result, label);
+        }
+
+        List<string> lines =
+        [
+            $"{label} provider: {result.TargetProvider}",
+            $"Codex Home: {result.CodexHome}",
+            $"备份: {result.BackupDir}",
+            $"已更新 rollout 文件: {result.ChangedSessionFiles}",
+            $"已更新 SQLite 行: {result.SqliteRowsUpdated}{(result.SqlitePresent ? string.Empty : "（未找到 state_5.sqlite）")}"
+        ];
+
+        if (result.SqliteUserEventRowsUpdated > 0)
+        {
+            lines.Add($"已更新 SQLite user-event 标记: {result.SqliteUserEventRowsUpdated}");
+        }
+        if (result.SqliteCwdRowsUpdated > 0)
+        {
+            lines.Add($"已更新 SQLite cwd 路径: {result.SqliteCwdRowsUpdated}");
+        }
+        if (result.UpdatedWorkspaceRoots > 0)
+        {
+            lines.Add($"已更新 workspace roots: {result.UpdatedWorkspaceRoots}");
+        }
+        if (result.SkippedLockedRolloutFiles.Count > 0)
+        {
+            string preview = string.Join(", ", result.SkippedLockedRolloutFiles.Take(5));
+            int extraCount = result.SkippedLockedRolloutFiles.Count - Math.Min(result.SkippedLockedRolloutFiles.Count, 5);
+            lines.Add($"跳过 locked rollout 文件: {result.SkippedLockedRolloutFiles.Count}");
+            lines.Add($"Locked 文件: {preview}{(extraCount > 0 ? $"（另有 {extraCount} 个）" : string.Empty)}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.EncryptedContentWarning))
+        {
+            lines.Add(result.EncryptedContentWarning);
+        }
+        if (result.AutoPruneResult is not null)
+        {
+            lines.Add(
+                $"备份清理: 删除 {result.AutoPruneResult.DeletedCount}, 剩余 {result.AutoPruneResult.RemainingCount}, 释放 {FormatBytes(result.AutoPruneResult.FreedBytes)}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.AutoPruneWarning))
+        {
+            lines.Add($"备份清理警告: {result.AutoPruneWarning}");
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static string FormatRestoreResult(RestoreResult result, string language)
+    {
+        if (!MacUiText.IsChinese(language))
+        {
+            return TextFormatter.FormatRestoreResult(result);
+        }
+
+        List<string> lines =
+        [
+            $"已从备份恢复: {result.BackupDir}",
+            $"Codex Home: {result.CodexHome}",
+            $"备份时的 Provider: {result.TargetProvider}",
+            $"备份的 rollout 文件数量: {result.ChangedSessionFiles}"
+        ];
+
+        if (result.CreatedAt is not null)
+        {
+            lines.Add($"备份创建时间: {result.CreatedAt:O}");
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static string FormatBackupPruneResult(BackupPruneResult result, string language)
+    {
+        if (!MacUiText.IsChinese(language))
+        {
+            return TextFormatter.FormatBackupPruneResult(result);
+        }
+
+        return string.Join(Environment.NewLine, new[]
+        {
+            $"备份根目录: {result.BackupRoot}",
+            $"已删除备份: {result.DeletedCount}",
+            $"剩余备份: {result.RemainingCount}",
+            $"释放空间: {FormatBytes(result.FreedBytes)}"
+        });
+    }
+
+    public static string FormatProviderSources(ProviderOption option, string language)
+    {
+        return string.Join(", ", option.Sources.Select(source => source switch
+        {
+            ProviderSource.Config => MacUiText.IsChinese(language) ? "配置" : "Config",
+            ProviderSource.Rollout => "Rollout",
+            ProviderSource.Sqlite => "SQLite",
+            ProviderSource.Manual => MacUiText.IsChinese(language) ? "手动" : "Manual",
+            _ => source.ToString()
+        }));
+    }
+
+    private static string FormatCounts(Dictionary<string, int> counts)
+    {
+        return counts.Count == 0
+            ? "(none)"
+            : string.Join(", ", counts.OrderBy(pair => pair.Key, StringComparer.Ordinal).Select(pair => $"{pair.Key}: {pair.Value}"));
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB", "TB"];
+        double value = bytes;
+        int unitIndex = 0;
+        while (value >= 1024 && unitIndex < units.Length - 1)
+        {
+            value /= 1024;
+            unitIndex += 1;
+        }
+
+        return unitIndex == 0 ? $"{bytes} B" : $"{value:0.##} {units[unitIndex]}";
+    }
+}

--- a/desktop/CodexProviderSync.Mac/MacUiText.cs
+++ b/desktop/CodexProviderSync.Mac/MacUiText.cs
@@ -1,0 +1,87 @@
+namespace CodexProviderSync.Mac;
+
+internal static class MacUiText
+{
+    public const string English = "en";
+    public const string Chinese = "zh-Hans";
+
+    public static string NormalizeLanguage(string? language)
+    {
+        return string.Equals(language, Chinese, StringComparison.Ordinal) ? Chinese : English;
+    }
+
+    public static bool IsChinese(string language)
+    {
+        return string.Equals(NormalizeLanguage(language), Chinese, StringComparison.Ordinal);
+    }
+
+    public static string Get(string language, string key)
+    {
+        bool zh = IsChinese(language);
+        return key switch
+        {
+            "language" => zh ? "语言" : "Language",
+            "recent" => zh ? "最近使用" : "Recent",
+            "browse" => zh ? "浏览" : "Browse",
+            "refresh" => zh ? "刷新" : "Refresh",
+            "status" => zh ? "当前状态" : "Status",
+            "providers" => zh ? "Provider 列表" : "Providers",
+            "actions" => zh ? "执行" : "Actions",
+            "executionLog" => zh ? "执行日志" : "Execution Log",
+            "addProvider" => zh ? "添加 provider id" : "Add provider id",
+            "add" => zh ? "添加" : "Add",
+            "removeManual" => zh ? "删除手动项" : "Remove Manual",
+            "noProvider" => zh ? "未选择 provider" : "No provider selected",
+            "switchConfig" => zh ? "切换 config.toml 并同步" : "Switch config.toml and sync",
+            "syncMetadata" => zh ? "仅同步 Metadata" : "Sync Metadata Only",
+            "switchSync" => zh ? "切换配置并同步" : "Switch Config + Sync",
+            "restoreConfig" => zh ? "恢复 config.toml" : "Restore config.toml",
+            "restoreSqlite" => zh ? "恢复 SQLite" : "Restore SQLite",
+            "restoreRollout" => zh ? "恢复 rollout metadata" : "Restore rollout metadata",
+            "restoreBackup" => zh ? "恢复备份" : "Restore Backup",
+            "openBackupFolder" => zh ? "打开备份目录" : "Open Backup Folder",
+            "cleanBackups" => zh ? "清理旧备份" : "Clean Old Backups",
+            "ready" => zh ? "就绪" : "Ready",
+            "targetProvider" => zh ? "目标 Provider" : "Target provider",
+            "restoreContents" => zh ? "恢复内容" : "Restore contents",
+            "keepBackups" => zh ? "保留备份数" : "Keep backups",
+            "writeWarning" => zh ? "执行写操作前，请先关闭 Codex CLI、Codex App、app-server 和相关终端。" : "Close Codex CLI, Codex App, app-server, and related terminals before executing write actions.",
+            "refreshing" => zh ? "刷新中..." : "Refreshing...",
+            "executing" => zh ? "执行中..." : "Executing...",
+            "restoring" => zh ? "恢复中..." : "Restoring...",
+            "cleaning" => zh ? "清理中..." : "Cleaning backups...",
+            "loadedSettings" => zh ? "已加载设置" : "Loaded settings",
+            "languageChanged" => zh ? "语言已切换" : "Language changed",
+            "enterProvider" => zh ? "请输入要添加的 provider id。" : "Enter a provider id before adding it.",
+            "selectProvider" => zh ? "请先选择一个 provider。" : "Select a provider first.",
+            "selectTargetProvider" => zh ? "请先选择目标 provider。" : "Select a target provider first.",
+            "addedManualProvider" => zh ? "已添加手动 provider" : "Added manual provider",
+            "removedManualProvider" => zh ? "已删除手动 provider" : "Removed manual provider",
+            "confirmSyncMode" => zh ? "仅同步 metadata" : "sync metadata only",
+            "confirmSwitchMode" => zh ? "切换 config.toml 并同步 metadata" : "switch config.toml and sync metadata",
+            "confirmWriteMessage" => zh ? "将为 provider \"{1}\" 执行：{0}。\n\n请先关闭 Codex CLI、Codex App、app-server 和相关终端。\n\n修改 metadata 前会先创建备份。是否继续？" : "This will {0} for provider \"{1}\".\n\nClose Codex CLI, Codex App, app-server, and related terminals first.\n\nA backup will be created before metadata is changed. Continue?",
+            "executionFinished" => zh ? "执行完成" : "Execution finished",
+            "switchedAndSynced" => zh ? "已切换并同步" : "Switched and synced",
+            "synced" => zh ? "已同步" : "Synced",
+            "chooseRestoreTarget" => zh ? "请至少选择一种要恢复的内容。" : "Choose at least one restore target.",
+            "restoreMessage" => zh ? "确认恢复以下备份？\n\n{0}\n\n将覆盖当前的: {1}。\n请先关闭 Codex。是否继续？" : "Restore this backup?\n\n{0}\n\nThis will overwrite: {1}.\nClose Codex first. Continue?",
+            "restoreFinished" => zh ? "恢复完成" : "Restore finished",
+            "cleanMessage" => zh ? "只保留最新 {0} 份本工具管理的备份。\n\n已删除的备份无法从本 App 恢复。是否继续？" : "Keep only the newest {0} managed backup(s).\n\nDeleted backup folders cannot be restored from this app. Continue?",
+            "backupCleanupFinished" => zh ? "备份清理完成" : "Backup cleanup finished",
+            "refreshed" => zh ? "已刷新" : "Refreshed",
+            "chooseCodexFolder" => zh ? "选择 .codex 目录" : "Choose .codex folder",
+            "chooseBackupFolder" => zh ? "选择备份目录" : "Choose backup folder",
+            "continue" => zh ? "继续" : "Continue",
+            "cancel" => zh ? "取消" : "Cancel",
+            "ok" => zh ? "确定" : "OK",
+            "error" => zh ? "错误" : "Error",
+            "confirmWriteTitle" => zh ? "确认写操作" : "Confirm Write Action",
+            "restoreTitle" => zh ? "恢复备份" : "Restore Backup",
+            "cleanTitle" => zh ? "清理旧备份" : "Clean Old Backups",
+            "current" => zh ? "当前" : "current",
+            "manual" => zh ? "手动" : "manual",
+            "saved" => zh ? "已保存" : "saved",
+            _ => key
+        };
+    }
+}

--- a/desktop/CodexProviderSync.Mac/MainWindow.cs
+++ b/desktop/CodexProviderSync.Mac/MainWindow.cs
@@ -1,0 +1,907 @@
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Platform.Storage;
+using CodexProviderSync.Core;
+
+namespace CodexProviderSync.Mac;
+
+public sealed class MainWindow : Window
+{
+    private readonly CodexSyncService _syncService = new();
+    private readonly SettingsService _settingsService = new();
+
+    private readonly TextBox _codexHomeText = new();
+    private readonly ComboBox _recentHomes = new();
+    private readonly Button _browseButton = new();
+    private readonly Button _refreshButton = new();
+    private readonly TextBlock _busyText = new();
+    private readonly TextBox _statusText = new();
+    private readonly ListBox _providerList = new();
+    private readonly TextBox _manualProviderText = new();
+    private readonly Button _addProviderButton = new();
+    private readonly Button _removeProviderButton = new();
+    private readonly TextBlock _selectedProviderText = new();
+    private readonly CheckBox _switchConfigCheck = new();
+    private readonly NumericUpDown _backupRetentionInput = new();
+    private readonly Button _executeButton = new();
+    private readonly CheckBox _restoreConfigCheck = new();
+    private readonly CheckBox _restoreDatabaseCheck = new();
+    private readonly CheckBox _restoreSessionsCheck = new();
+    private readonly Button _restoreButton = new();
+    private readonly Button _openBackupButton = new();
+    private readonly Button _pruneBackupsButton = new();
+    private readonly TextBox _logText = new();
+
+    private AppSettings _settings = new();
+    private StatusSnapshot? _currentStatus;
+    private bool _loadingSettings;
+
+    public MainWindow()
+    {
+        Title = "Codex Provider Sync";
+        MinWidth = 1120;
+        MinHeight = 760;
+        Width = 1240;
+        Height = 820;
+        Background = Brush.Parse("#f5f5f7");
+
+        Content = BuildLayout();
+        WireEvents();
+    }
+
+    protected override async void OnOpened(EventArgs e)
+    {
+        base.OnOpened(e);
+        await LoadStateAsync();
+    }
+
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        PersistUiState();
+        base.OnClosing(e);
+    }
+
+    private Control BuildLayout()
+    {
+        Grid root = new()
+        {
+            RowDefinitions = new RowDefinitions("Auto,*,220"),
+            Margin = new Thickness(18),
+            RowSpacing = 14
+        };
+
+        root.Children.Add(BuildCodexHomePanel());
+        root.Children.Add(BuildMainPanel());
+        root.Children.Add(BuildLogPanel());
+        Grid.SetRow(root.Children[1], 1);
+        Grid.SetRow(root.Children[2], 2);
+        return root;
+    }
+
+    private Control BuildCodexHomePanel()
+    {
+        Grid panel = new()
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,*,180,Auto,Auto"),
+            ColumnSpacing = 10
+        };
+
+        TextBlock label = Label("Codex Home");
+        _codexHomeText.Watermark = AppConstants.DefaultCodexHome();
+        _codexHomeText.MinHeight = 34;
+        _recentHomes.MinHeight = 34;
+        _recentHomes.PlaceholderText = "Recent";
+        _browseButton.Content = "Browse";
+        _browseButton.MinHeight = 34;
+        _refreshButton.Content = "Refresh";
+        _refreshButton.MinHeight = 34;
+
+        panel.Children.Add(label);
+        panel.Children.Add(_codexHomeText);
+        panel.Children.Add(_recentHomes);
+        panel.Children.Add(_browseButton);
+        panel.Children.Add(_refreshButton);
+        Grid.SetColumn(_codexHomeText, 1);
+        Grid.SetColumn(_recentHomes, 2);
+        Grid.SetColumn(_browseButton, 3);
+        Grid.SetColumn(_refreshButton, 4);
+        return Card(panel);
+    }
+
+    private Control BuildMainPanel()
+    {
+        Grid main = new()
+        {
+            ColumnDefinitions = new ColumnDefinitions("1.15*,1*,340"),
+            ColumnSpacing = 14
+        };
+
+        main.Children.Add(BuildStatusPanel());
+        main.Children.Add(BuildProviderPanel());
+        main.Children.Add(BuildActionsPanel());
+        Grid.SetColumn(main.Children[1], 1);
+        Grid.SetColumn(main.Children[2], 2);
+        return main;
+    }
+
+    private Control BuildStatusPanel()
+    {
+        _statusText.IsReadOnly = true;
+        _statusText.AcceptsReturn = true;
+        _statusText.TextWrapping = TextWrapping.NoWrap;
+        _statusText.FontFamily = FontFamily.Parse("Menlo, Consolas, monospace");
+        _statusText.FontSize = 12;
+        _statusText.Background = Brushes.White;
+
+        return Section("Status", _statusText);
+    }
+
+    private Control BuildProviderPanel()
+    {
+        Grid panel = new()
+        {
+            RowDefinitions = new RowDefinitions("*,Auto,Auto"),
+            RowSpacing = 10
+        };
+
+        _providerList.SelectionMode = SelectionMode.Single;
+        _providerList.Background = Brushes.White;
+
+        Grid addPanel = new()
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+            ColumnSpacing = 8
+        };
+        _manualProviderText.Watermark = "Add provider id";
+        _manualProviderText.MinHeight = 34;
+        _addProviderButton.Content = "Add";
+        _addProviderButton.MinHeight = 34;
+        addPanel.Children.Add(_manualProviderText);
+        addPanel.Children.Add(_addProviderButton);
+        Grid.SetColumn(_addProviderButton, 1);
+
+        _removeProviderButton.Content = "Remove Manual";
+        _removeProviderButton.HorizontalAlignment = HorizontalAlignment.Left;
+
+        panel.Children.Add(_providerList);
+        panel.Children.Add(addPanel);
+        panel.Children.Add(_removeProviderButton);
+        Grid.SetRow(addPanel, 1);
+        Grid.SetRow(_removeProviderButton, 2);
+
+        return Section("Providers", panel);
+    }
+
+    private Control BuildActionsPanel()
+    {
+        StackPanel panel = new()
+        {
+            Spacing = 12
+        };
+
+        _selectedProviderText.Text = "No provider selected";
+        _selectedProviderText.FontSize = 18;
+        _selectedProviderText.FontWeight = FontWeight.SemiBold;
+        _selectedProviderText.TextWrapping = TextWrapping.Wrap;
+
+        _switchConfigCheck.Content = "Switch config.toml and sync";
+
+        _backupRetentionInput.Minimum = 1;
+        _backupRetentionInput.Maximum = 100000;
+        _backupRetentionInput.Value = AppConstants.DefaultBackupRetentionCount;
+        _backupRetentionInput.Width = 112;
+
+        _executeButton.Content = "Sync Metadata Only";
+        _executeButton.MinHeight = 40;
+        _executeButton.HorizontalAlignment = HorizontalAlignment.Stretch;
+
+        _restoreConfigCheck.Content = "Restore config.toml";
+        _restoreDatabaseCheck.Content = "Restore SQLite";
+        _restoreSessionsCheck.Content = "Restore rollout metadata";
+        _restoreConfigCheck.IsChecked = false;
+        _restoreDatabaseCheck.IsChecked = true;
+        _restoreSessionsCheck.IsChecked = true;
+
+        _restoreButton.Content = "Restore Backup";
+        _restoreButton.MinHeight = 38;
+        _openBackupButton.Content = "Open Backup Folder";
+        _openBackupButton.MinHeight = 38;
+        _pruneBackupsButton.Content = "Clean Old Backups";
+        _pruneBackupsButton.MinHeight = 38;
+
+        _busyText.Text = "Ready";
+        _busyText.Foreground = Brush.Parse("#166534");
+
+        panel.Children.Add(MutedLabel("Target provider"));
+        panel.Children.Add(_selectedProviderText);
+        panel.Children.Add(_switchConfigCheck);
+        panel.Children.Add(BuildRetentionPanel());
+        panel.Children.Add(WarningBlock("Close Codex CLI, Codex App, app-server, and related terminals before executing write actions."));
+        panel.Children.Add(_executeButton);
+        panel.Children.Add(Separator());
+        panel.Children.Add(MutedLabel("Restore contents"));
+        panel.Children.Add(_restoreConfigCheck);
+        panel.Children.Add(_restoreDatabaseCheck);
+        panel.Children.Add(_restoreSessionsCheck);
+        panel.Children.Add(_restoreButton);
+        panel.Children.Add(_openBackupButton);
+        panel.Children.Add(_pruneBackupsButton);
+        panel.Children.Add(_busyText);
+
+        return Section("Actions", panel);
+    }
+
+    private Control BuildRetentionPanel()
+    {
+        StackPanel panel = new()
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        panel.Children.Add(MutedLabel("Keep backups"));
+        panel.Children.Add(_backupRetentionInput);
+        return panel;
+    }
+
+    private Control BuildLogPanel()
+    {
+        _logText.IsReadOnly = true;
+        _logText.AcceptsReturn = true;
+        _logText.FontFamily = FontFamily.Parse("Menlo, Consolas, monospace");
+        _logText.FontSize = 12;
+        _logText.Background = Brushes.White;
+        return Section("Execution Log", _logText);
+    }
+
+    private void WireEvents()
+    {
+        _browseButton.Click += async (_, _) => await BrowseCodexHomeAsync();
+        _refreshButton.Click += async (_, _) => await RefreshStatusAsync();
+        _recentHomes.SelectionChanged += (_, _) =>
+        {
+            if (_recentHomes.SelectedItem is string home)
+            {
+                _codexHomeText.Text = home;
+            }
+        };
+        _addProviderButton.Click += async (_, _) => await AddManualProviderAsync();
+        _removeProviderButton.Click += async (_, _) => await RemoveManualProviderAsync();
+        _providerList.SelectionChanged += (_, _) => UpdateSelectionLabel();
+        _switchConfigCheck.PropertyChanged += (_, args) =>
+        {
+            if (args.Property.Name == nameof(CheckBox.IsChecked))
+            {
+                UpdateExecuteButtonText();
+            }
+        };
+        _backupRetentionInput.ValueChanged += async (_, _) => await PersistBackupRetentionAsync();
+        _executeButton.Click += async (_, _) => await ExecuteSyncOrSwitchAsync();
+        _restoreButton.Click += async (_, _) => await RestoreBackupAsync();
+        _openBackupButton.Click += async (_, _) => await OpenBackupFolderAsync();
+        _pruneBackupsButton.Click += async (_, _) => await PruneBackupsAsync();
+        _codexHomeText.LostFocus += async (_, _) => await PersistHomeSelectionAsync();
+        _manualProviderText.KeyDown += async (_, args) =>
+        {
+            if (args.Key == Key.Enter)
+            {
+                args.Handled = true;
+                await AddManualProviderAsync();
+            }
+        };
+    }
+
+    private async Task LoadStateAsync()
+    {
+        _loadingSettings = true;
+        _settings = await _settingsService.LoadAsync();
+        ApplyWindowBounds(_settings.WindowBounds);
+        ReloadRecentHomes();
+        _codexHomeText.Text = _settings.LastCodexHome ?? AppConstants.DefaultCodexHome();
+        _backupRetentionInput.Value = Math.Max(1, _settings.BackupRetentionCount);
+        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Loaded settings: {_settingsService.SettingsPath}");
+        _loadingSettings = false;
+        await RefreshStatusAsync();
+    }
+
+    private async Task RefreshStatusAsync()
+    {
+        string codexHome = CurrentCodexHome();
+        await RunBusyAsync("Refreshing...", () => RefreshStatusCoreAsync(codexHome));
+    }
+
+    private async Task BrowseCodexHomeAsync()
+    {
+        IStorageFolder? start = null;
+        string current = CurrentCodexHome();
+        if (Directory.Exists(current))
+        {
+            start = await StorageProvider.TryGetFolderFromPathAsync(current);
+        }
+
+        IReadOnlyList<IStorageFolder> folders = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Choose .codex folder",
+            AllowMultiple = false,
+            SuggestedStartLocation = start
+        });
+
+        if (folders.Count == 0 || folders[0].Path.LocalPath is not { Length: > 0 } selected)
+        {
+            return;
+        }
+
+        _codexHomeText.Text = selected;
+        await PersistHomeSelectionAsync();
+        await RefreshStatusAsync();
+    }
+
+    private async Task PersistHomeSelectionAsync()
+    {
+        string codexHome = CurrentCodexHome();
+        if (string.IsNullOrWhiteSpace(codexHome))
+        {
+            return;
+        }
+
+        _settings = _settingsService.RecordCodexHome(_settings, codexHome);
+        _settings = _settingsService.UpdateState(_settings, SelectedProvider(), _settings.LastBackupDirectory, CaptureWindowBounds(), CurrentBackupRetentionCount());
+        await _settingsService.SaveAsync(_settings);
+        ReloadRecentHomes();
+    }
+
+    private async Task PersistBackupRetentionAsync()
+    {
+        if (_loadingSettings)
+        {
+            return;
+        }
+
+        _settings = _settingsService.UpdateState(
+            _settings,
+            SelectedProvider(),
+            _settings.LastBackupDirectory,
+            CaptureWindowBounds(),
+            CurrentBackupRetentionCount());
+        await _settingsService.SaveAsync(_settings);
+        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Backup retention set to {CurrentBackupRetentionCount()}");
+    }
+
+    private async Task AddManualProviderAsync()
+    {
+        string provider = (_manualProviderText.Text ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            await ShowInfoAsync("Enter a provider id before adding it.");
+            return;
+        }
+
+        _settings = _settingsService.AddManualProvider(_settings, provider);
+        await _settingsService.SaveAsync(_settings);
+        _manualProviderText.Clear();
+        ReloadProviderList();
+        SelectProvider(provider);
+        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Added manual provider: {provider}");
+    }
+
+    private async Task RemoveManualProviderAsync()
+    {
+        string? provider = SelectedProvider();
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            await ShowInfoAsync("Select a provider first.");
+            return;
+        }
+
+        _settings = _settingsService.RemoveManualProvider(_settings, provider);
+        await _settingsService.SaveAsync(_settings);
+        ReloadProviderList();
+        SelectProvider(_currentStatus?.CurrentProvider.Provider);
+        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Removed manual provider: {provider}");
+    }
+
+    private async Task ExecuteSyncOrSwitchAsync()
+    {
+        string? provider = SelectedProvider();
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            await ShowInfoAsync("Select a target provider first.");
+            return;
+        }
+
+        string mode = IsSwitchMode()
+            ? "switch config.toml and sync metadata"
+            : "sync metadata only";
+
+        if (!await ConfirmAsync(
+            "Confirm Write Action",
+            $"This will {mode} for provider \"{provider}\".\n\nClose Codex CLI, Codex App, app-server, and related terminals first.\n\nA backup will be created before metadata is changed. Continue?"))
+        {
+            return;
+        }
+
+        await RunBusyAsync("Executing...", async () =>
+        {
+            string codexHome = CurrentCodexHome();
+            int backupRetentionCount = CurrentBackupRetentionCount();
+            SyncResult result = IsSwitchMode()
+                ? await Task.Run(async () => await _syncService.RunSwitchAsync(codexHome, provider, backupRetentionCount))
+                : await Task.Run(async () => await _syncService.RunSyncAsync(codexHome, provider: provider, keepCount: backupRetentionCount));
+
+            _settings = _settingsService.UpdateState(_settings, provider, result.BackupDir, CaptureWindowBounds(), backupRetentionCount);
+            await _settingsService.SaveAsync(_settings);
+            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Execution finished");
+            AppendLog(TextFormatter.FormatSyncResult(result, IsSwitchMode() ? "Switched and synced" : "Synced"));
+            AppendLog(string.Empty);
+            await RefreshStatusCoreAsync(codexHome);
+            SelectProvider(provider);
+        });
+    }
+
+    private async Task RestoreBackupAsync()
+    {
+        string backupRoot = _currentStatus?.BackupRoot ?? AppConstants.DefaultBackupRoot(CurrentCodexHome());
+        string initialBackupDir = Directory.Exists(_settings.LastBackupDirectory)
+            ? _settings.LastBackupDirectory!
+            : backupRoot;
+
+        IStorageFolder? start = Directory.Exists(initialBackupDir)
+            ? await StorageProvider.TryGetFolderFromPathAsync(initialBackupDir)
+            : null;
+
+        IReadOnlyList<IStorageFolder> folders = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Choose backup folder",
+            AllowMultiple = false,
+            SuggestedStartLocation = start
+        });
+
+        if (folders.Count == 0 || folders[0].Path.LocalPath is not { Length: > 0 } backupDir)
+        {
+            return;
+        }
+
+        bool restoreConfig = _restoreConfigCheck.IsChecked == true;
+        bool restoreDatabase = _restoreDatabaseCheck.IsChecked == true;
+        bool restoreSessions = _restoreSessionsCheck.IsChecked == true;
+        if (!restoreConfig && !restoreDatabase && !restoreSessions)
+        {
+            await ShowInfoAsync("Choose at least one restore target.");
+            return;
+        }
+
+        string restoreTargets = string.Join(", ", new[]
+        {
+            restoreConfig ? "config.toml" : null,
+            restoreDatabase ? "SQLite" : null,
+            restoreSessions ? "rollout metadata" : null
+        }.Where(static value => value is not null));
+
+        if (!await ConfirmAsync(
+            "Restore Backup",
+            $"Restore this backup?\n\n{backupDir}\n\nThis will overwrite: {restoreTargets}.\nClose Codex first. Continue?"))
+        {
+            return;
+        }
+
+        await RunBusyAsync("Restoring...", async () =>
+        {
+            string codexHome = CurrentCodexHome();
+            RestoreResult result = await Task.Run(async () => await _syncService.RunRestoreAsync(
+                codexHome,
+                backupDir,
+                new RestoreBackupOptions
+                {
+                    RestoreConfig = restoreConfig,
+                    RestoreDatabase = restoreDatabase,
+                    RestoreSessions = restoreSessions
+                }));
+            _settings = _settingsService.UpdateState(_settings, SelectedProvider(), backupDir, CaptureWindowBounds(), CurrentBackupRetentionCount());
+            await _settingsService.SaveAsync(_settings);
+            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Restore finished");
+            AppendLog(TextFormatter.FormatRestoreResult(result));
+            AppendLog(string.Empty);
+            await RefreshStatusCoreAsync(codexHome);
+        });
+    }
+
+    private async Task OpenBackupFolderAsync()
+    {
+        string path = _currentStatus?.BackupRoot ?? AppConstants.DefaultBackupRoot(CurrentCodexHome());
+        Directory.CreateDirectory(path);
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = OperatingSystem.IsMacOS() ? "open" : path,
+                Arguments = OperatingSystem.IsMacOS() ? QuoteShellArgument(path) : string.Empty,
+                UseShellExecute = !OperatingSystem.IsMacOS()
+            });
+        }
+        catch (Exception error)
+        {
+            await ShowErrorAsync(error);
+        }
+    }
+
+    private async Task PruneBackupsAsync()
+    {
+        if (!await ConfirmAsync(
+            "Clean Old Backups",
+            $"Keep only the newest {CurrentBackupRetentionCount()} managed backup(s).\n\nDeleted backup folders cannot be restored from this app. Continue?"))
+        {
+            return;
+        }
+
+        await RunBusyAsync("Cleaning backups...", async () =>
+        {
+            string codexHome = CurrentCodexHome();
+            BackupPruneResult result = await Task.Run(async () => await _syncService.RunPruneBackupsAsync(codexHome, CurrentBackupRetentionCount()));
+            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Backup cleanup finished");
+            AppendLog(TextFormatter.FormatBackupPruneResult(result));
+            AppendLog(string.Empty);
+            await RefreshStatusCoreAsync(codexHome);
+        });
+    }
+
+    private async Task RefreshStatusCoreAsync(string codexHome)
+    {
+        _currentStatus = await Task.Run(async () => await _syncService.GetStatusAsync(codexHome));
+        _settings = _settingsService.RecordCodexHome(_settings, _currentStatus.CodexHome);
+        _settings = _settingsService.MergeDetectedProviders(_settings, _syncService.ExtractDetectedProviderIds(_currentStatus));
+        _settings = _settingsService.UpdateState(_settings, SelectedProvider(), _settings.LastBackupDirectory, CaptureWindowBounds(), CurrentBackupRetentionCount());
+        await _settingsService.SaveAsync(_settings);
+
+        _statusText.Text = TextFormatter.FormatStatus(_currentStatus);
+        ReloadRecentHomes();
+        ReloadProviderList();
+        _codexHomeText.Text = _currentStatus.CodexHome;
+        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Refreshed: {_currentStatus.CodexHome}");
+    }
+
+    private void ReloadRecentHomes()
+    {
+        string? selected = _codexHomeText.Text;
+        _recentHomes.Items.Clear();
+        foreach (string home in _settings.RecentCodexHomes)
+        {
+            _recentHomes.Items.Add(home);
+        }
+
+        _codexHomeText.Text = selected;
+    }
+
+    private void ReloadProviderList()
+    {
+        _providerList.Items.Clear();
+        if (_currentStatus is not null)
+        {
+            foreach (ProviderOption option in _syncService.BuildProviderOptions(_currentStatus, _settings))
+            {
+                ProviderListItem item = new()
+                {
+                    Option = option,
+                    SourcesText = TextFormatter.FormatProviderSources(option),
+                    DetailText = ProviderDetailText(option)
+                };
+                _providerList.Items.Add(BuildProviderRow(item));
+            }
+        }
+
+        SelectProvider(_settings.LastSelectedProvider ?? _currentStatus?.CurrentProvider.Provider);
+        UpdateSelectionLabel();
+    }
+
+    private ListBoxItem BuildProviderRow(ProviderListItem provider)
+    {
+        Grid row = new()
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+            RowDefinitions = new RowDefinitions("Auto,Auto"),
+            Margin = new Thickness(8, 7)
+        };
+
+        TextBlock title = new()
+        {
+            Text = provider.Option.Id,
+            FontWeight = provider.Option.IsCurrentProvider ? FontWeight.SemiBold : FontWeight.Normal,
+            TextTrimming = TextTrimming.CharacterEllipsis
+        };
+        TextBlock sources = new()
+        {
+            Text = provider.SourcesText,
+            Foreground = Brush.Parse("#52525b"),
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap
+        };
+        TextBlock detail = new()
+        {
+            Text = provider.DetailText,
+            Foreground = Brush.Parse("#71717a"),
+            FontSize = 12
+        };
+
+        row.Children.Add(title);
+        row.Children.Add(detail);
+        row.Children.Add(sources);
+        Grid.SetColumn(detail, 1);
+        Grid.SetRow(sources, 1);
+        Grid.SetColumnSpan(sources, 2);
+
+        return new ListBoxItem
+        {
+            Tag = provider.Option.Id,
+            Content = row
+        };
+    }
+
+    private static string ProviderDetailText(ProviderOption option)
+    {
+        List<string> details = [];
+        if (option.IsCurrentProvider)
+        {
+            details.Add("current");
+        }
+        if (option.IsManual)
+        {
+            details.Add("manual");
+        }
+        if (option.IsSaved)
+        {
+            details.Add("saved");
+        }
+
+        return details.Count == 0 ? string.Empty : string.Join(" · ", details);
+    }
+
+    private void SelectProvider(string? provider)
+    {
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return;
+        }
+
+        foreach (object? item in _providerList.Items)
+        {
+            if (item is ListBoxItem row && string.Equals(row.Tag as string, provider, StringComparison.Ordinal))
+            {
+                _providerList.SelectedItem = row;
+                break;
+            }
+        }
+    }
+
+    private void UpdateSelectionLabel()
+    {
+        string? provider = SelectedProvider();
+        _selectedProviderText.Text = string.IsNullOrWhiteSpace(provider) ? "No provider selected" : provider;
+    }
+
+    private void UpdateExecuteButtonText()
+    {
+        _executeButton.Content = IsSwitchMode()
+            ? "Switch Config + Sync"
+            : "Sync Metadata Only";
+    }
+
+    private string? SelectedProvider()
+    {
+        return _providerList.SelectedItem is ListBoxItem row ? row.Tag as string : null;
+    }
+
+    private string CurrentCodexHome()
+    {
+        string text = (_codexHomeText.Text ?? string.Empty).Trim();
+        return string.IsNullOrWhiteSpace(text) ? AppConstants.DefaultCodexHome() : text;
+    }
+
+    private int CurrentBackupRetentionCount()
+    {
+        decimal value = _backupRetentionInput.Value ?? AppConstants.DefaultBackupRetentionCount;
+        return Decimal.ToInt32(Math.Max(1, value));
+    }
+
+    private bool IsSwitchMode()
+    {
+        return _switchConfigCheck.IsChecked == true;
+    }
+
+    private void PersistUiState()
+    {
+        try
+        {
+            _settings = _settingsService.RecordCodexHome(_settings, CurrentCodexHome());
+            _settings = _settingsService.UpdateState(_settings, SelectedProvider(), _settings.LastBackupDirectory, CaptureWindowBounds(), CurrentBackupRetentionCount());
+            _settingsService.Save(_settings);
+        }
+        catch
+        {
+            // Ignore shutdown persistence failures.
+        }
+    }
+
+    private WindowBoundsState CaptureWindowBounds()
+    {
+        return new WindowBoundsState
+        {
+            X = Position.X,
+            Y = Position.Y,
+            Width = Decimal.ToInt32((decimal)Math.Max(Width, MinWidth)),
+            Height = Decimal.ToInt32((decimal)Math.Max(Height, MinHeight)),
+            Maximized = WindowState == WindowState.Maximized
+        };
+    }
+
+    private void ApplyWindowBounds(WindowBoundsState? bounds)
+    {
+        if (bounds is null || bounds.Width < 800 || bounds.Height < 600)
+        {
+            return;
+        }
+
+        Position = new PixelPoint(bounds.X, bounds.Y);
+        Width = bounds.Width;
+        Height = bounds.Height;
+        if (bounds.Maximized)
+        {
+            WindowState = WindowState.Maximized;
+        }
+    }
+
+    private async Task RunBusyAsync(string stateText, Func<Task> action)
+    {
+        SetBusy(true, stateText);
+        try
+        {
+            await action();
+        }
+        catch (Exception error)
+        {
+            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Error: {error}");
+            await ShowErrorAsync(error);
+        }
+        finally
+        {
+            SetBusy(false, "Ready");
+        }
+    }
+
+    private void SetBusy(bool busy, string stateText)
+    {
+        Cursor = busy ? new Cursor(StandardCursorType.Wait) : Cursor.Default;
+        _busyText.Text = stateText;
+        _busyText.Foreground = busy ? Brush.Parse("#b45309") : Brush.Parse("#166534");
+
+        _browseButton.IsEnabled = !busy;
+        _refreshButton.IsEnabled = !busy;
+        _addProviderButton.IsEnabled = !busy;
+        _removeProviderButton.IsEnabled = !busy;
+        _switchConfigCheck.IsEnabled = !busy;
+        _backupRetentionInput.IsEnabled = !busy;
+        _restoreConfigCheck.IsEnabled = !busy;
+        _restoreDatabaseCheck.IsEnabled = !busy;
+        _restoreSessionsCheck.IsEnabled = !busy;
+        _executeButton.IsEnabled = !busy;
+        _restoreButton.IsEnabled = !busy;
+        _openBackupButton.IsEnabled = !busy;
+        _pruneBackupsButton.IsEnabled = !busy;
+        _providerList.IsEnabled = !busy;
+        _manualProviderText.IsEnabled = !busy;
+        _codexHomeText.IsEnabled = !busy;
+        _recentHomes.IsEnabled = !busy;
+    }
+
+    private void AppendLog(string message)
+    {
+        _logText.Text = string.IsNullOrEmpty(_logText.Text)
+            ? message
+            : $"{_logText.Text}{Environment.NewLine}{message}";
+        _logText.CaretIndex = _logText.Text?.Length ?? 0;
+    }
+
+    private async Task<bool> ConfirmAsync(string title, string message)
+    {
+        ConfirmationDialog dialog = new(title, message, "Continue", "Cancel");
+        return await dialog.ShowDialog<bool>(this);
+    }
+
+    private async Task ShowInfoAsync(string message)
+    {
+        ConfirmationDialog dialog = new("Codex Provider Sync", message, "OK", null);
+        await dialog.ShowDialog<bool>(this);
+    }
+
+    private async Task ShowErrorAsync(Exception error)
+    {
+        ConfirmationDialog dialog = new("Error", error.Message, "OK", null);
+        await dialog.ShowDialog<bool>(this);
+    }
+
+    private static Border Card(Control content)
+    {
+        return new Border
+        {
+            Background = Brushes.White,
+            BorderBrush = Brush.Parse("#d4d4d8"),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(12),
+            Child = content
+        };
+    }
+
+    private static Control Section(string title, Control content)
+    {
+        Grid panel = new()
+        {
+            RowDefinitions = new RowDefinitions("Auto,*"),
+            RowSpacing = 8
+        };
+        panel.Children.Add(new TextBlock
+        {
+            Text = title,
+            FontSize = 13,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = Brush.Parse("#18181b")
+        });
+        panel.Children.Add(content);
+        Grid.SetRow(content, 1);
+        return Card(panel);
+    }
+
+    private static TextBlock Label(string text)
+    {
+        return new TextBlock
+        {
+            Text = text,
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = Brush.Parse("#18181b")
+        };
+    }
+
+    private static TextBlock MutedLabel(string text)
+    {
+        return new TextBlock
+        {
+            Text = text,
+            Foreground = Brush.Parse("#52525b"),
+            FontSize = 12
+        };
+    }
+
+    private static Border WarningBlock(string text)
+    {
+        return new Border
+        {
+            Background = Brush.Parse("#fff7ed"),
+            BorderBrush = Brush.Parse("#fed7aa"),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(10),
+            Child = new TextBlock
+            {
+                Text = text,
+                Foreground = Brush.Parse("#9a3412"),
+                TextWrapping = TextWrapping.Wrap
+            }
+        };
+    }
+
+    private static Separator Separator()
+    {
+        return new Separator
+        {
+            Margin = new Thickness(0, 2)
+        };
+    }
+
+    private static string QuoteShellArgument(string value)
+    {
+        return "\"" + value.Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/desktop/CodexProviderSync.Mac/MainWindow.cs
+++ b/desktop/CodexProviderSync.Mac/MainWindow.cs
@@ -16,6 +16,8 @@ public sealed class MainWindow : Window
 
     private readonly TextBox _codexHomeText = new();
     private readonly ComboBox _recentHomes = new();
+    private readonly TextBlock _languageLabel = new();
+    private readonly ComboBox _languageCombo = new();
     private readonly Button _browseButton = new();
     private readonly Button _refreshButton = new();
     private readonly TextBlock _busyText = new();
@@ -35,10 +37,20 @@ public sealed class MainWindow : Window
     private readonly Button _openBackupButton = new();
     private readonly Button _pruneBackupsButton = new();
     private readonly TextBox _logText = new();
+    private readonly TextBlock _codexHomeLabel = new();
+    private readonly TextBlock _statusTitle = new();
+    private readonly TextBlock _providersTitle = new();
+    private readonly TextBlock _actionsTitle = new();
+    private readonly TextBlock _logTitle = new();
+    private readonly TextBlock _targetProviderLabel = new();
+    private readonly TextBlock _restoreContentsLabel = new();
+    private readonly TextBlock _keepBackupsLabel = new();
+    private readonly TextBlock _writeWarningText = new();
 
     private AppSettings _settings = new();
     private StatusSnapshot? _currentStatus;
     private bool _loadingSettings;
+    private string _language = MacUiText.English;
 
     public MainWindow()
     {
@@ -86,29 +98,38 @@ public sealed class MainWindow : Window
     {
         Grid panel = new()
         {
-            ColumnDefinitions = new ColumnDefinitions("Auto,*,180,Auto,Auto"),
+            ColumnDefinitions = new ColumnDefinitions("Auto,*,170,Auto,Auto,Auto,132"),
             ColumnSpacing = 10
         };
 
-        TextBlock label = Label("Codex Home");
-        _codexHomeText.Watermark = AppConstants.DefaultCodexHome();
+        ConfigureLabel(_codexHomeLabel, "Codex Home");
+        ConfigureLabel(_languageLabel, "Language");
+        _codexHomeText.PlaceholderText = AppConstants.DefaultCodexHome();
         _codexHomeText.MinHeight = 34;
         _recentHomes.MinHeight = 34;
         _recentHomes.PlaceholderText = "Recent";
+        _languageCombo.MinHeight = 34;
+        _languageCombo.Items.Add("English");
+        _languageCombo.Items.Add("中文");
+        _languageCombo.SelectedIndex = 0;
         _browseButton.Content = "Browse";
         _browseButton.MinHeight = 34;
         _refreshButton.Content = "Refresh";
         _refreshButton.MinHeight = 34;
 
-        panel.Children.Add(label);
+        panel.Children.Add(_codexHomeLabel);
         panel.Children.Add(_codexHomeText);
         panel.Children.Add(_recentHomes);
         panel.Children.Add(_browseButton);
         panel.Children.Add(_refreshButton);
+        panel.Children.Add(_languageLabel);
+        panel.Children.Add(_languageCombo);
         Grid.SetColumn(_codexHomeText, 1);
         Grid.SetColumn(_recentHomes, 2);
         Grid.SetColumn(_browseButton, 3);
         Grid.SetColumn(_refreshButton, 4);
+        Grid.SetColumn(_languageLabel, 5);
+        Grid.SetColumn(_languageCombo, 6);
         return Card(panel);
     }
 
@@ -137,7 +158,7 @@ public sealed class MainWindow : Window
         _statusText.FontSize = 12;
         _statusText.Background = Brushes.White;
 
-        return Section("Status", _statusText);
+        return Section(_statusTitle, _statusText);
     }
 
     private Control BuildProviderPanel()
@@ -156,7 +177,7 @@ public sealed class MainWindow : Window
             ColumnDefinitions = new ColumnDefinitions("*,Auto"),
             ColumnSpacing = 8
         };
-        _manualProviderText.Watermark = "Add provider id";
+        _manualProviderText.PlaceholderText = "Add provider id";
         _manualProviderText.MinHeight = 34;
         _addProviderButton.Content = "Add";
         _addProviderButton.MinHeight = 34;
@@ -173,7 +194,7 @@ public sealed class MainWindow : Window
         Grid.SetRow(addPanel, 1);
         Grid.SetRow(_removeProviderButton, 2);
 
-        return Section("Providers", panel);
+        return Section(_providersTitle, panel);
     }
 
     private Control BuildActionsPanel()
@@ -216,14 +237,17 @@ public sealed class MainWindow : Window
         _busyText.Text = "Ready";
         _busyText.Foreground = Brush.Parse("#166534");
 
-        panel.Children.Add(MutedLabel("Target provider"));
+        ConfigureMutedLabel(_targetProviderLabel, "Target provider");
+        ConfigureMutedLabel(_restoreContentsLabel, "Restore contents");
+
+        panel.Children.Add(_targetProviderLabel);
         panel.Children.Add(_selectedProviderText);
         panel.Children.Add(_switchConfigCheck);
         panel.Children.Add(BuildRetentionPanel());
-        panel.Children.Add(WarningBlock("Close Codex CLI, Codex App, app-server, and related terminals before executing write actions."));
+        panel.Children.Add(WarningBlock(_writeWarningText));
         panel.Children.Add(_executeButton);
         panel.Children.Add(Separator());
-        panel.Children.Add(MutedLabel("Restore contents"));
+        panel.Children.Add(_restoreContentsLabel);
         panel.Children.Add(_restoreConfigCheck);
         panel.Children.Add(_restoreDatabaseCheck);
         panel.Children.Add(_restoreSessionsCheck);
@@ -232,7 +256,7 @@ public sealed class MainWindow : Window
         panel.Children.Add(_pruneBackupsButton);
         panel.Children.Add(_busyText);
 
-        return Section("Actions", panel);
+        return Section(_actionsTitle, panel);
     }
 
     private Control BuildRetentionPanel()
@@ -243,7 +267,8 @@ public sealed class MainWindow : Window
             Spacing = 8,
             VerticalAlignment = VerticalAlignment.Center
         };
-        panel.Children.Add(MutedLabel("Keep backups"));
+        ConfigureMutedLabel(_keepBackupsLabel, "Keep backups");
+        panel.Children.Add(_keepBackupsLabel);
         panel.Children.Add(_backupRetentionInput);
         return panel;
     }
@@ -255,13 +280,14 @@ public sealed class MainWindow : Window
         _logText.FontFamily = FontFamily.Parse("Menlo, Consolas, monospace");
         _logText.FontSize = 12;
         _logText.Background = Brushes.White;
-        return Section("Execution Log", _logText);
+        return Section(_logTitle, _logText);
     }
 
     private void WireEvents()
     {
         _browseButton.Click += async (_, _) => await BrowseCodexHomeAsync();
         _refreshButton.Click += async (_, _) => await RefreshStatusAsync();
+        _languageCombo.SelectionChanged += async (_, _) => await ChangeLanguageAsync();
         _recentHomes.SelectionChanged += (_, _) =>
         {
             if (_recentHomes.SelectedItem is string home)
@@ -299,11 +325,14 @@ public sealed class MainWindow : Window
     {
         _loadingSettings = true;
         _settings = await _settingsService.LoadAsync();
+        _language = MacUiText.NormalizeLanguage(_settings.UiLanguage);
+        _languageCombo.SelectedIndex = MacUiText.IsChinese(_language) ? 1 : 0;
+        ApplyLanguage();
         ApplyWindowBounds(_settings.WindowBounds);
         ReloadRecentHomes();
         _codexHomeText.Text = _settings.LastCodexHome ?? AppConstants.DefaultCodexHome();
         _backupRetentionInput.Value = Math.Max(1, _settings.BackupRetentionCount);
-        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Loaded settings: {_settingsService.SettingsPath}");
+        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {T("loadedSettings")}: {_settingsService.SettingsPath}");
         _loadingSettings = false;
         await RefreshStatusAsync();
     }
@@ -311,7 +340,26 @@ public sealed class MainWindow : Window
     private async Task RefreshStatusAsync()
     {
         string codexHome = CurrentCodexHome();
-        await RunBusyAsync("Refreshing...", () => RefreshStatusCoreAsync(codexHome));
+        await RunBusyAsync(T("refreshing"), () => RefreshStatusCoreAsync(codexHome));
+    }
+
+    private async Task ChangeLanguageAsync()
+    {
+        if (_loadingSettings)
+        {
+            return;
+        }
+
+        _language = _languageCombo.SelectedIndex == 1 ? MacUiText.Chinese : MacUiText.English;
+        _settings = _settingsService.UpdateUiLanguage(_settings, _language);
+        await _settingsService.SaveAsync(_settings);
+        ApplyLanguage();
+        if (_currentStatus is not null)
+        {
+            _statusText.Text = MacDisplayFormatter.FormatStatus(_currentStatus, _language);
+        }
+        ReloadProviderList();
+        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {T("languageChanged")}: {(_language == MacUiText.Chinese ? "中文" : "English")}");
     }
 
     private async Task BrowseCodexHomeAsync()
@@ -325,7 +373,7 @@ public sealed class MainWindow : Window
 
         IReadOnlyList<IStorageFolder> folders = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
         {
-            Title = "Choose .codex folder",
+            Title = T("chooseCodexFolder"),
             AllowMultiple = false,
             SuggestedStartLocation = start
         });
@@ -376,7 +424,7 @@ public sealed class MainWindow : Window
         string provider = (_manualProviderText.Text ?? string.Empty).Trim();
         if (string.IsNullOrWhiteSpace(provider))
         {
-            await ShowInfoAsync("Enter a provider id before adding it.");
+            await ShowInfoAsync(T("enterProvider"));
             return;
         }
 
@@ -385,7 +433,7 @@ public sealed class MainWindow : Window
         _manualProviderText.Clear();
         ReloadProviderList();
         SelectProvider(provider);
-        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Added manual provider: {provider}");
+        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {T("addedManualProvider")}: {provider}");
     }
 
     private async Task RemoveManualProviderAsync()
@@ -393,7 +441,7 @@ public sealed class MainWindow : Window
         string? provider = SelectedProvider();
         if (string.IsNullOrWhiteSpace(provider))
         {
-            await ShowInfoAsync("Select a provider first.");
+            await ShowInfoAsync(T("selectProvider"));
             return;
         }
 
@@ -401,7 +449,7 @@ public sealed class MainWindow : Window
         await _settingsService.SaveAsync(_settings);
         ReloadProviderList();
         SelectProvider(_currentStatus?.CurrentProvider.Provider);
-        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Removed manual provider: {provider}");
+        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {T("removedManualProvider")}: {provider}");
     }
 
     private async Task ExecuteSyncOrSwitchAsync()
@@ -409,22 +457,22 @@ public sealed class MainWindow : Window
         string? provider = SelectedProvider();
         if (string.IsNullOrWhiteSpace(provider))
         {
-            await ShowInfoAsync("Select a target provider first.");
+            await ShowInfoAsync(T("selectTargetProvider"));
             return;
         }
 
         string mode = IsSwitchMode()
-            ? "switch config.toml and sync metadata"
-            : "sync metadata only";
+            ? T("confirmSwitchMode")
+            : T("confirmSyncMode");
 
         if (!await ConfirmAsync(
-            "Confirm Write Action",
-            $"This will {mode} for provider \"{provider}\".\n\nClose Codex CLI, Codex App, app-server, and related terminals first.\n\nA backup will be created before metadata is changed. Continue?"))
+            T("confirmWriteTitle"),
+            string.Format(T("confirmWriteMessage"), mode, provider)))
         {
             return;
         }
 
-        await RunBusyAsync("Executing...", async () =>
+        await RunBusyAsync(T("executing"), async () =>
         {
             string codexHome = CurrentCodexHome();
             int backupRetentionCount = CurrentBackupRetentionCount();
@@ -434,8 +482,8 @@ public sealed class MainWindow : Window
 
             _settings = _settingsService.UpdateState(_settings, provider, result.BackupDir, CaptureWindowBounds(), backupRetentionCount);
             await _settingsService.SaveAsync(_settings);
-            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Execution finished");
-            AppendLog(TextFormatter.FormatSyncResult(result, IsSwitchMode() ? "Switched and synced" : "Synced"));
+            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {T("executionFinished")}");
+            AppendLog(MacDisplayFormatter.FormatSyncResult(result, IsSwitchMode() ? T("switchedAndSynced") : T("synced"), _language));
             AppendLog(string.Empty);
             await RefreshStatusCoreAsync(codexHome);
             SelectProvider(provider);
@@ -455,7 +503,7 @@ public sealed class MainWindow : Window
 
         IReadOnlyList<IStorageFolder> folders = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
         {
-            Title = "Choose backup folder",
+            Title = T("chooseBackupFolder"),
             AllowMultiple = false,
             SuggestedStartLocation = start
         });
@@ -470,7 +518,7 @@ public sealed class MainWindow : Window
         bool restoreSessions = _restoreSessionsCheck.IsChecked == true;
         if (!restoreConfig && !restoreDatabase && !restoreSessions)
         {
-            await ShowInfoAsync("Choose at least one restore target.");
+            await ShowInfoAsync(T("chooseRestoreTarget"));
             return;
         }
 
@@ -482,13 +530,13 @@ public sealed class MainWindow : Window
         }.Where(static value => value is not null));
 
         if (!await ConfirmAsync(
-            "Restore Backup",
-            $"Restore this backup?\n\n{backupDir}\n\nThis will overwrite: {restoreTargets}.\nClose Codex first. Continue?"))
+            T("restoreTitle"),
+            string.Format(T("restoreMessage"), backupDir, restoreTargets)))
         {
             return;
         }
 
-        await RunBusyAsync("Restoring...", async () =>
+        await RunBusyAsync(T("restoring"), async () =>
         {
             string codexHome = CurrentCodexHome();
             RestoreResult result = await Task.Run(async () => await _syncService.RunRestoreAsync(
@@ -502,8 +550,8 @@ public sealed class MainWindow : Window
                 }));
             _settings = _settingsService.UpdateState(_settings, SelectedProvider(), backupDir, CaptureWindowBounds(), CurrentBackupRetentionCount());
             await _settingsService.SaveAsync(_settings);
-            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Restore finished");
-            AppendLog(TextFormatter.FormatRestoreResult(result));
+            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {T("restoreFinished")}");
+            AppendLog(MacDisplayFormatter.FormatRestoreResult(result, _language));
             AppendLog(string.Empty);
             await RefreshStatusCoreAsync(codexHome);
         });
@@ -531,18 +579,18 @@ public sealed class MainWindow : Window
     private async Task PruneBackupsAsync()
     {
         if (!await ConfirmAsync(
-            "Clean Old Backups",
-            $"Keep only the newest {CurrentBackupRetentionCount()} managed backup(s).\n\nDeleted backup folders cannot be restored from this app. Continue?"))
+            T("cleanTitle"),
+            string.Format(T("cleanMessage"), CurrentBackupRetentionCount())))
         {
             return;
         }
 
-        await RunBusyAsync("Cleaning backups...", async () =>
+        await RunBusyAsync(T("cleaning"), async () =>
         {
             string codexHome = CurrentCodexHome();
             BackupPruneResult result = await Task.Run(async () => await _syncService.RunPruneBackupsAsync(codexHome, CurrentBackupRetentionCount()));
-            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Backup cleanup finished");
-            AppendLog(TextFormatter.FormatBackupPruneResult(result));
+            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {T("backupCleanupFinished")}");
+            AppendLog(MacDisplayFormatter.FormatBackupPruneResult(result, _language));
             AppendLog(string.Empty);
             await RefreshStatusCoreAsync(codexHome);
         });
@@ -556,11 +604,11 @@ public sealed class MainWindow : Window
         _settings = _settingsService.UpdateState(_settings, SelectedProvider(), _settings.LastBackupDirectory, CaptureWindowBounds(), CurrentBackupRetentionCount());
         await _settingsService.SaveAsync(_settings);
 
-        _statusText.Text = TextFormatter.FormatStatus(_currentStatus);
+        _statusText.Text = MacDisplayFormatter.FormatStatus(_currentStatus, _language);
         ReloadRecentHomes();
         ReloadProviderList();
         _codexHomeText.Text = _currentStatus.CodexHome;
-        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Refreshed: {_currentStatus.CodexHome}");
+        AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {T("refreshed")}: {_currentStatus.CodexHome}");
     }
 
     private void ReloadRecentHomes()
@@ -585,7 +633,7 @@ public sealed class MainWindow : Window
                 ProviderListItem item = new()
                 {
                     Option = option,
-                    SourcesText = TextFormatter.FormatProviderSources(option),
+                    SourcesText = MacDisplayFormatter.FormatProviderSources(option, _language),
                     DetailText = ProviderDetailText(option)
                 };
                 _providerList.Items.Add(BuildProviderRow(item));
@@ -639,20 +687,20 @@ public sealed class MainWindow : Window
         };
     }
 
-    private static string ProviderDetailText(ProviderOption option)
+    private string ProviderDetailText(ProviderOption option)
     {
         List<string> details = [];
         if (option.IsCurrentProvider)
         {
-            details.Add("current");
+            details.Add(T("current"));
         }
         if (option.IsManual)
         {
-            details.Add("manual");
+            details.Add(T("manual"));
         }
         if (option.IsSaved)
         {
-            details.Add("saved");
+            details.Add(T("saved"));
         }
 
         return details.Count == 0 ? string.Empty : string.Join(" · ", details);
@@ -678,14 +726,14 @@ public sealed class MainWindow : Window
     private void UpdateSelectionLabel()
     {
         string? provider = SelectedProvider();
-        _selectedProviderText.Text = string.IsNullOrWhiteSpace(provider) ? "No provider selected" : provider;
+        _selectedProviderText.Text = string.IsNullOrWhiteSpace(provider) ? T("noProvider") : provider;
     }
 
     private void UpdateExecuteButtonText()
     {
         _executeButton.Content = IsSwitchMode()
-            ? "Switch Config + Sync"
-            : "Sync Metadata Only";
+            ? T("switchSync")
+            : T("syncMetadata");
     }
 
     private string? SelectedProvider()
@@ -715,6 +763,7 @@ public sealed class MainWindow : Window
         try
         {
             _settings = _settingsService.RecordCodexHome(_settings, CurrentCodexHome());
+            _settings = _settingsService.UpdateUiLanguage(_settings, _language);
             _settings = _settingsService.UpdateState(_settings, SelectedProvider(), _settings.LastBackupDirectory, CaptureWindowBounds(), CurrentBackupRetentionCount());
             _settingsService.Save(_settings);
         }
@@ -761,12 +810,12 @@ public sealed class MainWindow : Window
         }
         catch (Exception error)
         {
-            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Error: {error}");
+            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {T("error")}: {error}");
             await ShowErrorAsync(error);
         }
         finally
         {
-            SetBusy(false, "Ready");
+            SetBusy(false, T("ready"));
         }
     }
 
@@ -793,6 +842,7 @@ public sealed class MainWindow : Window
         _manualProviderText.IsEnabled = !busy;
         _codexHomeText.IsEnabled = !busy;
         _recentHomes.IsEnabled = !busy;
+        _languageCombo.IsEnabled = !busy;
     }
 
     private void AppendLog(string message)
@@ -805,20 +855,54 @@ public sealed class MainWindow : Window
 
     private async Task<bool> ConfirmAsync(string title, string message)
     {
-        ConfirmationDialog dialog = new(title, message, "Continue", "Cancel");
+        ConfirmationDialog dialog = new(title, message, T("continue"), T("cancel"));
         return await dialog.ShowDialog<bool>(this);
     }
 
     private async Task ShowInfoAsync(string message)
     {
-        ConfirmationDialog dialog = new("Codex Provider Sync", message, "OK", null);
+        ConfirmationDialog dialog = new("Codex Provider Sync", message, T("ok"), null);
         await dialog.ShowDialog<bool>(this);
     }
 
     private async Task ShowErrorAsync(Exception error)
     {
-        ConfirmationDialog dialog = new("Error", error.Message, "OK", null);
+        ConfirmationDialog dialog = new(T("error"), error.Message, T("ok"), null);
         await dialog.ShowDialog<bool>(this);
+    }
+
+    private void ApplyLanguage()
+    {
+        _languageLabel.Text = T("language");
+        _recentHomes.PlaceholderText = T("recent");
+        _browseButton.Content = T("browse");
+        _refreshButton.Content = T("refresh");
+        _statusTitle.Text = T("status");
+        _providersTitle.Text = T("providers");
+        _actionsTitle.Text = T("actions");
+        _logTitle.Text = T("executionLog");
+        _manualProviderText.PlaceholderText = T("addProvider");
+        _addProviderButton.Content = T("add");
+        _removeProviderButton.Content = T("removeManual");
+        _switchConfigCheck.Content = T("switchConfig");
+        _restoreConfigCheck.Content = T("restoreConfig");
+        _restoreDatabaseCheck.Content = T("restoreSqlite");
+        _restoreSessionsCheck.Content = T("restoreRollout");
+        _restoreButton.Content = T("restoreBackup");
+        _openBackupButton.Content = T("openBackupFolder");
+        _pruneBackupsButton.Content = T("cleanBackups");
+        _targetProviderLabel.Text = T("targetProvider");
+        _restoreContentsLabel.Text = T("restoreContents");
+        _keepBackupsLabel.Text = T("keepBackups");
+        _writeWarningText.Text = T("writeWarning");
+        _busyText.Text = T("ready");
+        UpdateExecuteButtonText();
+        UpdateSelectionLabel();
+    }
+
+    private string T(string key)
+    {
+        return MacUiText.Get(_language, key);
     }
 
     private static Border Card(Control content)
@@ -834,48 +918,46 @@ public sealed class MainWindow : Window
         };
     }
 
-    private static Control Section(string title, Control content)
+    private static Control Section(TextBlock title, Control content)
     {
         Grid panel = new()
         {
             RowDefinitions = new RowDefinitions("Auto,*"),
             RowSpacing = 8
         };
-        panel.Children.Add(new TextBlock
-        {
-            Text = title,
-            FontSize = 13,
-            FontWeight = FontWeight.SemiBold,
-            Foreground = Brush.Parse("#18181b")
-        });
+        ConfigureSectionTitle(title);
+        panel.Children.Add(title);
         panel.Children.Add(content);
         Grid.SetRow(content, 1);
         return Card(panel);
     }
 
-    private static TextBlock Label(string text)
+    private static void ConfigureLabel(TextBlock label, string text)
     {
-        return new TextBlock
-        {
-            Text = text,
-            VerticalAlignment = VerticalAlignment.Center,
-            FontWeight = FontWeight.SemiBold,
-            Foreground = Brush.Parse("#18181b")
-        };
+        label.Text = text;
+        label.VerticalAlignment = VerticalAlignment.Center;
+        label.FontWeight = FontWeight.SemiBold;
+        label.Foreground = Brush.Parse("#18181b");
     }
 
-    private static TextBlock MutedLabel(string text)
+    private static void ConfigureSectionTitle(TextBlock title)
     {
-        return new TextBlock
-        {
-            Text = text,
-            Foreground = Brush.Parse("#52525b"),
-            FontSize = 12
-        };
+        title.FontSize = 13;
+        title.FontWeight = FontWeight.SemiBold;
+        title.Foreground = Brush.Parse("#18181b");
     }
 
-    private static Border WarningBlock(string text)
+    private static void ConfigureMutedLabel(TextBlock label, string text)
     {
+        label.Text = text;
+        label.Foreground = Brush.Parse("#52525b");
+        label.FontSize = 12;
+    }
+
+    private static Border WarningBlock(TextBlock text)
+    {
+        text.Foreground = Brush.Parse("#9a3412");
+        text.TextWrapping = TextWrapping.Wrap;
         return new Border
         {
             Background = Brush.Parse("#fff7ed"),
@@ -883,12 +965,7 @@ public sealed class MainWindow : Window
             BorderThickness = new Thickness(1),
             CornerRadius = new CornerRadius(8),
             Padding = new Thickness(10),
-            Child = new TextBlock
-            {
-                Text = text,
-                Foreground = Brush.Parse("#9a3412"),
-                TextWrapping = TextWrapping.Wrap
-            }
+            Child = text
         };
     }
 

--- a/desktop/CodexProviderSync.Mac/Program.cs
+++ b/desktop/CodexProviderSync.Mac/Program.cs
@@ -1,0 +1,20 @@
+using Avalonia;
+
+namespace CodexProviderSync.Mac;
+
+internal static class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        BuildAvaloniaApp()
+            .StartWithClassicDesktopLifetime(args);
+    }
+
+    private static AppBuilder BuildAvaloniaApp()
+    {
+        return AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+    }
+}

--- a/desktop/CodexProviderSync.Mac/ProviderListItem.cs
+++ b/desktop/CodexProviderSync.Mac/ProviderListItem.cs
@@ -1,0 +1,10 @@
+using CodexProviderSync.Core;
+
+namespace CodexProviderSync.Mac;
+
+internal sealed class ProviderListItem
+{
+    public required ProviderOption Option { get; init; }
+    public required string SourcesText { get; init; }
+    public required string DetailText { get; init; }
+}

--- a/docs/README_GUI_ZH.md
+++ b/docs/README_GUI_ZH.md
@@ -6,6 +6,8 @@
 
 如果你不想装 Node、不想打开 PowerShell，也不想记命令，直接下载发布页里的 `CodexProviderSync.exe` 双击运行即可。
 
+macOS 桌面版说明见 [README_MAC_GUI_ZH.md](README_MAC_GUI_ZH.md)。
+
 ## 它能做什么
 
 - 检测当前 `.codex` 下的 root provider

--- a/docs/README_MAC_GUI_ZH.md
+++ b/docs/README_MAC_GUI_ZH.md
@@ -1,0 +1,66 @@
+# macOS GUI 使用说明
+
+`CodexProviderSync.app` 是 macOS 桌面版 GUI，使用 Avalonia 构建，复用 `desktop/CodexProviderSync.Core` 的状态、同步、切换、恢复和清理逻辑。
+
+## 构建
+
+需要 .NET 10 SDK。
+
+```bash
+./scripts/publish-gui-macos.sh
+```
+
+默认产物：
+
+```text
+artifacts/osx-arm64/CodexProviderSync.app
+```
+
+如需指定 SDK：
+
+```bash
+DOTNET=/path/to/dotnet ./scripts/publish-gui-macos.sh
+```
+
+## 功能
+
+- 选择或输入 Codex Home，默认 `~/.codex`
+- `Refresh` 查看当前 provider、rollout provider counts、SQLite provider counts、备份统计、project visibility 和 `encrypted_content` 风险提示
+- Provider 列表展示 `config`、`rollout`、`SQLite`、`manual` 来源
+- 手动添加或删除 provider
+- `Sync Metadata Only`
+- `Switch config.toml and sync`
+- `Restore Backup`，可选择恢复 `config.toml`、SQLite、rollout metadata
+- `Clean Old Backups`
+- `Open Backup Folder`
+- 执行日志和错误提示
+
+## 安全边界
+
+- App 启动和 `Refresh` 不会修改 Codex Home 下的 session、SQLite 或 `config.toml` 元数据
+- 写操作前会弹出确认
+- `sync` 和 `switch` 由 Core 先创建 backup，再修改 metadata
+- `encrypted_content` 只提示风险，不承诺修复
+- 不处理 `auth.json`
+- 不登录、不认证
+- 不修改对话内容
+- 不修改 `updated_at`
+
+## 操作建议
+
+执行 `Sync Metadata Only`、`Switch config.toml and sync`、`Restore Backup` 或 `Clean Old Backups` 前，先关闭：
+
+- Codex CLI
+- Codex App
+- app-server
+- 仍在使用相关 Codex Home 的终端任务
+
+如果看到 `state_5.sqlite is currently in use`，关闭上述进程后重试。
+
+如果日志显示跳过 locked rollout files，通常表示当前会话仍占用 rollout 文件。同步大多已完成；等会话结束后再运行一次 sync 可补齐这些文件。
+
+## 发布说明
+
+`scripts/publish-gui-macos.sh` 默认发布 `osx-arm64` self-contained `.app` bundle，并在本机可用时执行 ad-hoc `codesign`。该脚本不修改 Windows GUI 发布脚本 `scripts/publish-gui.ps1`。
+
+当前 Avalonia 11.3.x 构建可能显示 `Tmds.DBus.Protocol` 的 NuGet advisory warning。该依赖来自 Avalonia 桌面包的跨平台传递依赖；macOS 发布产物可构建运行，但发布前仍应按团队安全策略评估或升级 Avalonia。

--- a/docs/README_MAC_GUI_ZH.md
+++ b/docs/README_MAC_GUI_ZH.md
@@ -10,6 +10,12 @@
 ./scripts/publish-gui-macos.sh
 ```
 
+构建 Intel (x86_64) 版本：
+
+```bash
+./scripts/publish-gui-macos.sh --runtime osx-x64 --output artifacts/osx-x64
+```
+
 默认产物：
 
 ```text

--- a/scripts/publish-gui-macos.sh
+++ b/scripts/publish-gui-macos.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+configuration="Release"
+runtime="osx-arm64"
+output="artifacts/osx-arm64"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --configuration)
+      configuration="${2:?Missing value for --configuration}"
+      shift 2
+      ;;
+    --runtime)
+      runtime="${2:?Missing value for --runtime}"
+      shift 2
+      ;;
+    --output)
+      output="${2:?Missing value for --output}"
+      shift 2
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: scripts/publish-gui-macos.sh [--configuration Release] [--runtime osx-arm64] [--output artifacts/osx-arm64]
+
+Publishes the Avalonia macOS GUI as a self-contained app bundle.
+Set DOTNET=/path/to/dotnet to use a specific SDK.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+project="$repo_root/desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj"
+output_dir="$repo_root/$output"
+publish_dir="$output_dir/publish"
+app_dir="$output_dir/CodexProviderSync.app"
+contents_dir="$app_dir/Contents"
+macos_dir="$contents_dir/MacOS"
+resources_dir="$contents_dir/Resources"
+dotnet="${DOTNET:-dotnet}"
+
+if [[ "$runtime" != osx-* ]]; then
+  echo "Runtime must be a macOS RID such as osx-arm64 or osx-x64." >&2
+  exit 1
+fi
+
+if [[ -e "$output_dir" ]]; then
+  rm -rf "$output_dir"
+fi
+
+mkdir -p "$publish_dir" "$macos_dir" "$resources_dir"
+
+"$dotnet" publish "$project" \
+  --runtime "$runtime" \
+  -c "$configuration" \
+  --self-contained true \
+  -o "$publish_dir" \
+  /p:PublishSingleFile=true \
+  /p:IncludeNativeLibrariesForSelfExtract=true \
+  /p:EnableCompressionInSingleFile=true \
+  /p:DebugType=None \
+  /p:DebugSymbols=false \
+  /p:PublishTrimmed=false
+
+cp -R "$publish_dir"/. "$macos_dir"/
+chmod +x "$macos_dir/CodexProviderSync"
+
+cat > "$contents_dir/Info.plist" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Codex Provider Sync</string>
+  <key>CFBundleExecutable</key>
+  <string>CodexProviderSync</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.dailin521.codexprovidersync</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Codex Provider Sync</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.2.5</string>
+  <key>CFBundleVersion</key>
+  <string>0.2.5</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>12.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+EOF
+
+rm -rf "$publish_dir"
+
+if command -v codesign >/dev/null 2>&1; then
+  codesign --force --deep --sign - "$app_dir" >/dev/null
+fi
+
+echo "macOS GUI app published to $app_dir"


### PR DESCRIPTION
## 概要

基于 Avalonia 新增 macOS 桌面端 GUI，复用现有 `CodexProviderSync.Core` 核心库。

### 新增内容

- `desktop/CodexProviderSync.Mac/` — macOS Avalonia 应用，功能与 Windows 版对齐
  - Provider 列表，显示来源（config、rollout、SQLite、手动添加）
  - 仅同步元数据 / 切换 config.toml 并同步
  - 恢复备份，支持选择性恢复（config、SQLite、rollout）
  - 备份保留数量控制、清理旧备份、打开备份目录
  - 语言切换（English / 中文）
- `scripts/publish-gui-macos.sh` — 自包含 `.app` 构建脚本，支持 `osx-arm64` 和 `osx-x64`，含 ad-hoc codesign
- `docs/README_MAC_GUI_ZH.md` — macOS GUI 使用说明

### 未改动

- CLI（`src/`）、Windows GUI（`desktop/CodexProviderSync.App/`）、Core 逻辑（`desktop/CodexProviderSync.Core/`）均无变动
- 现有测试无变动

### 测试情况

- 36/38 Node.js 测试通过（2 个 CLI 子进程测试在 Node 22 下因 `node:sqlite` 需要 Node 24+ 跳过，在 Node 24+ 下全通过）
- macOS GUI 在 Apple Silicon 上手动验证通过（Sync、Switch、Restore、Refresh、备份管理）
- `osx-arm64` 和 `osx-x64` 两个架构均构建成功
- 手动使用构建完成的 `.app` 实测全部功能正常，体验非常完美