### PR TITLE
支持新版 Codex Desktop 的嵌套 SQLite 状态库

### DIFF
--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -181,6 +181,13 @@ public sealed class CoreIntegrationTests
         }
 
         Assert.True(File.Exists(Path.Combine(result.BackupDir, "db", "sqlite", "state_5.sqlite")));
+        string metadataPath = Path.Combine(result.BackupDir, "metadata.json");
+        string metadataText = await File.ReadAllTextAsync(metadataPath);
+        Assert.Contains("\"sqlite/state_5.sqlite\"", metadataText);
+        Assert.DoesNotContain("\"sqlite\\\\state_5.sqlite\"", metadataText);
+        await File.WriteAllTextAsync(
+            metadataPath,
+            metadataText.Replace("sqlite/state_5.sqlite", "sqlite\\\\state_5.sqlite", StringComparison.Ordinal));
 
         await service.RunRestoreAsync(fixture.CodexHome, result.BackupDir);
 

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -144,6 +144,97 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSync_UpdatesNestedSqliteStateUsedByNewerCodexDesktop()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"custom\"");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-nested-db.jsonl");
+        await fixture.WriteRolloutAsync(
+            sessionPath,
+            "thread-nested-db",
+            "custom",
+            @"C:\Users\me\Desktop\project-mentor");
+        string nestedDbPath = Path.Combine(fixture.CodexHome, "sqlite", "state_5.sqlite");
+        await fixture.WriteStateDbWithCwdAtPathAsync(
+            nestedDbPath,
+        [
+            ("thread-nested-db", "openai", false, @"\\?\C:\Users\me\Desktop\project-mentor")
+        ]);
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(0, result.ChangedSessionFiles);
+        Assert.Equal(1, result.SqliteProviderRowsUpdated);
+        Assert.Equal(1, result.SqliteCwdRowsUpdated);
+        Assert.Equal(2, result.SqliteRowsUpdated);
+
+        await using (SqliteConnection connection = fixture.OpenSqliteConnection(nestedDbPath))
+        {
+            await connection.OpenAsync();
+            SqliteCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT model_provider, cwd FROM threads WHERE id = 'thread-nested-db'";
+            await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+            Assert.True(await reader.ReadAsync());
+            Assert.Equal("custom", reader.GetString(0));
+            Assert.Equal(@"C:\Users\me\Desktop\project-mentor", reader.GetString(1));
+        }
+
+        Assert.True(File.Exists(Path.Combine(result.BackupDir, "db", "sqlite", "state_5.sqlite")));
+
+        await service.RunRestoreAsync(fixture.CodexHome, result.BackupDir);
+
+        await using (SqliteConnection connection = fixture.OpenSqliteConnection(nestedDbPath))
+        {
+            await connection.OpenAsync();
+            SqliteCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT model_provider, cwd FROM threads WHERE id = 'thread-nested-db'";
+            await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+            Assert.True(await reader.ReadAsync());
+            Assert.Equal("openai", reader.GetString(0));
+            Assert.Equal(@"\\?\C:\Users\me\Desktop\project-mentor", reader.GetString(1));
+        }
+    }
+
+    [Fact]
+    public async Task RunSync_UpdatesBothRootAndNestedSqliteStateFiles()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"custom\"");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-dual-db.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-dual-db", "custom");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-root", "openai", false)
+        ]);
+        string nestedDbPath = Path.Combine(fixture.CodexHome, "sqlite", "state_5.sqlite");
+        await fixture.WriteStateDbAtPathAsync(
+            nestedDbPath,
+        [
+            ("thread-nested", "openai", false)
+        ]);
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.True(result.SqlitePresent);
+        Assert.Equal(2, result.SqliteProviderRowsUpdated);
+
+        foreach (string dbPath in new[] { Path.Combine(fixture.CodexHome, "state_5.sqlite"), nestedDbPath })
+        {
+            await using SqliteConnection connection = fixture.OpenSqliteConnection(dbPath);
+            await connection.OpenAsync();
+            SqliteCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT DISTINCT model_provider FROM threads";
+            string provider = (string)(await command.ExecuteScalarAsync())!;
+            Assert.Equal("custom", provider);
+        }
+
+        Assert.True(File.Exists(Path.Combine(result.BackupDir, "db", "state_5.sqlite")));
+        Assert.True(File.Exists(Path.Combine(result.BackupDir, "db", "sqlite", "state_5.sqlite")));
+    }
+
+    [Fact]
     public async Task RunSync_NormalizesExtendedRolloutCwd_BeforeRepairingSqlite()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -126,8 +126,13 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
     {
-        string dbPath = Path.Combine(CodexHome, "state_5.sqlite");
-        await using SqliteConnection connection = OpenSqliteConnection();
+        await WriteStateDbAtPathAsync(Path.Combine(CodexHome, "state_5.sqlite"), rows);
+    }
+
+    public async Task WriteStateDbAtPathAsync(string dbPath, IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using SqliteConnection connection = OpenSqliteConnection(dbPath);
         await connection.OpenAsync();
         SqliteCommand create = connection.CreateCommand();
         create.CommandText = """
@@ -223,7 +228,13 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbWithCwdAsync(IEnumerable<(string Id, string ModelProvider, bool Archived, string Cwd)> rows)
     {
-        await using SqliteConnection connection = OpenSqliteConnection();
+        await WriteStateDbWithCwdAtPathAsync(Path.Combine(CodexHome, "state_5.sqlite"), rows);
+    }
+
+    public async Task WriteStateDbWithCwdAtPathAsync(string dbPath, IEnumerable<(string Id, string ModelProvider, bool Archived, string Cwd)> rows)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using SqliteConnection connection = OpenSqliteConnection(dbPath);
         await connection.OpenAsync();
         SqliteCommand create = connection.CreateCommand();
         create.CommandText = """
@@ -290,6 +301,11 @@ internal sealed class TestCodexHomeFixture
 
     public SqliteConnection OpenSqliteConnection()
     {
-        return new SqliteConnection($"Data Source={Path.Combine(CodexHome, "state_5.sqlite")};Mode=ReadWriteCreate;Pooling=False");
+        return OpenSqliteConnection(Path.Combine(CodexHome, "state_5.sqlite"));
+    }
+
+    public SqliteConnection OpenSqliteConnection(string dbPath)
+    {
+        return new SqliteConnection($"Data Source={dbPath};Mode=ReadWriteCreate;Pooling=False");
     }
 }

