### PR TITLE
Fix two-account provider sync and sqlite path handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,17 @@ Use `codex-provider switch <provider-id>` when:
 - the user wants to change the root `model_provider`
 - the user wants one command to both switch provider and resync history
 
+Use the dedicated two-account commands when the user only has the official OpenAI
+account and one relay account:
+
+- `codex-provider use-official` switches to the built-in official provider
+  `openai` and syncs history metadata to it.
+- `codex-provider use-relay` switches to the relay provider `OpenAI`, first
+  verifying that `[model_providers.OpenAI]` exists and contains `base_url`, then
+  syncs history metadata to it.
+- Prefer these commands over `switch openai` / `switch OpenAI` for this two-account
+  workflow to avoid confusing the case-sensitive provider IDs.
+
 Use `codex-provider restore <backup-dir>` when:
 
 - the user wants to roll back a previous sync
@@ -125,6 +136,8 @@ codex-provider status
 codex-provider sync
 codex-provider sync --keep 5
 codex-provider sync --provider openai
+codex-provider use-official
+codex-provider use-relay
 codex-provider switch apigather
 codex-provider prune-backups --keep 5
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\20260319T042708906Z

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ CLI 需要 Node.js `24+`。如果使用 Node 20/22，可能会看到 `node:sqlit
 codex-provider status
 codex-provider sync
 codex-provider sync --provider openai
+codex-provider use-official
+codex-provider use-relay
 codex-provider switch apigather
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\<timestamp>
 codex-provider prune-backups --keep 5
@@ -59,6 +61,8 @@ codex-provider prune-backups --keep 5
 
 - `status`：只检查当前 provider、rollout、SQLite、项目可见性诊断。
 - `sync`：不切换登录状态，只把历史会话 metadata 同步到当前 provider。
+- `use-official`：切到官方 provider `openai`，并同步历史会话 metadata。
+- `use-relay`：切到中转 provider `OpenAI`，要求 `[model_providers.OpenAI]` 存在且包含 `base_url`，然后同步历史会话 metadata。
 - `switch <provider-id>`：修改 `config.toml` 根级 `model_provider`，然后执行同步。
 - `restore <backup-dir>`：从备份恢复，支持 `--no-config`、`--no-db`、`--no-sessions`。
 - `prune-backups --keep <n>`：只清理本工具创建的旧备份。

--- a/desktop/CodexProviderSync.App/CodexProviderSync.App.csproj
+++ b/desktop/CodexProviderSync.App/CodexProviderSync.App.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/desktop/CodexProviderSync.App/MainForm.cs
+++ b/desktop/CodexProviderSync.App/MainForm.cs
@@ -43,6 +43,8 @@ public sealed class MainForm : Form
         AutoSize = true,
         Margin = new Padding(0, 4, 8, 0)
     };
+    private readonly Button _useOfficialButton = new() { Text = "Use Official", Dock = DockStyle.Fill, Height = 36 };
+    private readonly Button _useRelayButton = new() { Text = "Use Relay", Dock = DockStyle.Fill, Height = 36 };
     private readonly CheckBox _restoreConfigCheck = new() { Text = "恢复配置文件（config.toml）", Checked = false, AutoSize = true };
     private readonly CheckBox _restoreDatabaseCheck = new() { Text = "恢复线程数据库（SQLite）", Checked = true, AutoSize = true };
     private readonly CheckBox _restoreSessionsCheck = new() { Text = "恢复会话文件元数据（rollout）", Checked = true, AutoSize = true };
@@ -265,9 +267,10 @@ public sealed class MainForm : Form
         {
             Dock = DockStyle.Fill,
             ColumnCount = 1,
-            RowCount = 11,
+            RowCount = 12,
             Padding = new Padding(12)
         };
+        panel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         panel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         panel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         panel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
@@ -283,14 +286,15 @@ public sealed class MainForm : Form
         panel.Controls.Add(new Label { Text = "目标 Provider", AutoSize = true }, 0, 0);
         panel.Controls.Add(_selectedProviderValue, 0, 1);
         panel.Controls.Add(BuildUpdateConfigPanel(), 0, 2);
-        panel.Controls.Add(BuildWarningPanel(), 0, 3);
-        panel.Controls.Add(BuildBackupRetentionPanel(), 0, 4);
-        panel.Controls.Add(_executeButton, 0, 5);
-        panel.Controls.Add(BuildRestoreOptionsPanel(), 0, 6);
-        panel.Controls.Add(_restoreButton, 0, 7);
-        panel.Controls.Add(_openBackupButton, 0, 8);
-        panel.Controls.Add(_pruneBackupsButton, 0, 9);
-        panel.Controls.Add(_busyLabel, 0, 10);
+        panel.Controls.Add(BuildQuickSwitchPanel(), 0, 3);
+        panel.Controls.Add(BuildWarningPanel(), 0, 4);
+        panel.Controls.Add(BuildBackupRetentionPanel(), 0, 5);
+        panel.Controls.Add(_executeButton, 0, 6);
+        panel.Controls.Add(BuildRestoreOptionsPanel(), 0, 7);
+        panel.Controls.Add(_restoreButton, 0, 8);
+        panel.Controls.Add(_openBackupButton, 0, 9);
+        panel.Controls.Add(_pruneBackupsButton, 0, 10);
+        panel.Controls.Add(_busyLabel, 0, 11);
 
         group.Controls.Add(panel);
         return group;
@@ -308,6 +312,21 @@ public sealed class MainForm : Form
         panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
         panel.Controls.Add(_updateConfigCheck, 0, 0);
         panel.Controls.Add(_updateConfigLabel, 1, 0);
+        return panel;
+    }
+
+    private Control BuildQuickSwitchPanel()
+    {
+        TableLayoutPanel panel = new()
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 2,
+            Margin = new Padding(0, 2, 0, 8)
+        };
+        panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+        panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+        panel.Controls.Add(_useOfficialButton, 0, 0);
+        panel.Controls.Add(_useRelayButton, 1, 0);
         return panel;
     }
 
@@ -414,6 +433,8 @@ public sealed class MainForm : Form
         _removeProviderButton.Click += async (_, _) => await RemoveManualProviderAsync();
         _backupRetentionInput.ValueChanged += async (_, _) => await PersistBackupRetentionAsync();
         _executeButton.Click += async (_, _) => await ExecuteSyncOrSwitchAsync();
+        _useOfficialButton.Click += async (_, _) => await UseOfficialAsync();
+        _useRelayButton.Click += async (_, _) => await UseRelayAsync();
         _restoreButton.Click += async (_, _) => await RestoreBackupAsync();
         _openBackupButton.Click += (_, _) => OpenBackupFolder();
         _pruneBackupsButton.Click += async (_, _) => await PruneBackupsAsync();
@@ -553,6 +574,38 @@ public sealed class MainForm : Form
             AppendLog(string.Empty);
             await RefreshStatusCoreAsync(codexHome);
             SelectProvider(provider);
+        });
+    }
+
+    private async Task UseOfficialAsync()
+    {
+        await RunQuickSwitchAsync("official OpenAI", () => _syncService.RunUseOfficialAsync(CurrentCodexHome(), CurrentBackupRetentionCount()));
+    }
+
+    private async Task UseRelayAsync()
+    {
+        await RunQuickSwitchAsync("relay OpenAI", () => _syncService.RunUseRelayAsync(CurrentCodexHome(), CurrentBackupRetentionCount()));
+    }
+
+    private async Task RunQuickSwitchAsync(string label, Func<Task<SyncResult>> action)
+    {
+        if (!ConfirmCodexClosed("Close Codex CLI, Codex App, app-server, and related terminals before switching. Continue?"))
+        {
+            return;
+        }
+
+        await RunBusyAsync($"Switching to {label}...", async () =>
+        {
+            string codexHome = CurrentCodexHome();
+            int backupRetentionCount = CurrentBackupRetentionCount();
+            SyncResult result = await Task.Run(action);
+            _settings = _settingsService.UpdateState(_settings, result.TargetProvider, result.BackupDir, CaptureWindowBounds(), backupRetentionCount);
+            await _settingsService.SaveAsync(_settings);
+            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Switched to {label}");
+            AppendLog(TextFormatter.FormatSyncResult(result, $"Switched to {label} and synchronized"));
+            AppendLog(string.Empty);
+            await RefreshStatusCoreAsync(codexHome);
+            SelectProvider(result.TargetProvider);
         });
     }
 
@@ -830,6 +883,8 @@ public sealed class MainForm : Form
         _restoreDatabaseCheck.Enabled = !busy;
         _restoreSessionsCheck.Enabled = !busy;
         _executeButton.Enabled = !busy;
+        _useOfficialButton.Enabled = !busy;
+        _useRelayButton.Enabled = !busy;
         _restoreButton.Enabled = !busy;
         _openBackupButton.Enabled = !busy;
         _pruneBackupsButton.Enabled = !busy;

--- a/desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
+++ b/desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -86,6 +86,72 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunUseRelay_RequiresCustomEndpoint_ThenSwitchesAndSyncsToOpenAI()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"", includeRelayProvider: true);
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-relay.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-relay", "openai");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-relay", "openai", false)
+        ]);
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunUseRelayAsync(fixture.CodexHome);
+
+        Assert.Equal("OpenAI", result.TargetProvider);
+        Assert.True(result.ConfigUpdated);
+        string configText = await File.ReadAllTextAsync(Path.Combine(fixture.CodexHome, "config.toml"));
+        Assert.Contains("model_provider = \"OpenAI\"", configText);
+        Assert.Contains("base_url = \"https://relay.example.com\"", configText);
+        string rollout = await File.ReadAllTextAsync(sessionPath);
+        Assert.Contains("\"model_provider\":\"OpenAI\"", rollout);
+        Assert.Contains("\"message\":\"hi\"", rollout);
+        Assert.Equal([("thread-relay", "OpenAI")], await ReadThreadProvidersAsync(fixture));
+    }
+
+    [Fact]
+    public async Task RunUseRelay_RejectsOpenAIProviderWithoutCustomEndpoint()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"");
+
+        CodexSyncService service = new();
+        InvalidOperationException error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.RunUseRelayAsync(fixture.CodexHome));
+
+        Assert.Contains("Relay provider \"OpenAI\"", error.Message);
+        Assert.DoesNotContain("model_provider = \"OpenAI\"", await File.ReadAllTextAsync(Path.Combine(fixture.CodexHome, "config.toml")));
+    }
+
+    [Fact]
+    public async Task RunUseOfficial_SwitchesAndSyncsToLowercaseOpenai()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"OpenAI\"", includeRelayProvider: true);
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-official.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-official", "OpenAI");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-official", "OpenAI", false)
+        ]);
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunUseOfficialAsync(fixture.CodexHome);
+
+        Assert.Equal("openai", result.TargetProvider);
+        Assert.True(result.ConfigUpdated);
+        string configText = await File.ReadAllTextAsync(Path.Combine(fixture.CodexHome, "config.toml"));
+        Assert.Contains("model_provider = \"openai\"", configText);
+        Assert.Contains("base_url = \"https://relay.example.com\"", configText);
+        string rollout = await File.ReadAllTextAsync(sessionPath);
+        Assert.Contains("\"model_provider\":\"openai\"", rollout);
+        Assert.Contains("\"message\":\"hi\"", rollout);
+        Assert.Equal([("thread-official", "openai")], await ReadThreadProvidersAsync(fixture));
+    }
+
+    [Fact]
     public async Task RunSync_RepairsSqliteHasUserEventFromRolloutUserMessages()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
@@ -555,7 +621,7 @@ public sealed class CoreIntegrationTests
         long oldestBytes = await fixture.WriteBackupAsync(
             "20260319T000000000Z",
             ("note.txt", "oldest"),
-            ("db/state_5.sqlite", "sqlite"));
+            ($"db/{AppConstants.SqliteDirBasename}/state_5.sqlite", "sqlite"));
         await fixture.WriteBackupAsync("20260320T000000000Z", ("note.txt", "middle"));
         await fixture.WriteBackupAsync("20260321T000000000Z", ("note.txt", "newest"));
 
@@ -744,7 +810,9 @@ public sealed class CoreIntegrationTests
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
         await fixture.WriteConfigAsync("model_provider = \"openai\"");
-        await File.WriteAllTextAsync(Path.Combine(fixture.CodexHome, "state_5.sqlite"), "not sqlite");
+        await File.WriteAllTextAsync(
+            Path.Combine(fixture.CodexHome, AppConstants.SqliteDirBasename, "state_5.sqlite"),
+            "not sqlite");
 
         CodexSyncService service = new();
         StatusSnapshot status = await service.GetStatusAsync(fixture.CodexHome);
@@ -784,5 +852,21 @@ public sealed class CoreIntegrationTests
 
         Assert.Contains("model_provider = \"manual\"", await File.ReadAllTextAsync(Path.Combine(fixture.CodexHome, "config.toml")));
         Assert.Contains("\"model_provider\":\"manual\"", await File.ReadAllTextAsync(sessionPath));
+    }
+
+    private static async Task<List<(string Id, string Provider)>> ReadThreadProvidersAsync(TestCodexHomeFixture fixture)
+    {
+        await using SqliteConnection connection = fixture.OpenSqliteConnection();
+        await connection.OpenAsync();
+        SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT id, model_provider FROM threads ORDER BY id";
+        await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+        List<(string Id, string Provider)> rows = [];
+        while (await reader.ReadAsync())
+        {
+            rows.Add((reader.GetString(0), reader.GetString(1)));
+        }
+
+        return rows;
     }
 }

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -21,6 +21,7 @@ internal sealed class TestCodexHomeFixture
         string codexHome = Path.Combine(root, ".codex");
         Directory.CreateDirectory(Path.Combine(codexHome, "sessions", "2026", "03", "19"));
         Directory.CreateDirectory(Path.Combine(codexHome, "archived_sessions", "2026", "03", "18"));
+        Directory.CreateDirectory(Path.Combine(codexHome, AppConstants.SqliteDirBasename));
         return await Task.FromResult(new TestCodexHomeFixture(root, codexHome));
     }
 
@@ -39,10 +40,13 @@ internal sealed class TestCodexHomeFixture
         return Path.Combine(BackupRoot(), directoryName);
     }
 
-    public async Task WriteConfigAsync(string modelProviderLine)
+    public async Task WriteConfigAsync(string modelProviderLine, bool includeRelayProvider = false)
     {
         string prefix = string.IsNullOrWhiteSpace(modelProviderLine) ? string.Empty : modelProviderLine + "\n";
-        string configText = $"{prefix}sandbox_mode = \"danger-full-access\"\n\n[model_providers.apigather]\nbase_url = \"https://example.com\"\n";
+        string relayBlock = includeRelayProvider
+            ? "\n[model_providers.OpenAI]\nbase_url = \"https://relay.example.com\"\n"
+            : string.Empty;
+        string configText = $"{prefix}sandbox_mode = \"danger-full-access\"\n\n[model_providers.apigather]\nbase_url = \"https://example.com\"{relayBlock}";
         await File.WriteAllTextAsync(Path.Combine(CodexHome, "config.toml"), configText);
     }
 
@@ -126,7 +130,7 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
     {
-        string dbPath = Path.Combine(CodexHome, "state_5.sqlite");
+        string dbPath = Path.Combine(CodexHome, AppConstants.SqliteDirBasename, "state_5.sqlite");
         await using SqliteConnection connection = OpenSqliteConnection();
         await connection.OpenAsync();
         SqliteCommand create = connection.CreateCommand();
@@ -157,7 +161,7 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbWithUserEventColumnAsync(IEnumerable<(string Id, string ModelProvider, bool Archived, bool HasUserEvent)> rows)
     {
-        string dbPath = Path.Combine(CodexHome, "state_5.sqlite");
+        string dbPath = Path.Combine(CodexHome, AppConstants.SqliteDirBasename, "state_5.sqlite");
         await using SqliteConnection connection = OpenSqliteConnection();
         await connection.OpenAsync();
         SqliteCommand create = connection.CreateCommand();
@@ -290,6 +294,6 @@ internal sealed class TestCodexHomeFixture
 
     public SqliteConnection OpenSqliteConnection()
     {
-        return new SqliteConnection($"Data Source={Path.Combine(CodexHome, "state_5.sqlite")};Mode=ReadWriteCreate;Pooling=False");
+        return new SqliteConnection($"Data Source={Path.Combine(CodexHome, AppConstants.SqliteDirBasename, "state_5.sqlite")};Mode=ReadWriteCreate;Pooling=False");
     }
 }

--- a/desktop/CodexProviderSync.Core/AppConstants.cs
+++ b/desktop/CodexProviderSync.Core/AppConstants.cs
@@ -6,7 +6,10 @@ namespace CodexProviderSync.Core;
 public static class AppConstants
 {
     public const string DefaultProvider = "openai";
+    public const string OfficialProvider = "openai";
+    public const string RelayProvider = "OpenAI";
     public const string BackupNamespace = "provider-sync";
+    public const string SqliteDirBasename = "sqlite";
     public const string DbFileBasename = "state_5.sqlite";
     public const string GlobalStateFileBasename = ".codex-global-state.json";
     public const string GlobalStateBackupFileBasename = ".codex-global-state.json.bak";

--- a/desktop/CodexProviderSync.Core/BackupService.cs
+++ b/desktop/CodexProviderSync.Core/BackupService.cs
@@ -26,12 +26,16 @@ public sealed class BackupService
         Directory.CreateDirectory(dbDir);
 
         List<string> copiedDbFiles = [];
-        foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
+        string? dbPath = _sqliteStateService.ExistingStateDbPath(codexHome);
+        if (dbPath is not null)
         {
-            string fileName = $"{AppConstants.DbFileBasename}{suffix}";
-            if (await CopyIfPresentAsync(Path.Combine(codexHome, fileName), Path.Combine(dbDir, fileName), overwrite: false))
+            foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
             {
-                copiedDbFiles.Add(fileName);
+                string relativePath = DbBackupRelativePath(codexHome, dbPath, suffix);
+                if (await CopyIfPresentAsync(dbPath + suffix, Path.Combine(dbDir, relativePath), overwrite: false))
+                {
+                    copiedDbFiles.Add(relativePath);
+                }
             }
         }
 
@@ -142,8 +146,9 @@ public sealed class BackupService
             foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
             {
                 string fileName = $"{AppConstants.DbFileBasename}{suffix}";
-                string targetPath = Path.Combine(codexHome, fileName);
-                if (!backedUpFiles.Contains(fileName) && File.Exists(targetPath))
+                string relativePrimaryPath = Path.Combine(AppConstants.SqliteDirBasename, fileName);
+                string targetPath = Path.Combine(Path.GetDirectoryName(_sqliteStateService.StateDbPath(codexHome))!, fileName);
+                if (!backedUpFiles.Contains(relativePrimaryPath) && !backedUpFiles.Contains(fileName) && File.Exists(targetPath))
                 {
                     File.Delete(targetPath);
                 }
@@ -151,7 +156,7 @@ public sealed class BackupService
 
             foreach (string fileName in metadata.DbFiles)
             {
-                await CopyIfPresentAsync(Path.Combine(dbDir, fileName), Path.Combine(codexHome, fileName), overwrite: true);
+                await CopyIfPresentAsync(Path.Combine(dbDir, fileName), RestoreDbTargetPath(codexHome, fileName), overwrite: true);
             }
         }
 
@@ -303,6 +308,23 @@ public sealed class BackupService
         File.Copy(sourcePath, destinationPath, overwrite);
         await Task.CompletedTask;
         return true;
+    }
+
+    private static string DbBackupRelativePath(string codexHome, string dbPath, string suffix)
+    {
+        string relativePath = Path.GetRelativePath(codexHome, dbPath + suffix);
+        return !relativePath.StartsWith("..", StringComparison.Ordinal)
+            && !Path.IsPathRooted(relativePath)
+            ? relativePath
+            : AppConstants.DbFileBasename + suffix;
+    }
+
+    private static string RestoreDbTargetPath(string codexHome, string relativePath)
+    {
+        return relativePath.Contains(Path.DirectorySeparatorChar, StringComparison.Ordinal)
+            || relativePath.Contains(Path.AltDirectorySeparatorChar, StringComparison.Ordinal)
+            ? Path.Combine(codexHome, relativePath)
+            : Path.Combine(codexHome, AppConstants.SqliteDirBasename, relativePath);
     }
 
     private static JsonSerializerOptions JsonOptions()

--- a/desktop/CodexProviderSync.Core/CodexProviderSync.Core.csproj
+++ b/desktop/CodexProviderSync.Core/CodexProviderSync.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>0.2.5</Version>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.22" />
   </ItemGroup>
 
 </Project>

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -284,6 +284,36 @@ public sealed class CodexSyncService
         }
     }
 
+    public Task<SyncResult> RunUseOfficialAsync(
+        string? explicitCodexHome,
+        int keepCount = AppConstants.DefaultBackupRetentionCount)
+    {
+        return RunSwitchAsync(explicitCodexHome, AppConstants.OfficialProvider, keepCount);
+    }
+
+    public async Task<SyncResult> RunUseRelayAsync(
+        string? explicitCodexHome,
+        int keepCount = AppConstants.DefaultBackupRetentionCount)
+    {
+        string codexHome = _codexHomeService.NormalizeCodexHome(explicitCodexHome);
+        await _codexHomeService.EnsureCodexHomeAsync(codexHome);
+        string configPath = _codexHomeService.ConfigPath(codexHome);
+        string configText = await _configFileService.ReadConfigTextAsync(configPath);
+        if (!_configFileService.ConfigDeclaresProvider(configText, AppConstants.RelayProvider))
+        {
+            throw new InvalidOperationException(
+                $"Relay provider \"{AppConstants.RelayProvider}\" is not available in config.toml. Add it first with your custom endpoint.");
+        }
+
+        if (!_configFileService.ProviderBlockHasCustomEndpoint(configText, AppConstants.RelayProvider))
+        {
+            throw new InvalidOperationException(
+                $"Relay provider \"{AppConstants.RelayProvider}\" does not define base_url in config.toml. Refusing to switch because that would not use your relay endpoint.");
+        }
+
+        return await RunSwitchAsync(codexHome, AppConstants.RelayProvider, keepCount);
+    }
+
     public async Task<RestoreResult> RunRestoreAsync(string? explicitCodexHome, string backupDir)
     {
         return await RunRestoreAsync(explicitCodexHome, backupDir, new RestoreBackupOptions());

--- a/desktop/CodexProviderSync.Core/ConfigFileService.cs
+++ b/desktop/CodexProviderSync.Core/ConfigFileService.cs
@@ -66,6 +66,42 @@ public sealed partial class ConfigFileService
         return ListConfiguredProviderIds(configText).Contains(provider, StringComparer.Ordinal);
     }
 
+    public string? ReadProviderBlock(string configText, string provider)
+    {
+        string escapedProvider = Regex.Escape(provider);
+        Match headerMatch = Regex.Match(
+            configText,
+            $"^\\[model_providers\\.{escapedProvider}]\\s*$",
+            RegexOptions.Multiline);
+        if (!headerMatch.Success)
+        {
+            return null;
+        }
+
+        int blockStart = headerMatch.Index + headerMatch.Length;
+        string rest = configText[blockStart..];
+        Match nextHeaderMatch = Regex.Match(rest, "^\\[[^\\]]+]\\s*$", RegexOptions.Multiline);
+        int blockEnd = nextHeaderMatch.Success ? blockStart + nextHeaderMatch.Index : configText.Length;
+        return configText[blockStart..blockEnd];
+    }
+
+    public bool ProviderBlockHasCustomEndpoint(string configText, string provider)
+    {
+        string? block = ReadProviderBlock(configText, provider);
+        if (block is null)
+        {
+            return false;
+        }
+
+        return SplitLines(block).Any(static rawLine =>
+        {
+            string trimmed = rawLine.Trim();
+            return !string.IsNullOrWhiteSpace(trimmed)
+                && !trimmed.StartsWith('#')
+                && Regex.IsMatch(trimmed, "^base_url\\s*=\\s*(\"[^\"]+\"|'[^']+')\\s*$");
+        });
+    }
+
     public string SetRootProviderInConfigText(string configText, string provider)
     {
         string newline = DetectNewline(configText);

--- a/desktop/CodexProviderSync.Core/GlobalStateService.cs
+++ b/desktop/CodexProviderSync.Core/GlobalStateService.cs
@@ -1,11 +1,14 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Data.Sqlite;
 
 namespace CodexProviderSync.Core;
 
 public sealed class GlobalStateService
 {
+    private readonly SqliteStateService _sqliteStateService = new();
+
     public string StatePath(string codexHome)
     {
         return Path.Combine(codexHome, AppConstants.GlobalStateFileBasename);
@@ -18,8 +21,8 @@ public sealed class GlobalStateService
 
     public async Task<IReadOnlyList<ThreadCwdStat>> ReadThreadCwdStatsAsync(string codexHome)
     {
-        string dbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
-        if (!File.Exists(dbPath))
+        string? dbPath = _sqliteStateService.ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             return [];
         }
@@ -191,8 +194,8 @@ public sealed class GlobalStateService
             return [];
         }
 
-        string dbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
-        if (!File.Exists(dbPath))
+        string? dbPath = _sqliteStateService.ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             return roots
                 .Select(static root => new ProjectThreadVisibility
@@ -518,6 +521,7 @@ public sealed class GlobalStateService
     {
         return new JsonSerializerOptions
         {
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
             WriteIndented = true
         };
     }

--- a/desktop/CodexProviderSync.Core/SessionRolloutService.cs
+++ b/desktop/CodexProviderSync.Core/SessionRolloutService.cs
@@ -348,13 +348,14 @@ public sealed class SessionRolloutService
                 }
 
                 await collected.WriteAsync(buffer.AsMemory(0, bytesRead));
-                ReadOnlySpan<byte> current = collected.GetBuffer().AsSpan(0, (int)collected.Length);
-                int newlineIndex = current.IndexOf((byte)'\n');
+                byte[] collectedBuffer = collected.GetBuffer();
+                int collectedLength = (int)collected.Length;
+                int newlineIndex = Array.IndexOf(collectedBuffer, (byte)'\n', 0, collectedLength);
                 if (newlineIndex >= 0)
                 {
-                    bool crlf = newlineIndex > 0 && current[newlineIndex - 1] == '\r';
+                    bool crlf = newlineIndex > 0 && collectedBuffer[newlineIndex - 1] == '\r';
                     int lineLength = crlf ? newlineIndex - 1 : newlineIndex;
-                    string firstLine = Encoding.UTF8.GetString(current[..lineLength]);
+                    string firstLine = Encoding.UTF8.GetString(collectedBuffer, 0, lineLength);
                     return new FirstLineRecord(firstLine, crlf ? "\r\n" : "\n", newlineIndex + 1);
                 }
             }

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -13,13 +13,25 @@ public sealed class SqliteStateService
 
     public string StateDbPath(string codexHome)
     {
-        return Path.Combine(codexHome, AppConstants.DbFileBasename);
+        return Path.Combine(codexHome, AppConstants.SqliteDirBasename, AppConstants.DbFileBasename);
+    }
+
+    public string? ExistingStateDbPath(string codexHome)
+    {
+        string primaryPath = StateDbPath(codexHome);
+        if (File.Exists(primaryPath))
+        {
+            return primaryPath;
+        }
+
+        string legacyPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
+        return File.Exists(legacyPath) ? legacyPath : null;
     }
 
     public async Task<ProviderCounts?> ReadSqliteProviderCountsAsync(string codexHome)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        string? dbPath = ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             return null;
         }
@@ -83,8 +95,8 @@ public sealed class SqliteStateService
         IReadOnlyCollection<string>? userEventThreadIds = null,
         IReadOnlyDictionary<string, string>? threadCwdsById = null)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        string? dbPath = ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             return null;
         }
@@ -151,8 +163,8 @@ public sealed class SqliteStateService
 
     public async Task<bool> AssertSqliteWritableAsync(string codexHome, int? busyTimeoutMs = null)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        string? dbPath = ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             return false;
         }
@@ -182,8 +194,8 @@ public sealed class SqliteStateService
         IReadOnlyCollection<string>? userEventThreadIds = null,
         IReadOnlyDictionary<string, string>? threadCwdsById = null)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        string? dbPath = ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             if (afterUpdate is not null)
             {

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -143,6 +143,8 @@ Quick mapping:
 
 - inspect only: `codex-provider status`
 - fix visibility under current provider: `codex-provider sync`
+- switch to the official account and sync: `codex-provider use-official`
+- switch to the relay account and sync: `codex-provider use-relay`
 - switch provider and sync: `codex-provider switch openai`
 - install a desktop double-click launcher: `codex-provider install-windows-launcher`
 - roll back a mistake: `codex-provider restore <backup-dir>`
@@ -155,6 +157,13 @@ Quick mapping:
   - syncs history to the current provider
   - `--provider <id>` overrides the target provider
   - if root `model_provider` is missing, it falls back to `openai`
+- `codex-provider use-official`
+  - switches root `model_provider` to the official provider `openai`
+  - immediately syncs history metadata to `openai`
+- `codex-provider use-relay`
+  - switches root `model_provider` to the relay provider `OpenAI`
+  - refuses to run unless `[model_providers.OpenAI]` exists and defines `base_url`
+  - immediately syncs history metadata to `OpenAI`
 - `codex-provider switch <provider-id>`
   - updates root `model_provider` in `config.toml`
   - immediately runs a sync
@@ -176,6 +185,8 @@ codex-provider status
 codex-provider sync
 codex-provider sync --keep 5
 codex-provider sync --provider openai
+codex-provider use-official
+codex-provider use-relay
 codex-provider switch openai
 codex-provider switch apigather
 codex-provider prune-backups --keep 5

--- a/scripts/smoke-two-account-switch.mjs
+++ b/scripts/smoke-two-account-switch.mjs
@@ -1,0 +1,148 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { runUseOfficial, runUseRelay } from "../src/service.js";
+
+const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-provider-sync-smoke-"));
+const codexHome = path.join(root, ".codex");
+await fs.mkdir(path.join(codexHome, "sessions", "2026", "06", "14"), { recursive: true });
+await fs.mkdir(path.join(codexHome, "archived_sessions", "2026", "06", "13"), { recursive: true });
+
+const configPath = path.join(codexHome, "config.toml");
+await fs.writeFile(
+  configPath,
+  [
+    'model_provider = "openai"',
+    'sandbox_mode = "danger-full-access"',
+    "",
+    "[model_providers.OpenAI]",
+    'base_url = "https://relay.example.com/v1"',
+    'api_key_env_var = "OPENAI_API_KEY"',
+    ""
+  ].join("\n"),
+  "utf8"
+);
+
+async function writeRollout(filePath, id, provider, message) {
+  const timestamp = "2026-06-14T00:00:00.000Z";
+  const first = {
+    timestamp,
+    type: "session_meta",
+    payload: {
+      id,
+      timestamp,
+      cwd: "E:\\Code\\demo",
+      source: "cli",
+      cli_version: "0.115.0",
+      model_provider: provider
+    }
+  };
+  const second = {
+    timestamp,
+    type: "event_msg",
+    payload: {
+      type: "user_message",
+      message
+    }
+  };
+  await fs.writeFile(filePath, `${JSON.stringify(first)}\n${JSON.stringify(second)}\n`, "utf8");
+}
+
+const sessionPath = path.join(codexHome, "sessions", "2026", "06", "14", "rollout-live.jsonl");
+const archivedPath = path.join(codexHome, "archived_sessions", "2026", "06", "13", "rollout-archived.jsonl");
+await writeRollout(sessionPath, "thread-live", "openai", "DO_NOT_TOUCH_LIVE_MESSAGE");
+await writeRollout(archivedPath, "thread-archived", "openai", "DO_NOT_TOUCH_ARCHIVED_MESSAGE");
+
+const dbPath = path.join(codexHome, "state_5.sqlite");
+const db = new DatabaseSync(dbPath);
+try {
+  db.exec(`
+    CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      model_provider TEXT,
+      cwd TEXT NOT NULL DEFAULT '',
+      archived INTEGER NOT NULL DEFAULT 0,
+      first_user_message TEXT NOT NULL DEFAULT ''
+    )
+  `);
+  const insert = db.prepare(
+    "INSERT INTO threads (id, model_provider, cwd, archived, first_user_message) VALUES (?, ?, ?, ?, ?)"
+  );
+  insert.run("thread-live", "openai", "E:\\Code\\demo", 0, "DO_NOT_TOUCH_LIVE_MESSAGE");
+  insert.run("thread-archived", "openai", "E:\\Code\\demo", 1, "DO_NOT_TOUCH_ARCHIVED_MESSAGE");
+} finally {
+  db.close();
+}
+
+function readThreadRows() {
+  const current = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    return current
+      .prepare("SELECT id, model_provider, first_user_message FROM threads ORDER BY id")
+      .all();
+  } finally {
+    current.close();
+  }
+}
+
+async function readRolloutSummary(filePath) {
+  const lines = (await fs.readFile(filePath, "utf8")).trimEnd().split("\n");
+  const meta = JSON.parse(lines[0]);
+  const message = JSON.parse(lines[1]);
+  return {
+    provider: meta.payload.model_provider,
+    message: message.payload.message
+  };
+}
+
+async function snapshot(label, result = null) {
+  const config = await fs.readFile(configPath, "utf8");
+  return {
+    label,
+    configProvider: config.match(/model_provider = "([^"]+)"/)?.[1],
+    relayBaseUrlPresent: config.includes("https://relay.example.com/v1"),
+    liveRollout: await readRolloutSummary(sessionPath),
+    archivedRollout: await readRolloutSummary(archivedPath),
+    sqlite: readThreadRows(),
+    result: result
+      ? {
+          targetProvider: result.targetProvider,
+          changedSessionFiles: result.changedSessionFiles,
+          sqliteRowsUpdated: result.sqliteRowsUpdated,
+          backupCreated: Boolean(result.backupDir)
+        }
+      : null
+  };
+}
+
+const before = await snapshot("before");
+const relayResult = await runUseRelay({ codexHome, keepCount: 10 });
+const afterRelay = await snapshot("after use-relay", relayResult);
+const officialResult = await runUseOfficial({ codexHome, keepCount: 10 });
+const afterOfficial = await snapshot("after use-official", officialResult);
+
+const checks = [
+  before.configProvider === "openai",
+  before.relayBaseUrlPresent,
+  afterRelay.configProvider === "OpenAI",
+  afterRelay.relayBaseUrlPresent,
+  afterRelay.liveRollout.provider === "OpenAI",
+  afterRelay.archivedRollout.provider === "OpenAI",
+  afterRelay.liveRollout.message === "DO_NOT_TOUCH_LIVE_MESSAGE",
+  afterRelay.archivedRollout.message === "DO_NOT_TOUCH_ARCHIVED_MESSAGE",
+  afterRelay.sqlite.every((row) => row.model_provider === "OpenAI"),
+  afterOfficial.configProvider === "openai",
+  afterOfficial.relayBaseUrlPresent,
+  afterOfficial.liveRollout.provider === "openai",
+  afterOfficial.archivedRollout.provider === "openai",
+  afterOfficial.liveRollout.message === "DO_NOT_TOUCH_LIVE_MESSAGE",
+  afterOfficial.archivedRollout.message === "DO_NOT_TOUCH_ARCHIVED_MESSAGE",
+  afterOfficial.sqlite.every((row) => row.model_provider === "openai")
+];
+
+console.log(JSON.stringify({ codexHome, before, afterRelay, afterOfficial, passed: checks.every(Boolean) }, null, 2));
+if (!checks.every(Boolean)) {
+  process.exitCode = 1;
+}

--- a/src/backup.js
+++ b/src/backup.js
@@ -7,10 +7,11 @@ import {
   DEFAULT_BACKUP_RETENTION_COUNT,
   defaultBackupRoot,
   GLOBAL_STATE_BACKUP_FILE_BASENAME,
-  GLOBAL_STATE_FILE_BASENAME
+  GLOBAL_STATE_FILE_BASENAME,
+  SQLITE_DIR_BASENAME
 } from "./constants.js";
 import { assertSessionFilesWritable, restoreSessionChanges } from "./session-files.js";
-import { assertSqliteWritable } from "./sqlite-state.js";
+import { assertSqliteWritable, existingStateDbPath, stateDbPath } from "./sqlite-state.js";
 
 function timestampSlug(date = new Date()) {
   return date.toISOString().replaceAll(":", "").replaceAll("-", "").replace(".", "");
@@ -22,8 +23,22 @@ async function copyIfPresent(sourcePath, destinationPath) {
   } catch {
     return false;
   }
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
   await fs.copyFile(sourcePath, destinationPath);
   return true;
+}
+
+function dbBackupRelativePath(codexHome, dbPath, suffix) {
+  const relativePath = path.relative(codexHome, `${dbPath}${suffix}`);
+  return relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)
+    ? relativePath
+    : `${DB_FILE_BASENAME}${suffix}`;
+}
+
+function restoreDbTargetPath(codexHome, relativePath) {
+  return relativePath.includes("/") || relativePath.includes("\\")
+    ? path.join(codexHome, relativePath)
+    : path.join(path.dirname(stateDbPath(codexHome)), relativePath);
 }
 
 async function removeIfPresent(targetPath) {
@@ -55,11 +70,14 @@ export async function createBackup({
   await fs.mkdir(dbDir, { recursive: true });
 
   const copiedDbFiles = [];
-  for (const suffix of ["", "-shm", "-wal"]) {
-    const fileName = `${DB_FILE_BASENAME}${suffix}`;
-    const copied = await copyIfPresent(path.join(codexHome, fileName), path.join(dbDir, fileName));
-    if (copied) {
-      copiedDbFiles.push(fileName);
+  const dbPath = await existingStateDbPath(codexHome);
+  if (dbPath) {
+    for (const suffix of ["", "-shm", "-wal"]) {
+      const relativePath = dbBackupRelativePath(codexHome, dbPath, suffix);
+      const copied = await copyIfPresent(`${dbPath}${suffix}`, path.join(dbDir, relativePath));
+      if (copied) {
+        copiedDbFiles.push(relativePath);
+      }
     }
   }
 
@@ -196,12 +214,13 @@ export async function restoreBackup(backupDir, codexHome, options = {}) {
     const backedUpFiles = new Set(metadata.dbFiles ?? []);
     for (const suffix of ["", "-shm", "-wal"]) {
       const fileName = `${DB_FILE_BASENAME}${suffix}`;
-      if (!backedUpFiles.has(fileName)) {
-        await removeIfPresent(path.join(codexHome, fileName));
+      const targetPath = path.join(path.dirname(stateDbPath(codexHome)), fileName);
+      if (!backedUpFiles.has(path.join(SQLITE_DIR_BASENAME, fileName)) && !backedUpFiles.has(fileName)) {
+        await removeIfPresent(targetPath);
       }
     }
     for (const fileName of metadata.dbFiles ?? []) {
-      await copyIfPresent(path.join(dbDir, fileName), path.join(codexHome, fileName));
+      await copyIfPresent(path.join(dbDir, fileName), restoreDbTargetPath(codexHome, fileName));
     }
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,6 +18,8 @@ Usage:
   codex-provider status [--codex-home PATH]
   codex-provider sync [--provider ID] [--keep N] [--codex-home PATH]
   codex-provider switch <provider-id> [--keep N] [--codex-home PATH]
+  codex-provider use-official [--keep N] [--codex-home PATH]
+  codex-provider use-relay [--keep N] [--codex-home PATH]
   codex-provider prune-backups [--keep N] [--codex-home PATH]
   codex-provider restore <backup-dir> [--no-config] [--no-db] [--no-sessions] [--codex-home PATH]
   codex-provider install-windows-launcher [--dir PATH] [--codex-home PATH]
@@ -212,6 +214,28 @@ async function main() {
       onProgress: createSyncProgressReporter()
     });
     console.log(summarizeSync(result, "Switched to"));
+    return;
+  }
+
+  if (command === "use-official") {
+    const { runUseOfficial } = await loadService();
+    const result = await runUseOfficial({
+      codexHome: flags["codex-home"],
+      keepCount: parseKeepCount(flags.keep),
+      onProgress: createSyncProgressReporter()
+    });
+    console.log(summarizeSync(result, "Switched to official OpenAI"));
+    return;
+  }
+
+  if (command === "use-relay") {
+    const { runUseRelay } = await loadService();
+    const result = await runUseRelay({
+      codexHome: flags["codex-home"],
+      keepCount: parseKeepCount(flags.keep),
+      onProgress: createSyncProgressReporter()
+    });
+    console.log(summarizeSync(result, "Switched to relay"));
     return;
   }
 

--- a/src/config-file.js
+++ b/src/config-file.js
@@ -45,6 +45,35 @@ export function configDeclaresProvider(configText, provider) {
   return listConfiguredProviderIds(configText).includes(provider);
 }
 
+export function readProviderBlock(configText, provider) {
+  const escapedProvider = provider.replaceAll(".", "\\.");
+  const headerRegex = new RegExp(`^\\[model_providers\\.${escapedProvider}]\\s*$`, "m");
+  const headerMatch = headerRegex.exec(configText);
+  if (!headerMatch) {
+    return null;
+  }
+
+  const blockStart = headerMatch.index + headerMatch[0].length;
+  const rest = configText.slice(blockStart);
+  const nextHeaderMatch = /^\[[^\]]+]\s*$/m.exec(rest);
+  const blockEnd = nextHeaderMatch ? blockStart + nextHeaderMatch.index : configText.length;
+  return configText.slice(blockStart, blockEnd);
+}
+
+export function providerBlockHasCustomEndpoint(configText, provider) {
+  const block = readProviderBlock(configText, provider);
+  if (!block) {
+    return false;
+  }
+
+  return splitLines(block).some((line) => {
+    const trimmed = line.trim();
+    return trimmed
+      && !trimmed.startsWith("#")
+      && /^base_url\s*=\s*("[^"]+"|'[^']+')\s*$/.test(trimmed);
+  });
+}
+
 export function setRootProviderInConfigText(configText, provider) {
   const lines = splitLines(configText);
   let insertIndex = lines.length;

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,8 +2,11 @@ import os from "node:os";
 import path from "node:path";
 
 export const DEFAULT_PROVIDER = "openai";
+export const OFFICIAL_PROVIDER = "openai";
+export const RELAY_PROVIDER = "OpenAI";
 export const DEFAULT_LOCK_NAME = "provider-sync.lock";
 export const BACKUP_NAMESPACE = "provider-sync";
+export const SQLITE_DIR_BASENAME = "sqlite";
 export const DB_FILE_BASENAME = "state_5.sqlite";
 export const GLOBAL_STATE_FILE_BASENAME = ".codex-global-state.json";
 export const GLOBAL_STATE_BACKUP_FILE_BASENAME = ".codex-global-state.json.bak";

--- a/src/service.js
+++ b/src/service.js
@@ -4,12 +4,15 @@ import path from "node:path";
 import {
   DEFAULT_BACKUP_RETENTION_COUNT,
   DEFAULT_PROVIDER,
+  OFFICIAL_PROVIDER,
+  RELAY_PROVIDER,
   defaultBackupRoot,
   defaultCodexHome
 } from "./constants.js";
 import {
   configDeclaresProvider,
   listConfiguredProviderIds,
+  providerBlockHasCustomEndpoint,
   readConfigText,
   readCurrentProviderFromConfigText,
   setRootProviderInConfigText,
@@ -92,6 +95,16 @@ function buildEncryptedContentWarning(encryptedContentCounts, targetProvider) {
     return null;
   }
   return `Encrypted content warning: ${total} rollout file(s) contain encrypted_content from provider(s) ${[...riskyProviders].sort().join(", ")}. Visibility metadata can be synchronized to ${targetProvider}, but continuing or compacting those histories may fail with invalid_encrypted_content. Return to the original provider/account or start a new session if you need reliable continuation.`;
+}
+
+function assertRelayProviderConfig(configText) {
+  if (!configDeclaresProvider(configText, RELAY_PROVIDER)) {
+    throw new Error(`Relay provider "${RELAY_PROVIDER}" is not available in config.toml. Add [model_providers.${RELAY_PROVIDER}] with your custom endpoint first.`);
+  }
+
+  if (!providerBlockHasCustomEndpoint(configText, RELAY_PROVIDER)) {
+    throw new Error(`Relay provider "${RELAY_PROVIDER}" does not define base_url in config.toml. Refusing to switch because that would not use your relay endpoint.`);
+  }
 }
 
 export async function getStatus({ codexHome: explicitCodexHome } = {}) {
@@ -392,7 +405,8 @@ export async function runSwitch({
   codexHome: explicitCodexHome,
   provider,
   keepCount = DEFAULT_BACKUP_RETENTION_COUNT,
-  onProgress
+  onProgress,
+  validateConfigText
 }) {
   if (!provider) {
     throw new Error("Missing provider id. Usage: codex-provider switch <provider-id>");
@@ -402,6 +416,9 @@ export async function runSwitch({
   await ensureCodexHome(codexHome);
   const configPath = path.join(codexHome, "config.toml");
   const originalConfigText = await readConfigText(configPath);
+  if (typeof validateConfigText === "function") {
+    validateConfigText(originalConfigText);
+  }
   if (!configDeclaresProvider(originalConfigText, provider)) {
     throw new Error(`Provider "${provider}" is not available in config.toml. Configure it first or use one of: ${listConfiguredProviderIds(originalConfigText).join(", ")}`);
   }
@@ -435,6 +452,21 @@ export async function runSwitch({
     await writeConfigText(configPath, originalConfigText);
     throw error;
   }
+}
+
+export async function runUseOfficial(options = {}) {
+  return runSwitch({
+    ...options,
+    provider: OFFICIAL_PROVIDER
+  });
+}
+
+export async function runUseRelay(options = {}) {
+  return runSwitch({
+    ...options,
+    provider: RELAY_PROVIDER,
+    validateConfigText: assertRelayProviderConfig
+  });
 }
 
 export async function runRestore({

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -2,12 +2,38 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
-import { DB_FILE_BASENAME } from "./constants.js";
+import { DB_FILE_BASENAME, SQLITE_DIR_BASENAME } from "./constants.js";
 
 const DEFAULT_BUSY_TIMEOUT_MS = 5000;
 
 export function stateDbPath(codexHome) {
-  return path.join(codexHome, DB_FILE_BASENAME);
+  return path.join(codexHome, SQLITE_DIR_BASENAME, DB_FILE_BASENAME);
+}
+
+export async function resolveStateDbPath(codexHome) {
+  const primaryPath = stateDbPath(codexHome);
+  try {
+    await fs.access(primaryPath);
+    return primaryPath;
+  } catch {
+    return path.join(codexHome, DB_FILE_BASENAME);
+  }
+}
+
+export async function existingStateDbPath(codexHome) {
+  const primaryPath = stateDbPath(codexHome);
+  try {
+    await fs.access(primaryPath);
+    return primaryPath;
+  } catch {
+    const legacyPath = path.join(codexHome, DB_FILE_BASENAME);
+    try {
+      await fs.access(legacyPath);
+      return legacyPath;
+    } catch {
+      return null;
+    }
+  }
 }
 
 function openDatabase(dbPath) {
@@ -63,10 +89,8 @@ export function wrapSqliteMalformedError(error, action) {
 }
 
 export async function readSqliteProviderCounts(codexHome) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
     return null;
   }
 
@@ -118,10 +142,8 @@ export async function readSqliteProviderCounts(codexHome) {
 }
 
 export async function readSqliteRepairStats(codexHome, options = {}) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
     return null;
   }
 
@@ -168,10 +190,8 @@ export async function readSqliteRepairStats(codexHome, options = {}) {
 }
 
 export async function assertSqliteWritable(codexHome, options = {}) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
     return { databasePresent: false };
   }
 
@@ -198,10 +218,8 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
     ? (maybeOptions ?? {})
     : (afterUpdateOrOptions ?? {});
 
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
     if (afterUpdate) {
       await afterUpdate({
         updatedRows: 0,

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+﻿import { spawn } from "node:child_process";
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
@@ -13,7 +13,7 @@ import {
   restoreBackup,
   updateSessionBackupManifest
 } from "../src/backup.js";
-import { getStatus, renderStatus, runRestore, runSwitch, runSync } from "../src/service.js";
+import { getStatus, renderStatus, runRestore, runSwitch, runSync, runUseOfficial, runUseRelay } from "../src/service.js";
 import { DEFAULT_BACKUP_RETENTION_COUNT } from "../src/constants.js";
 import { getUnsupportedNodeVersionMessage } from "../src/node-version.js";
 import { applySessionChanges, collectSessionChanges } from "../src/session-files.js";
@@ -23,7 +23,12 @@ async function makeTempCodexHome() {
   const codexHome = path.join(root, ".codex");
   await fs.mkdir(path.join(codexHome, "sessions", "2026", "03", "19"), { recursive: true });
   await fs.mkdir(path.join(codexHome, "archived_sessions", "2026", "03", "18"), { recursive: true });
+  await fs.mkdir(path.join(codexHome, "sqlite"), { recursive: true });
   return { root, codexHome };
+}
+
+function stateDbPath(codexHome) {
+  return path.join(codexHome, "sqlite", "state_5.sqlite");
 }
 
 async function writeRollout(filePath, id, provider) {
@@ -83,8 +88,11 @@ async function writeBackup(codexHome, directoryName, files) {
   return totalBytes;
 }
 
-async function writeConfig(codexHome, modelProviderLine = "") {
-  const config = `${modelProviderLine}${modelProviderLine ? "\n" : ""}sandbox_mode = "danger-full-access"\n\n[model_providers.apigather]\nbase_url = "https://example.com"\n`;
+async function writeConfig(codexHome, modelProviderLine = "", { includeRelayProvider = false, relayBaseUrl = "https://relay.example.com" } = {}) {
+  const relayBlock = includeRelayProvider
+    ? `\n[model_providers.OpenAI]\nbase_url = "${relayBaseUrl}"\n`
+    : "";
+  const config = `${modelProviderLine}${modelProviderLine ? "\n" : ""}sandbox_mode = "danger-full-access"\n\n[model_providers.apigather]\nbase_url = "https://example.com"\n${relayBlock}`;
   await fs.writeFile(path.join(codexHome, "config.toml"), config, "utf8");
 }
 
@@ -95,7 +103,7 @@ async function writeGlobalState(codexHome, value) {
 }
 
 async function writeStateDb(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+  const dbPath = stateDbPath(codexHome);
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -117,7 +125,7 @@ async function writeStateDb(codexHome, rows) {
 }
 
 async function writeStateDbWithUserEventColumn(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+  const dbPath = stateDbPath(codexHome);
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -140,7 +148,7 @@ async function writeStateDbWithUserEventColumn(codexHome, rows) {
 }
 
 async function writeStateDbForProjectVisibility(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+  const dbPath = stateDbPath(codexHome);
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -277,7 +285,7 @@ test("runSync rewrites rollout files and sqlite, then restore reverts both", asy
   assert.match(syncedSession, /"model_provider":"openai"/);
   assert.match(syncedArchived, /"model_provider":"openai"/);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const providers = db
       .prepare("SELECT id, model_provider FROM threads ORDER BY id")
@@ -352,7 +360,7 @@ test("runSync repairs SQLite has_user_event from rollout user messages", async (
   assert.equal(syncResult.sqliteRowsUpdated, 1);
   assert.equal(syncResult.sqliteUserEventRowsUpdated, 1);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT has_user_event FROM threads WHERE id = ?")
@@ -390,7 +398,7 @@ test("runSync repairs SQLite cwd from rollout session metadata", async () => {
   assert.equal(syncResult.sqliteRowsUpdated, 1);
   assert.equal(syncResult.sqliteCwdRowsUpdated, 1);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT cwd FROM threads WHERE id = ?")
@@ -427,7 +435,7 @@ test("runSync normalizes extended rollout cwd before repairing SQLite", async ()
   assert.equal(syncResult.sqliteRowsUpdated, 1);
   assert.equal(syncResult.sqliteCwdRowsUpdated, 1);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT cwd FROM threads WHERE id = ?")
@@ -515,6 +523,73 @@ test("runSwitch updates config and syncs provider metadata", async () => {
   assert.match(config, /^model_provider = "apigather"/m);
   const rollout = await fs.readFile(sessionPath, "utf8");
   assert.match(rollout, /"model_provider":"apigather"/);
+});
+
+test("runUseRelay requires a custom endpoint and syncs to uppercase OpenAI", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"', { includeRelayProvider: true });
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-relay.jsonl");
+  await writeRollout(sessionPath, "thread-relay", "openai");
+  await writeStateDb(codexHome, [
+    { id: "thread-relay", model_provider: "openai", archived: false }
+  ]);
+
+  const result = await runUseRelay({ codexHome });
+
+  assert.equal(result.targetProvider, "OpenAI");
+  assert.equal(result.configUpdated, true);
+  assert.match(await fs.readFile(path.join(codexHome, "config.toml"), "utf8"), /^model_provider = "OpenAI"/m);
+  assert.match(await fs.readFile(sessionPath, "utf8"), /"model_provider":"OpenAI"/);
+});
+
+test("runUseRelay accepts a single-quoted relay base_url", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"', {
+    includeRelayProvider: true,
+    relayBaseUrl: "https://relay.example.com"
+  });
+  let config = await fs.readFile(path.join(codexHome, "config.toml"), "utf8");
+  config = config.replace('base_url = "https://relay.example.com"', "base_url = 'https://relay.example.com'");
+  await fs.writeFile(path.join(codexHome, "config.toml"), config, "utf8");
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-relay-single-quote.jsonl");
+  await writeRollout(sessionPath, "thread-relay-single-quote", "openai");
+  await writeStateDb(codexHome, [
+    { id: "thread-relay-single-quote", model_provider: "openai", archived: false }
+  ]);
+
+  const result = await runUseRelay({ codexHome });
+
+  assert.equal(result.targetProvider, "OpenAI");
+  assert.match(await fs.readFile(path.join(codexHome, "config.toml"), "utf8"), /^model_provider = "OpenAI"/m);
+});
+
+test("runUseRelay rejects uppercase OpenAI without relay base_url", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+
+  await assert.rejects(
+    () => runUseRelay({ codexHome }),
+    /Relay provider "OpenAI"/
+  );
+
+  assert.match(await fs.readFile(path.join(codexHome, "config.toml"), "utf8"), /^model_provider = "openai"/m);
+});
+
+test("runUseOfficial syncs to lowercase openai", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "OpenAI"', { includeRelayProvider: true });
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-official.jsonl");
+  await writeRollout(sessionPath, "thread-official", "OpenAI");
+  await writeStateDb(codexHome, [
+    { id: "thread-official", model_provider: "OpenAI", archived: false }
+  ]);
+
+  const result = await runUseOfficial({ codexHome });
+
+  assert.equal(result.targetProvider, "openai");
+  assert.equal(result.configUpdated, true);
+  assert.match(await fs.readFile(path.join(codexHome, "config.toml"), "utf8"), /^model_provider = "openai"/m);
+  assert.match(await fs.readFile(sessionPath, "utf8"), /"model_provider":"openai"/);
 });
 
 test("status reports implicit default provider and rollout/sqlite counts", async () => {
@@ -624,7 +699,7 @@ test("runSync leaves rollout files and sqlite untouched when sqlite is locked", 
     { id: "thread-a", model_provider: "apigather", archived: false }
   ]);
 
-  const lockDb = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const lockDb = new DatabaseSync(stateDbPath(codexHome));
   try {
     lockDb.exec("BEGIN IMMEDIATE");
     await assert.rejects(
@@ -643,7 +718,7 @@ test("runSync leaves rollout files and sqlite untouched when sqlite is locked", 
   const rollout = await fs.readFile(sessionPath, "utf8");
   assert.match(rollout, /"model_provider":"apigather"/);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT model_provider FROM threads WHERE id = ?")
@@ -683,7 +758,7 @@ test("runSync skips locked rollout files and still updates sqlite", async () => 
   const rollout = await fs.readFile(sessionPath, "utf8");
   assert.match(rollout, /"model_provider":"apigather"/);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT model_provider FROM threads WHERE id = ?")
@@ -720,18 +795,22 @@ test("applySessionChanges preserves large UTF-8 session metadata", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"');
   const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-large.jsonl");
+  const title = "\u4e2d\u6587\u4f1a\u8bdd";
+  const note = "\u4fdd\u7559 UTF-8 \u5185\u5bb9";
+  const message = "\u4f60\u597d";
+  const largeBlobPrefix = "\u6570\u636e\u5757";
   const payload = {
     id: "thread-large",
     timestamp: "2026-03-19T00:00:00.000Z",
-    cwd: "C:\\AITemp\\中文",
+    cwd: "C:\\AITemp\\\u4e2d\u6587",
     source: "cli",
     cli_version: "0.115.0",
     model_provider: "apigather",
-    title: "中文会话",
-    note: "保留 UTF-8 内容",
-    large_blob: "数据块".repeat(40000)
+    title,
+    note,
+    large_blob: largeBlobPrefix.repeat(40000)
   };
-  await writeCustomRollout(sessionPath, payload, "你好");
+  await writeCustomRollout(sessionPath, payload, message);
 
   const { changes } = await collectSessionChanges(codexHome, "openai");
   const result = await applySessionChanges(changes);
@@ -741,10 +820,10 @@ test("applySessionChanges preserves large UTF-8 session metadata", async () => {
 
   const rollout = await fs.readFile(sessionPath, "utf8");
   assert.match(rollout, /"model_provider":"openai"/);
-  assert.match(rollout, /"title":"中文会话"/);
-  assert.match(rollout, /"note":"保留 UTF-8 内容"/);
-  assert.match(rollout, /"message":"你好"/);
-  assert.match(rollout, /"large_blob":"数据块数据块/);
+  assert.match(rollout, new RegExp(`"title":"${title}"`));
+  assert.match(rollout, new RegExp(`"note":"${note}"`));
+  assert.match(rollout, new RegExp(`"message":"${message}"`));
+  assert.match(rollout, new RegExp(`"large_blob":"${largeBlobPrefix}${largeBlobPrefix}`));
 });
 
 test("applySessionChanges restores original rollout mtime", async () => {
@@ -916,7 +995,7 @@ test("runSync fails before rollout rewrite when SQLite is malformed", async () =
   await writeConfig(codexHome, 'model_provider = "openai"');
   const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-malformed-db.jsonl");
   await writeRollout(sessionPath, "thread-malformed", "apigather");
-  await fs.writeFile(path.join(codexHome, "state_5.sqlite"), "not sqlite", "utf8");
+  await fs.writeFile(stateDbPath(codexHome), "not sqlite", "utf8");
 
   await assert.rejects(
     () => runSync({ codexHome }),
@@ -929,7 +1008,7 @@ test("status reports malformed SQLite without failing", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"');
   await writeRollout(path.join(codexHome, "sessions", "2026", "03", "19", "rollout-status-db.jsonl"), "thread-status", "openai");
-  await fs.writeFile(path.join(codexHome, "state_5.sqlite"), "not sqlite", "utf8");
+  await fs.writeFile(stateDbPath(codexHome), "not sqlite", "utf8");
 
   const status = await getStatus({ codexHome });
   assert.equal(status.sqliteCounts.unreadable, true);
@@ -961,7 +1040,7 @@ test("pruneBackups removes the oldest backup directories", async () => {
   const { codexHome } = await makeTempCodexHome();
   const oldestBytes = await writeBackup(codexHome, "20260319T000000000Z", [
     ["note.txt", "oldest"],
-    ["db/state_5.sqlite", "sqlite"]
+    ["db/sqlite/state_5.sqlite", "sqlite"]
   ]);
   await writeBackup(codexHome, "20260320T000000000Z", [["note.txt", "middle"]]);
   await writeBackup(codexHome, "20260321T000000000Z", [["note.txt", "newest"]]);


### PR DESCRIPTION
This PR adds a simple two-account flow for official OpenAI (openai) and relay (OpenAI), preserves relay base_url, and fixes Codex SQLite path handling so the CLI and desktop app sync the real state DB under ~/.codex/sqlite/state_5.sqlite. It also updates backups, tests, and a Win10+ self-contained publish target.