--- a/desktop/CodexProviderSync.Core/BackupService.cs
+++ b/desktop/CodexProviderSync.Core/BackupService.cs
@@ -26,12 +26,18 @@ public sealed class BackupService
         Directory.CreateDirectory(dbDir);
 
         List<string> copiedDbFiles = [];
-        foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
+        foreach (string relativePath in _sqliteStateService.StateDbRelativePathsSnapshot())
         {
-            string fileName = $"{AppConstants.DbFileBasename}{suffix}";
-            if (await CopyIfPresentAsync(Path.Combine(codexHome, fileName), Path.Combine(dbDir, fileName), overwrite: false))
+            foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
             {
-                copiedDbFiles.Add(fileName);
+                string fileName = $"{relativePath}{suffix}";
+                if (await CopyIfPresentAsync(
+                    _sqliteStateService.StateDbPathFromRelative(codexHome, fileName),
+                    Path.Combine(dbDir, fileName),
+                    overwrite: false))
+                {
+                    copiedDbFiles.Add(fileName);
+                }
             }
         }
 
@@ -139,19 +145,25 @@ public sealed class BackupService
             string dbDir = Path.Combine(normalizedBackupDir, "db");
             HashSet<string> backedUpFiles = new(metadata.DbFiles, StringComparer.Ordinal);
 
-            foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
+            foreach (string relativePath in _sqliteStateService.StateDbRelativePathsSnapshot())
             {
-                string fileName = $"{AppConstants.DbFileBasename}{suffix}";
-                string targetPath = Path.Combine(codexHome, fileName);
-                if (!backedUpFiles.Contains(fileName) && File.Exists(targetPath))
+                foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
                 {
-                    File.Delete(targetPath);
+                    string fileName = $"{relativePath}{suffix}";
+                    string targetPath = _sqliteStateService.StateDbPathFromRelative(codexHome, fileName);
+                    if (!backedUpFiles.Contains(fileName) && File.Exists(targetPath))
+                    {
+                        File.Delete(targetPath);
+                    }
                 }
             }
 
             foreach (string fileName in metadata.DbFiles)
             {
-                await CopyIfPresentAsync(Path.Combine(dbDir, fileName), Path.Combine(codexHome, fileName), overwrite: true);
+                await CopyIfPresentAsync(
+                    Path.Combine(dbDir, fileName),
+                    _sqliteStateService.StateDbPathFromRelative(codexHome, fileName),
+                    overwrite: true);
             }
         }
 

--- a/desktop/CodexProviderSync.Core/BackupService.cs
+++ b/desktop/CodexProviderSync.Core/BackupService.cs
@@ -33,10 +33,10 @@ public sealed class BackupService
                 string fileName = $"{relativePath}{suffix}";
                 if (await CopyIfPresentAsync(
                     _sqliteStateService.StateDbPathFromRelative(codexHome, fileName),
-                    Path.Combine(dbDir, fileName),
+                    _sqliteStateService.StateDbPathFromRelative(dbDir, fileName),
                     overwrite: false))
                 {
-                    copiedDbFiles.Add(fileName);
+                    copiedDbFiles.Add(_sqliteStateService.NormalizeStateDbRelativePath(fileName));
                 }
             }
         }
@@ -143,7 +143,10 @@ public sealed class BackupService
         {
             await _sqliteStateService.AssertSqliteWritableAsync(codexHome);
             string dbDir = Path.Combine(normalizedBackupDir, "db");
-            HashSet<string> backedUpFiles = new(metadata.DbFiles, StringComparer.Ordinal);
+            List<string> dbFiles = metadata.DbFiles
+                .Select(_sqliteStateService.NormalizeStateDbRelativePath)
+                .ToList();
+            HashSet<string> backedUpFiles = new(dbFiles, StringComparer.Ordinal);
 
             foreach (string relativePath in _sqliteStateService.StateDbRelativePathsSnapshot())
             {
@@ -158,10 +161,10 @@ public sealed class BackupService
                 }
             }
 
-            foreach (string fileName in metadata.DbFiles)
+            foreach (string fileName in dbFiles)
             {
                 await CopyIfPresentAsync(
-                    Path.Combine(dbDir, fileName),
+                    _sqliteStateService.StateDbPathFromRelative(dbDir, fileName),
                     _sqliteStateService.StateDbPathFromRelative(codexHome, fileName),
                     overwrite: true);
             }

--- a/desktop/CodexProviderSync.Core/GlobalStateService.cs
+++ b/desktop/CodexProviderSync.Core/GlobalStateService.cs
@@ -6,6 +6,8 @@ namespace CodexProviderSync.Core;
 
 public sealed class GlobalStateService
 {
+    private readonly SqliteStateService _sqliteStateService = new();
+
     public string StatePath(string codexHome)
     {
         return Path.Combine(codexHome, AppConstants.GlobalStateFileBasename);
@@ -18,7 +20,7 @@ public sealed class GlobalStateService
 
     public async Task<IReadOnlyList<ThreadCwdStat>> ReadThreadCwdStatsAsync(string codexHome)
     {
-        string dbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
+        string dbPath = _sqliteStateService.StateDbPath(codexHome);
         if (!File.Exists(dbPath))
         {
             return [];
@@ -191,7 +193,7 @@ public sealed class GlobalStateService
             return [];
         }
 
-        string dbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
+        string dbPath = _sqliteStateService.StateDbPath(codexHome);
         if (!File.Exists(dbPath))
         {
             return roots

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -8,7 +8,7 @@ public sealed class SqliteStateService
     private static readonly string[] StateDbRelativePaths =
     [
         AppConstants.DbFileBasename,
-        Path.Combine("sqlite", AppConstants.DbFileBasename)
+        $"sqlite/{AppConstants.DbFileBasename}"
     ];
 
     static SqliteStateService()
@@ -38,6 +38,13 @@ public sealed class SqliteStateService
             new[] { codexHome }
                 .Concat(relativePath.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries))
                 .ToArray());
+    }
+
+    public string NormalizeStateDbRelativePath(string relativePath)
+    {
+        return string.Join(
+            "/",
+            relativePath.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries));
     }
 
     private List<string> ExistingStateDbPaths(string codexHome)

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -5,6 +5,11 @@ namespace CodexProviderSync.Core;
 public sealed class SqliteStateService
 {
     private const int DefaultBusyTimeoutMs = 5000;
+    private static readonly string[] StateDbRelativePaths =
+    [
+        AppConstants.DbFileBasename,
+        Path.Combine("sqlite", AppConstants.DbFileBasename)
+    ];
 
     static SqliteStateService()
     {
@@ -13,7 +18,34 @@ public sealed class SqliteStateService
 
     public string StateDbPath(string codexHome)
     {
+        string nestedPath = StateDbPathFromRelative(codexHome, StateDbRelativePaths[1]);
+        if (File.Exists(nestedPath))
+        {
+            return nestedPath;
+        }
+
         return Path.Combine(codexHome, AppConstants.DbFileBasename);
+    }
+
+    public IReadOnlyList<string> StateDbRelativePathsSnapshot()
+    {
+        return StateDbRelativePaths.ToArray();
+    }
+
+    public string StateDbPathFromRelative(string codexHome, string relativePath)
+    {
+        return Path.Combine(
+            new[] { codexHome }
+                .Concat(relativePath.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries))
+                .ToArray());
+    }
+
+    private List<string> ExistingStateDbPaths(string codexHome)
+    {
+        return StateDbRelativePaths
+            .Select(relativePath => StateDbPathFromRelative(codexHome, relativePath))
+            .Where(File.Exists)
+            .ToList();
     }
 
     public async Task<ProviderCounts?> ReadSqliteProviderCountsAsync(string codexHome)
@@ -151,19 +183,23 @@ public sealed class SqliteStateService
 
     public async Task<bool> AssertSqliteWritableAsync(string codexHome, int? busyTimeoutMs = null)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        List<string> dbPaths = ExistingStateDbPaths(codexHome);
+        if (dbPaths.Count == 0)
         {
             return false;
         }
 
-        await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
         try
         {
-            await connection.OpenAsync();
-            await SetBusyTimeoutAsync(connection, busyTimeoutMs);
-            await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
-            await ExecuteNonQueryAsync(connection, "ROLLBACK");
+            foreach (string dbPath in dbPaths)
+            {
+                await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
+                await connection.OpenAsync();
+                await SetBusyTimeoutAsync(connection, busyTimeoutMs);
+                await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
+                await ExecuteNonQueryAsync(connection, "ROLLBACK");
+            }
+
             return true;
         }
         catch (Exception error)
@@ -182,8 +218,8 @@ public sealed class SqliteStateService
         IReadOnlyCollection<string>? userEventThreadIds = null,
         IReadOnlyDictionary<string, string>? threadCwdsById = null)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        List<string> dbPaths = ExistingStateDbPaths(codexHome);
+        if (dbPaths.Count == 0)
         {
             if (afterUpdate is not null)
             {
@@ -193,61 +229,67 @@ public sealed class SqliteStateService
             return (0, 0, 0, 0, false);
         }
 
-        await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
-        bool transactionOpen = false;
+        List<(SqliteConnection Connection, bool TransactionOpen)> openedConnections = [];
         try
         {
-            await connection.OpenAsync();
-            await SetBusyTimeoutAsync(connection, busyTimeoutMs);
-            await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
-            transactionOpen = true;
-
-            await using SqliteCommand command = connection.CreateCommand();
-            command.CommandText = """
-                UPDATE threads
-                SET model_provider = $provider
-                WHERE COALESCE(model_provider, '') <> $provider
-                """;
-            command.Parameters.AddWithValue("$provider", targetProvider);
-            int providerRowsUpdated = await command.ExecuteNonQueryAsync();
+            int providerRowsUpdated = 0;
             int userEventRowsUpdated = 0;
-            if (userEventThreadIds?.Count > 0 && await TableHasColumnAsync(connection, "threads", "has_user_event"))
-            {
-                await using SqliteCommand userEventCommand = connection.CreateCommand();
-                userEventCommand.CommandText = """
-                    UPDATE threads
-                    SET has_user_event = 1
-                    WHERE id = $id AND COALESCE(has_user_event, 0) <> 1
-                    """;
-                SqliteParameter idParameter = userEventCommand.Parameters.Add("$id", SqliteType.Text);
-                foreach (string threadId in userEventThreadIds)
-                {
-                    idParameter.Value = threadId;
-                    userEventRowsUpdated += await userEventCommand.ExecuteNonQueryAsync();
-                }
-            }
-
             int cwdRowsUpdated = 0;
-            if (threadCwdsById?.Count > 0 && await TableHasColumnAsync(connection, "threads", "cwd"))
+            foreach (string dbPath in dbPaths)
             {
-                await using SqliteCommand cwdCommand = connection.CreateCommand();
-                cwdCommand.CommandText = """
-                    UPDATE threads
-                    SET cwd = $cwd
-                    WHERE id = $id AND COALESCE(cwd, '') <> $cwd
-                    """;
-                SqliteParameter cwdIdParameter = cwdCommand.Parameters.Add("$id", SqliteType.Text);
-                SqliteParameter cwdParameter = cwdCommand.Parameters.Add("$cwd", SqliteType.Text);
-                foreach ((string threadId, string cwd) in threadCwdsById)
-                {
-                    if (string.IsNullOrWhiteSpace(threadId) || string.IsNullOrWhiteSpace(cwd))
-                    {
-                        continue;
-                    }
+                SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
+                openedConnections.Add((connection, false));
+                await connection.OpenAsync();
+                await SetBusyTimeoutAsync(connection, busyTimeoutMs);
+                await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
+                openedConnections[^1] = (connection, true);
 
-                    cwdIdParameter.Value = threadId;
-                    cwdParameter.Value = cwd;
-                    cwdRowsUpdated += await cwdCommand.ExecuteNonQueryAsync();
+                await using SqliteCommand command = connection.CreateCommand();
+                command.CommandText = """
+                    UPDATE threads
+                    SET model_provider = $provider
+                    WHERE COALESCE(model_provider, '') <> $provider
+                    """;
+                command.Parameters.AddWithValue("$provider", targetProvider);
+                providerRowsUpdated += await command.ExecuteNonQueryAsync();
+
+                if (userEventThreadIds?.Count > 0 && await TableHasColumnAsync(connection, "threads", "has_user_event"))
+                {
+                    await using SqliteCommand userEventCommand = connection.CreateCommand();
+                    userEventCommand.CommandText = """
+                        UPDATE threads
+                        SET has_user_event = 1
+                        WHERE id = $id AND COALESCE(has_user_event, 0) <> 1
+                        """;
+                    SqliteParameter idParameter = userEventCommand.Parameters.Add("$id", SqliteType.Text);
+                    foreach (string threadId in userEventThreadIds)
+                    {
+                        idParameter.Value = threadId;
+                        userEventRowsUpdated += await userEventCommand.ExecuteNonQueryAsync();
+                    }
+                }
+
+                if (threadCwdsById?.Count > 0 && await TableHasColumnAsync(connection, "threads", "cwd"))
+                {
+                    await using SqliteCommand cwdCommand = connection.CreateCommand();
+                    cwdCommand.CommandText = """
+                        UPDATE threads
+                        SET cwd = $cwd
+                        WHERE id = $id AND COALESCE(cwd, '') <> $cwd
+                        """;
+                    SqliteParameter cwdIdParameter = cwdCommand.Parameters.Add("$id", SqliteType.Text);
+                    SqliteParameter cwdParameter = cwdCommand.Parameters.Add("$cwd", SqliteType.Text);
+                    foreach ((string threadId, string cwd) in threadCwdsById)
+                    {
+                        if (string.IsNullOrWhiteSpace(threadId) || string.IsNullOrWhiteSpace(cwd))
+                        {
+                            continue;
+                        }
+
+                        cwdIdParameter.Value = threadId;
+                        cwdParameter.Value = cwd;
+                        cwdRowsUpdated += await cwdCommand.ExecuteNonQueryAsync();
+                    }
                 }
             }
 
@@ -258,14 +300,23 @@ public sealed class SqliteStateService
                 await afterUpdate((updatedRows, providerRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true));
             }
 
-            await ExecuteNonQueryAsync(connection, "COMMIT");
-            transactionOpen = false;
+            for (int index = 0; index < openedConnections.Count; index += 1)
+            {
+                await ExecuteNonQueryAsync(openedConnections[index].Connection, "COMMIT");
+                openedConnections[index] = (openedConnections[index].Connection, false);
+            }
+
             return (updatedRows, providerRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true);
         }
         catch (Exception error)
         {
-            if (transactionOpen)
+            foreach ((SqliteConnection connection, bool transactionOpen) in openedConnections)
             {
+                if (!transactionOpen)
+                {
+                    continue;
+                }
+
                 try
                 {
                     await ExecuteNonQueryAsync(connection, "ROLLBACK");
@@ -279,6 +330,13 @@ public sealed class SqliteStateService
             throw WrapSqliteMalformedError(
                 WrapSqliteBusyError(error, "update session provider metadata"),
                 "update session provider metadata");
+        }
+        finally
+        {
+            foreach ((SqliteConnection connection, _) in openedConnections)
+            {
+                await connection.DisposeAsync();
+            }
         }
     }
 

--- a/src/backup.js
+++ b/src/backup.js
@@ -9,7 +9,12 @@ import {
   GLOBAL_STATE_FILE_BASENAME
 } from "./constants.js";
 import { assertSessionFilesWritable, restoreSessionChanges } from "./session-files.js";
-import { assertSqliteWritable, stateDbPathFromRelative, stateDbRelativePaths } from "./sqlite-state.js";
+import {
+  assertSqliteWritable,
+  normalizeStateDbRelativePath,
+  stateDbPathFromRelative,
+  stateDbRelativePaths
+} from "./sqlite-state.js";
 
 function timestampSlug(date = new Date()) {
   return date.toISOString().replaceAll(":", "").replaceAll("-", "").replace(".", "");
@@ -59,10 +64,10 @@ export async function createBackup({
     for (const suffix of ["", "-shm", "-wal"]) {
       const fileName = `${relativePath}${suffix}`;
       const sourcePath = stateDbPathFromRelative(codexHome, fileName);
-      const destinationPath = path.join(dbDir, ...fileName.split("/"));
+      const destinationPath = stateDbPathFromRelative(dbDir, fileName);
       const copied = await copyIfPresent(sourcePath, destinationPath);
       if (copied) {
-        copiedDbFiles.push(fileName);
+        copiedDbFiles.push(normalizeStateDbRelativePath(fileName));
       }
     }
   }
@@ -197,7 +202,7 @@ export async function restoreBackup(backupDir, codexHome, options = {}) {
     await assertSqliteWritable(codexHome);
 
     const dbDir = path.join(backupDir, "db");
-    const backedUpFiles = new Set(metadata.dbFiles ?? []);
+    const backedUpFiles = new Set((metadata.dbFiles ?? []).map(normalizeStateDbRelativePath));
     for (const relativePath of stateDbRelativePaths()) {
       for (const suffix of ["", "-shm", "-wal"]) {
         const fileName = `${relativePath}${suffix}`;
@@ -206,9 +211,10 @@ export async function restoreBackup(backupDir, codexHome, options = {}) {
         }
       }
     }
-    for (const fileName of metadata.dbFiles ?? []) {
+    for (const rawFileName of metadata.dbFiles ?? []) {
+      const fileName = normalizeStateDbRelativePath(rawFileName);
       await copyIfPresent(
-        path.join(dbDir, ...fileName.split("/")),
+        stateDbPathFromRelative(dbDir, fileName),
         stateDbPathFromRelative(codexHome, fileName)
       );
     }

--- a/src/backup.js
+++ b/src/backup.js
@@ -3,14 +3,13 @@ import path from "node:path";
 
 import {
   BACKUP_NAMESPACE,
-  DB_FILE_BASENAME,
   DEFAULT_BACKUP_RETENTION_COUNT,
   defaultBackupRoot,
   GLOBAL_STATE_BACKUP_FILE_BASENAME,
   GLOBAL_STATE_FILE_BASENAME
 } from "./constants.js";
 import { assertSessionFilesWritable, restoreSessionChanges } from "./session-files.js";
-import { assertSqliteWritable } from "./sqlite-state.js";
+import { assertSqliteWritable, stateDbPathFromRelative, stateDbRelativePaths } from "./sqlite-state.js";
 
 function timestampSlug(date = new Date()) {
   return date.toISOString().replaceAll(":", "").replaceAll("-", "").replace(".", "");
@@ -22,6 +21,7 @@ async function copyIfPresent(sourcePath, destinationPath) {
   } catch {
     return false;
   }
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
   await fs.copyFile(sourcePath, destinationPath);
   return true;
 }
@@ -55,11 +55,15 @@ export async function createBackup({
   await fs.mkdir(dbDir, { recursive: true });
 
   const copiedDbFiles = [];
-  for (const suffix of ["", "-shm", "-wal"]) {
-    const fileName = `${DB_FILE_BASENAME}${suffix}`;
-    const copied = await copyIfPresent(path.join(codexHome, fileName), path.join(dbDir, fileName));
-    if (copied) {
-      copiedDbFiles.push(fileName);
+  for (const relativePath of stateDbRelativePaths()) {
+    for (const suffix of ["", "-shm", "-wal"]) {
+      const fileName = `${relativePath}${suffix}`;
+      const sourcePath = stateDbPathFromRelative(codexHome, fileName);
+      const destinationPath = path.join(dbDir, ...fileName.split("/"));
+      const copied = await copyIfPresent(sourcePath, destinationPath);
+      if (copied) {
+        copiedDbFiles.push(fileName);
+      }
     }
   }
 
@@ -194,14 +198,19 @@ export async function restoreBackup(backupDir, codexHome, options = {}) {
 
     const dbDir = path.join(backupDir, "db");
     const backedUpFiles = new Set(metadata.dbFiles ?? []);
-    for (const suffix of ["", "-shm", "-wal"]) {
-      const fileName = `${DB_FILE_BASENAME}${suffix}`;
-      if (!backedUpFiles.has(fileName)) {
-        await removeIfPresent(path.join(codexHome, fileName));
+    for (const relativePath of stateDbRelativePaths()) {
+      for (const suffix of ["", "-shm", "-wal"]) {
+        const fileName = `${relativePath}${suffix}`;
+        if (!backedUpFiles.has(fileName)) {
+          await removeIfPresent(stateDbPathFromRelative(codexHome, fileName));
+        }
       }
     }
     for (const fileName of metadata.dbFiles ?? []) {
-      await copyIfPresent(path.join(dbDir, fileName), path.join(codexHome, fileName));
+      await copyIfPresent(
+        path.join(dbDir, ...fileName.split("/")),
+        stateDbPathFromRelative(codexHome, fileName)
+      );
     }
   }
 

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -5,9 +6,39 @@ import { DatabaseSync } from "node:sqlite";
 import { DB_FILE_BASENAME } from "./constants.js";
 
 const DEFAULT_BUSY_TIMEOUT_MS = 5000;
+const STATE_DB_RELATIVE_PATHS = [
+  DB_FILE_BASENAME,
+  path.posix.join("sqlite", DB_FILE_BASENAME)
+];
 
 export function stateDbPath(codexHome) {
+  const nestedPath = stateDbPathFromRelative(codexHome, STATE_DB_RELATIVE_PATHS[1]);
+  if (fsSync.existsSync(nestedPath)) {
+    return nestedPath;
+  }
   return path.join(codexHome, DB_FILE_BASENAME);
+}
+
+export function stateDbPathFromRelative(codexHome, relativePath) {
+  return path.join(codexHome, ...relativePath.split("/"));
+}
+
+export function stateDbRelativePaths() {
+  return [...STATE_DB_RELATIVE_PATHS];
+}
+
+async function existingStateDbPaths(codexHome) {
+  const paths = [];
+  for (const relativePath of STATE_DB_RELATIVE_PATHS) {
+    const dbPath = stateDbPathFromRelative(codexHome, relativePath);
+    try {
+      await fs.access(dbPath);
+      paths.push(dbPath);
+    } catch {
+      // Missing SQLite state files are expected across Codex versions.
+    }
+  }
+  return paths;
 }
 
 function openDatabase(dbPath) {
@@ -168,19 +199,20 @@ export async function readSqliteRepairStats(codexHome, options = {}) {
 }
 
 export async function assertSqliteWritable(codexHome, options = {}) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPaths = await existingStateDbPaths(codexHome);
+  if (dbPaths.length === 0) {
     return { databasePresent: false };
   }
 
-  let db;
+  const openedDbs = [];
   try {
-    db = openDatabase(dbPath);
-    setBusyTimeout(db, options.busyTimeoutMs);
-    db.exec("BEGIN IMMEDIATE");
-    db.exec("ROLLBACK");
+    for (const dbPath of dbPaths) {
+      const db = openDatabase(dbPath);
+      openedDbs.push(db);
+      setBusyTimeout(db, options.busyTimeoutMs);
+      db.exec("BEGIN IMMEDIATE");
+      db.exec("ROLLBACK");
+    }
     return { databasePresent: true };
   } catch (error) {
     throw wrapSqliteMalformedError(
@@ -188,7 +220,9 @@ export async function assertSqliteWritable(codexHome, options = {}) {
       "update session provider metadata"
     );
   } finally {
-    db?.close();
+    for (const db of openedDbs) {
+      db.close();
+    }
   }
 }
 
@@ -198,10 +232,8 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
     ? (maybeOptions ?? {})
     : (afterUpdateOrOptions ?? {});
 
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPaths = await existingStateDbPaths(codexHome);
+  if (dbPaths.length === 0) {
     if (afterUpdate) {
       await afterUpdate({
         updatedRows: 0,
@@ -220,67 +252,82 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
     };
   }
 
-  let db;
-  let transactionOpen = false;
+  const openedDbs = [];
   try {
-    db = openDatabase(dbPath);
-    setBusyTimeout(db, options.busyTimeoutMs);
-    db.exec("BEGIN IMMEDIATE");
-    transactionOpen = true;
-    const stmt = db.prepare(`
-      UPDATE threads
-      SET model_provider = ?
-      WHERE COALESCE(model_provider, '') <> ?
-    `);
-    const result = stmt.run(targetProvider, targetProvider);
+    let providerUpdatedRows = 0;
     let userEventUpdatedRows = 0;
-    if (tableHasColumn(db, "threads", "has_user_event") && options.userEventThreadIds?.size) {
-      const userEventStmt = db.prepare(`
-        UPDATE threads
-        SET has_user_event = 1
-        WHERE id = ? AND COALESCE(has_user_event, 0) <> 1
-      `);
-      for (const threadId of options.userEventThreadIds) {
-        userEventUpdatedRows += userEventStmt.run(threadId).changes ?? 0;
-      }
-    }
     let cwdUpdatedRows = 0;
-    if (tableHasColumn(db, "threads", "cwd") && options.threadCwdById?.size) {
-      const cwdStmt = db.prepare(`
+
+    for (const dbPath of dbPaths) {
+      const db = openDatabase(dbPath);
+      openedDbs.push({ db, transactionOpen: false });
+      setBusyTimeout(db, options.busyTimeoutMs);
+      db.exec("BEGIN IMMEDIATE");
+      openedDbs.at(-1).transactionOpen = true;
+
+      const stmt = db.prepare(`
         UPDATE threads
-        SET cwd = ?
-        WHERE id = ? AND COALESCE(cwd, '') <> ?
+        SET model_provider = ?
+        WHERE COALESCE(model_provider, '') <> ?
       `);
-      for (const [threadId, cwd] of options.threadCwdById) {
-        if (typeof threadId !== "string" || !threadId || typeof cwd !== "string" || !cwd.trim()) {
-          continue;
+      const result = stmt.run(targetProvider, targetProvider);
+      providerUpdatedRows += result.changes ?? 0;
+
+      if (tableHasColumn(db, "threads", "has_user_event") && options.userEventThreadIds?.size) {
+        const userEventStmt = db.prepare(`
+          UPDATE threads
+          SET has_user_event = 1
+          WHERE id = ? AND COALESCE(has_user_event, 0) <> 1
+        `);
+        for (const threadId of options.userEventThreadIds) {
+          userEventUpdatedRows += userEventStmt.run(threadId).changes ?? 0;
         }
-        cwdUpdatedRows += cwdStmt.run(cwd, threadId, cwd).changes ?? 0;
+      }
+
+      if (tableHasColumn(db, "threads", "cwd") && options.threadCwdById?.size) {
+        const cwdStmt = db.prepare(`
+          UPDATE threads
+          SET cwd = ?
+          WHERE id = ? AND COALESCE(cwd, '') <> ?
+        `);
+        for (const [threadId, cwd] of options.threadCwdById) {
+          if (typeof threadId !== "string" || !threadId || typeof cwd !== "string" || !cwd.trim()) {
+            continue;
+          }
+          cwdUpdatedRows += cwdStmt.run(cwd, threadId, cwd).changes ?? 0;
+        }
       }
     }
-    const updatedRows = (result.changes ?? 0) + userEventUpdatedRows + cwdUpdatedRows;
+
+    const updatedRows = providerUpdatedRows + userEventUpdatedRows + cwdUpdatedRows;
     if (afterUpdate) {
       await afterUpdate({
         updatedRows,
-        providerRowsUpdated: result.changes ?? 0,
+        providerRowsUpdated: providerUpdatedRows,
         userEventRowsUpdated: userEventUpdatedRows,
         cwdRowsUpdated: cwdUpdatedRows,
         databasePresent: true
       });
     }
-    db.exec("COMMIT");
-    transactionOpen = false;
+
+    for (const entry of openedDbs) {
+      entry.db.exec("COMMIT");
+      entry.transactionOpen = false;
+    }
     return {
       updatedRows,
-      providerRowsUpdated: result.changes ?? 0,
+      providerRowsUpdated: providerUpdatedRows,
       userEventRowsUpdated: userEventUpdatedRows,
       cwdRowsUpdated: cwdUpdatedRows,
       databasePresent: true
     };
   } catch (error) {
-    if (transactionOpen) {
+    for (const entry of openedDbs) {
+      if (!entry.transactionOpen) {
+        continue;
+      }
       try {
-        db.exec("ROLLBACK");
+        entry.db.exec("ROLLBACK");
       } catch {
         // Ignore rollback failures and surface the original error.
       }
@@ -290,6 +337,8 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
       "update session provider metadata"
     );
   } finally {
-    db?.close();
+    for (const entry of openedDbs) {
+      entry.db.close();
+    }
   }
 }

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -20,11 +20,19 @@ export function stateDbPath(codexHome) {
 }
 
 export function stateDbPathFromRelative(codexHome, relativePath) {
-  return path.join(codexHome, ...relativePath.split("/"));
+  return path.join(codexHome, ...stateDbRelativePathSegments(relativePath));
+}
+
+export function normalizeStateDbRelativePath(relativePath) {
+  return stateDbRelativePathSegments(relativePath).join("/");
 }
 
 export function stateDbRelativePaths() {
   return [...STATE_DB_RELATIVE_PATHS];
+}
+
+function stateDbRelativePathSegments(relativePath) {
+  return `${relativePath}`.split(/[\\/]+/).filter(Boolean);
 }
 
 async function existingStateDbPaths(codexHome) {
@@ -260,10 +268,11 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
 
     for (const dbPath of dbPaths) {
       const db = openDatabase(dbPath);
-      openedDbs.push({ db, transactionOpen: false });
+      const entry = { db, transactionOpen: false };
+      openedDbs.push(entry);
       setBusyTimeout(db, options.busyTimeoutMs);
       db.exec("BEGIN IMMEDIATE");
-      openedDbs.at(-1).transactionOpen = true;
+      entry.transactionOpen = true;
 
       const stmt = db.prepare(`
         UPDATE threads

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -95,7 +95,11 @@ async function writeGlobalState(codexHome, value) {
 }
 
 async function writeStateDb(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+  await writeStateDbAtPath(path.join(codexHome, "state_5.sqlite"), rows);
+}
+
+async function writeStateDbAtPath(dbPath, rows) {
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -399,6 +403,101 @@ test("runSync repairs SQLite cwd from rollout session metadata", async () => {
   } finally {
     db.close();
   }
+});
+
+test("runSync updates nested sqlite state used by newer Codex Desktop", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "custom"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-nested-db.jsonl");
+  await writeCustomRollout(sessionPath, {
+    id: "thread-nested-db",
+    timestamp: "2026-03-19T00:00:00.000Z",
+    cwd: "C:\\Users\\me\\Desktop\\project-mentor",
+    source: "vscode",
+    cli_version: "0.115.0",
+    model_provider: "custom"
+  });
+  const nestedDbPath = path.join(codexHome, "sqlite", "state_5.sqlite");
+  await writeStateDbAtPath(nestedDbPath, [
+    {
+      id: "thread-nested-db",
+      model_provider: "openai",
+      archived: false,
+      cwd: "\\\\?\\C:\\Users\\me\\Desktop\\project-mentor"
+    }
+  ]);
+
+  const syncResult = await runSync({ codexHome });
+
+  assert.equal(syncResult.changedSessionFiles, 0);
+  assert.equal(syncResult.sqliteProviderRowsUpdated, 1);
+  assert.equal(syncResult.sqliteCwdRowsUpdated, 1);
+  assert.equal(syncResult.sqliteRowsUpdated, 2);
+
+  const db = new DatabaseSync(nestedDbPath);
+  try {
+    const row = db
+      .prepare("SELECT model_provider, cwd FROM threads WHERE id = ?")
+      .get("thread-nested-db");
+    assert.deepEqual({ ...row }, {
+      model_provider: "custom",
+      cwd: "C:\\Users\\me\\Desktop\\project-mentor"
+    });
+  } finally {
+    db.close();
+  }
+
+  await fs.access(path.join(syncResult.backupDir, "db", "sqlite", "state_5.sqlite"));
+
+  await runRestore({ codexHome, backupDir: syncResult.backupDir });
+
+  const restoredDb = new DatabaseSync(nestedDbPath);
+  try {
+    const row = restoredDb
+      .prepare("SELECT model_provider, cwd FROM threads WHERE id = ?")
+      .get("thread-nested-db");
+    assert.deepEqual({ ...row }, {
+      model_provider: "openai",
+      cwd: "\\\\?\\C:\\Users\\me\\Desktop\\project-mentor"
+    });
+  } finally {
+    restoredDb.close();
+  }
+});
+
+test("runSync updates both root and nested sqlite state files when both exist", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "custom"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-dual-db.jsonl");
+  await writeRollout(sessionPath, "thread-dual-db", "custom");
+  await writeStateDb(codexHome, [
+    { id: "thread-root", model_provider: "openai", archived: false }
+  ]);
+  const nestedDbPath = path.join(codexHome, "sqlite", "state_5.sqlite");
+  await writeStateDbAtPath(nestedDbPath, [
+    { id: "thread-nested", model_provider: "openai", archived: false }
+  ]);
+
+  const syncResult = await runSync({ codexHome });
+
+  assert.equal(syncResult.sqliteProviderRowsUpdated, 2);
+  assert.equal(syncResult.sqlitePresent, true);
+
+  for (const dbPath of [path.join(codexHome, "state_5.sqlite"), nestedDbPath]) {
+    const db = new DatabaseSync(dbPath);
+    try {
+      const providers = db
+        .prepare("SELECT DISTINCT model_provider FROM threads")
+        .all()
+        .map((row) => row.model_provider);
+      assert.deepEqual(providers, ["custom"]);
+    } finally {
+      db.close();
+    }
+  }
+
+  await fs.access(path.join(syncResult.backupDir, "db", "state_5.sqlite"));
+  await fs.access(path.join(syncResult.backupDir, "db", "sqlite", "state_5.sqlite"));
 });
 
 test("runSync normalizes extended rollout cwd before repairing SQLite", async () => {

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -448,6 +448,14 @@ test("runSync updates nested sqlite state used by newer Codex Desktop", async ()
   }
 
   await fs.access(path.join(syncResult.backupDir, "db", "sqlite", "state_5.sqlite"));
+  const metadataPath = path.join(syncResult.backupDir, "metadata.json");
+  const metadata = JSON.parse(await fs.readFile(metadataPath, "utf8"));
+  assert.ok(metadata.dbFiles.includes("sqlite/state_5.sqlite"));
+  assert.equal(metadata.dbFiles.some((fileName) => fileName.includes("\\")), false);
+  metadata.dbFiles = metadata.dbFiles.map((fileName) =>
+    fileName.replace("sqlite/state_5.sqlite", "sqlite\\state_5.sqlite")
+  );
+  await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2), "utf8");
 
   await runRestore({ codexHome, backupDir: syncResult.backupDir });
 


### PR DESCRIPTION
## 背景

我们在一次真实的 Windows 会话恢复中遇到一个问题：`~/.codex/sessions` 已经恢复，旧位置 `~/.codex/state_5.sqlite` 也看起来正常，但 Codex Desktop 仍然显示项目下没有会话。

进一步排查后发现，新版 Codex Desktop 实际读取的是 `~/.codex/sqlite/state_5.sqlite`。当前工具只检查和更新根目录的 `state_5.sqlite`，因此状态输出会误报健康，而 Desktop 使用的数据库里仍保留旧的 `model_provider = openai` 以及部分带 `\\?\` 前缀的 Windows `cwd`。

## 修改内容

- 同时识别 `state_5.sqlite` 和 `sqlite/state_5.sqlite` 两个状态库位置。
- 只读状态和项目可见性诊断优先读取嵌套状态库，贴近新版 Codex Desktop 的行为。
- 同步时更新所有已存在的状态库，避免旧版和新版状态存储不一致。
- 备份和恢复同时覆盖根目录与嵌套 SQLite 文件，包括 `-wal` 和 `-shm`。
- Node CLI 和桌面 Core 服务保持相同行为，并补充嵌套状态库回归测试。

## 验证

- `npm test`：40 个测试通过。
- `dotnet test desktop\CodexProviderSync.Core.Tests\CodexProviderSync.Core.Tests.csproj`：34 个测试通过。