### PR TITLE
Detect Codex state database location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,9 @@ For normal Windows users, prefer the GUI app when it is available. Use the CLI w
 The tool works by updating both:
 
 - rollout metadata under `~/.codex/sessions` and `~/.codex/archived_sessions`
-- SQLite thread metadata in `~/.codex/state_5.sqlite`
+- SQLite thread metadata in the detected Codex state database, normally
+  `~/.codex/sqlite/state_5.sqlite` with legacy fallback to
+  `~/.codex/state_5.sqlite`
 
 Do not solve this by manually editing rollout files only unless the user explicitly asks for manual intervention.
 
@@ -32,7 +34,7 @@ Use this order by default:
 CLI fallback flow:
 
 1. Run `codex-provider status`
-2. Read `Current provider` and compare rollout/SQLite distribution
+2. Read `Current provider`, the displayed SQLite database path, and compare rollout/SQLite distribution
 3. Decide whether the user needs `sync`, `switch`, or `restore`
 4. Run the command
 5. Report whether the result is complete or partially skipped due to locked files
@@ -112,6 +114,9 @@ If `switch <provider-id>` fails because the provider is missing:
 ## Safe Defaults
 
 - default Codex home: `~/.codex`
+- detect the SQLite DB before reasoning about SQLite counts; recent Codex uses
+  `~/.codex/sqlite/state_5.sqlite`, while older layouts may use
+  `~/.codex/state_5.sqlite`
 - prefer `status` before destructive-looking operations, even though this tool only edits metadata
 - by default the tool keeps the most recent 5 managed backups
 - use GUI retention settings or CLI `--keep <n>` when the user wants a different retention count

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -27,6 +27,14 @@ public sealed class CoreIntegrationTests
         Assert.Equal(2, syncResult.ChangedSessionFiles);
         Assert.Empty(syncResult.SkippedLockedRolloutFiles);
         Assert.Equal(2, syncResult.SqliteRowsUpdated);
+        BackupMetadataFile backupMetadata = JsonSerializer.Deserialize<BackupMetadataFile>(
+            await File.ReadAllTextAsync(Path.Combine(syncResult.BackupDir, "metadata.json")),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })!;
+        Assert.Equal(
+        [
+            Path.Combine(AppConstants.SqliteDirBasename, AppConstants.DbFileBasename)
+        ],
+            backupMetadata.DbFiles);
 
         string syncedSession = await File.ReadAllTextAsync(sessionPath);
         string syncedArchived = await File.ReadAllTextAsync(archivedPath);
@@ -273,8 +281,44 @@ public sealed class CoreIntegrationTests
         Assert.True(status.CurrentProvider.Implicit);
         Assert.Equal(1, status.RolloutCounts.Sessions["apigather"]);
         Assert.Equal(1, status.SqliteCounts!.ArchivedSessions["openai"]);
+        Assert.NotNull(status.StateDbLocation);
+        Assert.Equal("sqlite-dir", status.StateDbLocation!.Source);
+        Assert.Equal(fixture.StateDbPath(), status.StateDbLocation.Path);
         Assert.Equal(2, status.BackupSummary.Count);
         Assert.Equal(backupOneBytes + backupTwoBytes, status.BackupSummary.TotalBytes);
+        Assert.Contains($"database: {fixture.StateDbPath()}", TextFormatter.FormatStatus(status));
+    }
+
+    [Fact]
+    public async Task GetStatus_FallsBackToLegacyRootSqliteDatabase()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync(string.Empty);
+        await using (SqliteConnection connection = fixture.OpenLegacySqliteConnection())
+        {
+            await connection.OpenAsync();
+            SqliteCommand create = connection.CreateCommand();
+            create.CommandText = """
+                CREATE TABLE threads (
+                  id TEXT PRIMARY KEY,
+                  model_provider TEXT,
+                  archived INTEGER NOT NULL DEFAULT 0
+                )
+                """;
+            await create.ExecuteNonQueryAsync();
+            SqliteCommand insert = connection.CreateCommand();
+            insert.CommandText = "INSERT INTO threads (id, model_provider, archived) VALUES ('legacy-thread', 'openai', 0)";
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        CodexSyncService service = new();
+        StatusSnapshot status = await service.GetStatusAsync(fixture.CodexHome);
+
+        Assert.NotNull(status.StateDbLocation);
+        Assert.Equal("legacy-root", status.StateDbLocation!.Source);
+        Assert.Equal(fixture.LegacyStateDbPath(), status.StateDbLocation.Path);
+        Assert.Equal(1, status.SqliteCounts!.Sessions["openai"]);
+        Assert.Contains("legacy root", TextFormatter.FormatStatus(status));
     }
 
     [Fact]
@@ -744,7 +788,8 @@ public sealed class CoreIntegrationTests
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
         await fixture.WriteConfigAsync("model_provider = \"openai\"");
-        await File.WriteAllTextAsync(Path.Combine(fixture.CodexHome, "state_5.sqlite"), "not sqlite");
+        Directory.CreateDirectory(Path.GetDirectoryName(fixture.StateDbPath())!);
+        await File.WriteAllTextAsync(fixture.StateDbPath(), "not sqlite");
 
         CodexSyncService service = new();
         StatusSnapshot status = await service.GetStatusAsync(fixture.CodexHome);

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -39,6 +39,16 @@ internal sealed class TestCodexHomeFixture
         return Path.Combine(BackupRoot(), directoryName);
     }
 
+    public string StateDbPath()
+    {
+        return Path.Combine(CodexHome, AppConstants.SqliteDirBasename, AppConstants.DbFileBasename);
+    }
+
+    public string LegacyStateDbPath()
+    {
+        return Path.Combine(CodexHome, AppConstants.DbFileBasename);
+    }
+
     public async Task WriteConfigAsync(string modelProviderLine)
     {
         string prefix = string.IsNullOrWhiteSpace(modelProviderLine) ? string.Empty : modelProviderLine + "\n";
@@ -126,7 +136,6 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
     {
-        string dbPath = Path.Combine(CodexHome, "state_5.sqlite");
         await using SqliteConnection connection = OpenSqliteConnection();
         await connection.OpenAsync();
         SqliteCommand create = connection.CreateCommand();
@@ -157,7 +166,6 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbWithUserEventColumnAsync(IEnumerable<(string Id, string ModelProvider, bool Archived, bool HasUserEvent)> rows)
     {
-        string dbPath = Path.Combine(CodexHome, "state_5.sqlite");
         await using SqliteConnection connection = OpenSqliteConnection();
         await connection.OpenAsync();
         SqliteCommand create = connection.CreateCommand();
@@ -290,6 +298,17 @@ internal sealed class TestCodexHomeFixture
 
     public SqliteConnection OpenSqliteConnection()
     {
-        return new SqliteConnection($"Data Source={Path.Combine(CodexHome, "state_5.sqlite")};Mode=ReadWriteCreate;Pooling=False");
+        return OpenSqliteConnection(StateDbPath());
+    }
+
+    public SqliteConnection OpenLegacySqliteConnection()
+    {
+        return OpenSqliteConnection(LegacyStateDbPath());
+    }
+
+    private static SqliteConnection OpenSqliteConnection(string dbPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        return new SqliteConnection($"Data Source={dbPath};Mode=ReadWriteCreate;Pooling=False");
     }
 }

--- a/desktop/CodexProviderSync.Core/AppConstants.cs
+++ b/desktop/CodexProviderSync.Core/AppConstants.cs
@@ -8,6 +8,7 @@ public static class AppConstants
     public const string DefaultProvider = "openai";
     public const string BackupNamespace = "provider-sync";
     public const string DbFileBasename = "state_5.sqlite";
+    public const string SqliteDirBasename = "sqlite";
     public const string GlobalStateFileBasename = ".codex-global-state.json";
     public const string GlobalStateBackupFileBasename = ".codex-global-state.json.bak";
     public const int DefaultBackupRetentionCount = 5;

--- a/desktop/CodexProviderSync.Core/BackupService.cs
+++ b/desktop/CodexProviderSync.Core/BackupService.cs
@@ -26,12 +26,16 @@ public sealed class BackupService
         Directory.CreateDirectory(dbDir);
 
         List<string> copiedDbFiles = [];
-        foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
+        StateDbLocation? stateDb = _sqliteStateService.DetectStateDb(codexHome);
+        if (stateDb is not null)
         {
-            string fileName = $"{AppConstants.DbFileBasename}{suffix}";
-            if (await CopyIfPresentAsync(Path.Combine(codexHome, fileName), Path.Combine(dbDir, fileName), overwrite: false))
+            foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
             {
-                copiedDbFiles.Add(fileName);
+                string relativePath = DbBackupRelativePath(codexHome, stateDb.Path, suffix);
+                if (await CopyIfPresentAsync(stateDb.Path + suffix, Path.Combine(dbDir, relativePath), overwrite: false))
+                {
+                    copiedDbFiles.Add(relativePath);
+                }
             }
         }
 
@@ -139,19 +143,23 @@ public sealed class BackupService
             string dbDir = Path.Combine(normalizedBackupDir, "db");
             HashSet<string> backedUpFiles = new(metadata.DbFiles, StringComparer.Ordinal);
 
-            foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
+            foreach (string baseFile in metadata.DbFiles.Where(static fileName => Path.GetFileName(fileName) == AppConstants.DbFileBasename))
             {
-                string fileName = $"{AppConstants.DbFileBasename}{suffix}";
-                string targetPath = Path.Combine(codexHome, fileName);
-                if (!backedUpFiles.Contains(fileName) && File.Exists(targetPath))
+                string basePath = RestoreDbTargetPath(codexHome, baseFile);
+                foreach (string suffix in new[] { "-shm", "-wal" })
                 {
-                    File.Delete(targetPath);
+                    string sidecarFile = baseFile + suffix;
+                    string sidecarPath = basePath + suffix;
+                    if (!backedUpFiles.Contains(sidecarFile) && File.Exists(sidecarPath))
+                    {
+                        File.Delete(sidecarPath);
+                    }
                 }
             }
 
             foreach (string fileName in metadata.DbFiles)
             {
-                await CopyIfPresentAsync(Path.Combine(dbDir, fileName), Path.Combine(codexHome, fileName), overwrite: true);
+                await CopyIfPresentAsync(Path.Combine(dbDir, fileName), RestoreDbTargetPath(codexHome, fileName), overwrite: true);
             }
         }
 
@@ -303,6 +311,26 @@ public sealed class BackupService
         File.Copy(sourcePath, destinationPath, overwrite);
         await Task.CompletedTask;
         return true;
+    }
+
+    private static string DbBackupRelativePath(string codexHome, string dbPath, string suffix)
+    {
+        string relativePath = Path.GetRelativePath(codexHome, dbPath + suffix);
+        return !relativePath.StartsWith("..", StringComparison.Ordinal)
+            && !Path.IsPathRooted(relativePath)
+            ? relativePath
+            : AppConstants.DbFileBasename + suffix;
+    }
+
+    private static string RestoreDbTargetPath(string codexHome, string relativePath)
+    {
+        if (Path.IsPathRooted(relativePath)
+            || relativePath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Contains("..", StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException($"Invalid database backup path: {relativePath}");
+        }
+
+        return Path.Combine(codexHome, relativePath);
     }
 
     private static JsonSerializerOptions JsonOptions()

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -50,6 +50,7 @@ public sealed class CodexSyncService
         CurrentProviderInfo currentProvider = _configFileService.ReadCurrentProviderFromConfigText(configText);
         IReadOnlyList<string> configuredProviders = _configFileService.ListConfiguredProviderIds(configText);
         SessionChangeCollection rolloutInfo = await _sessionRolloutService.CollectSessionChangesAsync(codexHome, "__status_only__", skipLockedReads: true);
+        StateDbLocation? stateDbLocation = _sqliteStateService.DetectStateDb(codexHome);
         ProviderCounts? sqliteCounts = await _sqliteStateService.ReadSqliteProviderCountsAsync(codexHome);
         SqliteRepairStats? sqliteRepairStats = sqliteCounts is not null && !sqliteCounts.Unreadable
             ? await _sqliteStateService.ReadSqliteRepairStatsAsync(
@@ -72,6 +73,7 @@ public sealed class CodexSyncService
             EncryptedContentCounts = rolloutInfo.EncryptedContentCounts,
             EncryptedContentWarning = BuildEncryptedContentWarning(rolloutInfo.EncryptedContentCounts, currentProvider.Provider),
             SqliteCounts = sqliteCounts,
+            StateDbLocation = stateDbLocation,
             SqliteRepairStats = sqliteRepairStats,
             ProjectThreadVisibility = projectThreadVisibility,
             BackupRoot = _codexHomeService.BackupRoot(codexHome),

--- a/desktop/CodexProviderSync.Core/GlobalStateService.cs
+++ b/desktop/CodexProviderSync.Core/GlobalStateService.cs
@@ -6,6 +6,8 @@ namespace CodexProviderSync.Core;
 
 public sealed class GlobalStateService
 {
+    private readonly SqliteStateService _sqliteStateService = new();
+
     public string StatePath(string codexHome)
     {
         return Path.Combine(codexHome, AppConstants.GlobalStateFileBasename);
@@ -18,8 +20,8 @@ public sealed class GlobalStateService
 
     public async Task<IReadOnlyList<ThreadCwdStat>> ReadThreadCwdStatsAsync(string codexHome)
     {
-        string dbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
-        if (!File.Exists(dbPath))
+        string? dbPath = _sqliteStateService.ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             return [];
         }
@@ -191,8 +193,8 @@ public sealed class GlobalStateService
             return [];
         }
 
-        string dbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
-        if (!File.Exists(dbPath))
+        string? dbPath = _sqliteStateService.ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             return roots
                 .Select(static root => new ProjectThreadVisibility

--- a/desktop/CodexProviderSync.Core/Models.cs
+++ b/desktop/CodexProviderSync.Core/Models.cs
@@ -23,11 +23,14 @@ public sealed class StatusSnapshot
     public required ProviderCounts EncryptedContentCounts { get; init; }
     public string? EncryptedContentWarning { get; init; }
     public required ProviderCounts? SqliteCounts { get; init; }
+    public StateDbLocation? StateDbLocation { get; init; }
     public SqliteRepairStats? SqliteRepairStats { get; init; }
     public IReadOnlyList<ProjectThreadVisibility> ProjectThreadVisibility { get; init; } = [];
     public required string BackupRoot { get; init; }
     public required BackupSummary BackupSummary { get; init; }
 }
+
+public sealed record StateDbLocation(string Path, string RelativePath, string Source);
 
 public sealed class SqliteRepairStats
 {

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -13,13 +13,51 @@ public sealed class SqliteStateService
 
     public string StateDbPath(string codexHome)
     {
+        return Path.Combine(codexHome, AppConstants.SqliteDirBasename, AppConstants.DbFileBasename);
+    }
+
+    public string LegacyStateDbPath(string codexHome)
+    {
         return Path.Combine(codexHome, AppConstants.DbFileBasename);
+    }
+
+    public IReadOnlyList<StateDbLocation> StateDbCandidates(string codexHome)
+    {
+        return
+        [
+            new StateDbLocation(
+                StateDbPath(codexHome),
+                Path.Combine(AppConstants.SqliteDirBasename, AppConstants.DbFileBasename),
+                "sqlite-dir"),
+            new StateDbLocation(
+                LegacyStateDbPath(codexHome),
+                AppConstants.DbFileBasename,
+                "legacy-root")
+        ];
+    }
+
+    public StateDbLocation? DetectStateDb(string codexHome)
+    {
+        foreach (StateDbLocation candidate in StateDbCandidates(codexHome))
+        {
+            if (File.Exists(candidate.Path))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    public string? ExistingStateDbPath(string codexHome)
+    {
+        return DetectStateDb(codexHome)?.Path;
     }
 
     public async Task<ProviderCounts?> ReadSqliteProviderCountsAsync(string codexHome)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        string? dbPath = ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             return null;
         }
@@ -83,8 +121,8 @@ public sealed class SqliteStateService
         IReadOnlyCollection<string>? userEventThreadIds = null,
         IReadOnlyDictionary<string, string>? threadCwdsById = null)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        string? dbPath = ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             return null;
         }
@@ -151,8 +189,8 @@ public sealed class SqliteStateService
 
     public async Task<bool> AssertSqliteWritableAsync(string codexHome, int? busyTimeoutMs = null)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        string? dbPath = ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             return false;
         }
@@ -182,8 +220,8 @@ public sealed class SqliteStateService
         IReadOnlyCollection<string>? userEventThreadIds = null,
         IReadOnlyDictionary<string, string>? threadCwdsById = null)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        string? dbPath = ExistingStateDbPath(codexHome);
+        if (dbPath is null)
         {
             if (afterUpdate is not null)
             {

--- a/desktop/CodexProviderSync.Core/TextFormatter.cs
+++ b/desktop/CodexProviderSync.Core/TextFormatter.cs
@@ -34,6 +34,16 @@ public static class TextFormatter
             lines.Insert(11, $"  Locked rollout files skipped during status scan: {status.LockedRolloutFiles.Count}");
         }
 
+        if (status.StateDbLocation is not null)
+        {
+            string legacyNote = status.StateDbLocation.Source == "legacy-root" ? " (legacy root)" : string.Empty;
+            lines.Add($"  database: {status.StateDbLocation.Path}{legacyNote}");
+        }
+        else
+        {
+            lines.Add("  database: not found (checked sqlite/state_5.sqlite, state_5.sqlite)");
+        }
+
         if (status.SqliteCounts?.Unreadable == true)
         {
             lines.Add($"  {status.SqliteCounts.Error ?? "state_5.sqlite is malformed or unreadable"}");

--- a/desktop/CodexProviderSync.Mac/MacDisplayFormatter.cs
+++ b/desktop/CodexProviderSync.Mac/MacDisplayFormatter.cs
@@ -38,6 +38,16 @@ internal static class MacDisplayFormatter
             lines.Insert(11, $"  状态扫描时跳过 locked rollout 文件: {status.LockedRolloutFiles.Count}");
         }
 
+        if (status.StateDbLocation is not null)
+        {
+            string legacyNote = status.StateDbLocation.Source == "legacy-root" ? " (legacy root)" : string.Empty;
+            lines.Add($"  database: {status.StateDbLocation.Path}{legacyNote}");
+        }
+        else
+        {
+            lines.Add("  database: not found (checked sqlite/state_5.sqlite, state_5.sqlite)");
+        }
+
         if (status.SqliteCounts?.Unreadable == true)
         {
             lines.Add($"  {status.SqliteCounts.Error ?? "state_5.sqlite 损坏或不可读"}");

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -27,7 +27,9 @@ Typical symptom:
 `codex-provider-sync` fixes that by updating both:
 
 - `~/.codex/sessions` and `~/.codex/archived_sessions`
-- `~/.codex/state_5.sqlite`
+- the Codex state database, usually `~/.codex/sqlite/state_5.sqlite`
+
+Older Codex layouts may still use `~/.codex/state_5.sqlite`; the tool detects the active location and reports it in `codex-provider status`.
 
 ## GUI For Windows
 
@@ -150,7 +152,7 @@ Quick mapping:
 ## Commands
 
 - `codex-provider status`
-  - shows current provider and provider distribution in rollout files and SQLite
+  - shows current provider, the detected SQLite database path, and provider distribution in rollout files and SQLite
 - `codex-provider sync`
   - syncs history to the current provider
   - `--provider <id>` overrides the target provider

--- a/src/backup.js
+++ b/src/backup.js
@@ -10,7 +10,7 @@ import {
   GLOBAL_STATE_FILE_BASENAME
 } from "./constants.js";
 import { assertSessionFilesWritable, restoreSessionChanges } from "./session-files.js";
-import { assertSqliteWritable } from "./sqlite-state.js";
+import { assertSqliteWritable, detectStateDb } from "./sqlite-state.js";
 
 function timestampSlug(date = new Date()) {
   return date.toISOString().replaceAll(":", "").replaceAll("-", "").replace(".", "");
@@ -22,8 +22,23 @@ async function copyIfPresent(sourcePath, destinationPath) {
   } catch {
     return false;
   }
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
   await fs.copyFile(sourcePath, destinationPath);
   return true;
+}
+
+function dbBackupRelativePath(codexHome, dbPath, suffix) {
+  const relativePath = path.relative(codexHome, `${dbPath}${suffix}`);
+  return relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)
+    ? relativePath
+    : `${DB_FILE_BASENAME}${suffix}`;
+}
+
+function restoreDbTargetPath(codexHome, relativePath) {
+  if (path.isAbsolute(relativePath) || relativePath.split(/[\\/]/).includes("..")) {
+    throw new Error(`Invalid database backup path: ${relativePath}`);
+  }
+  return path.join(codexHome, relativePath);
 }
 
 async function removeIfPresent(targetPath) {
@@ -55,11 +70,14 @@ export async function createBackup({
   await fs.mkdir(dbDir, { recursive: true });
 
   const copiedDbFiles = [];
-  for (const suffix of ["", "-shm", "-wal"]) {
-    const fileName = `${DB_FILE_BASENAME}${suffix}`;
-    const copied = await copyIfPresent(path.join(codexHome, fileName), path.join(dbDir, fileName));
-    if (copied) {
-      copiedDbFiles.push(fileName);
+  const stateDb = await detectStateDb(codexHome);
+  if (stateDb) {
+    for (const suffix of ["", "-shm", "-wal"]) {
+      const relativePath = dbBackupRelativePath(codexHome, stateDb.path, suffix);
+      const copied = await copyIfPresent(`${stateDb.path}${suffix}`, path.join(dbDir, relativePath));
+      if (copied) {
+        copiedDbFiles.push(relativePath);
+      }
     }
   }
 
@@ -194,14 +212,19 @@ export async function restoreBackup(backupDir, codexHome, options = {}) {
 
     const dbDir = path.join(backupDir, "db");
     const backedUpFiles = new Set(metadata.dbFiles ?? []);
-    for (const suffix of ["", "-shm", "-wal"]) {
-      const fileName = `${DB_FILE_BASENAME}${suffix}`;
-      if (!backedUpFiles.has(fileName)) {
-        await removeIfPresent(path.join(codexHome, fileName));
+    const backedUpBaseFiles = (metadata.dbFiles ?? [])
+      .filter((fileName) => path.basename(fileName) === DB_FILE_BASENAME);
+    for (const baseFile of backedUpBaseFiles) {
+      const basePath = restoreDbTargetPath(codexHome, baseFile);
+      for (const suffix of ["-shm", "-wal"]) {
+        const sidecarFile = `${baseFile}${suffix}`;
+        if (!backedUpFiles.has(sidecarFile)) {
+          await removeIfPresent(`${basePath}${suffix}`);
+        }
       }
     }
     for (const fileName of metadata.dbFiles ?? []) {
-      await copyIfPresent(path.join(dbDir, fileName), path.join(codexHome, fileName));
+      await copyIfPresent(path.join(dbDir, fileName), restoreDbTargetPath(codexHome, fileName));
     }
   }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,7 @@ export const DEFAULT_PROVIDER = "openai";
 export const DEFAULT_LOCK_NAME = "provider-sync.lock";
 export const BACKUP_NAMESPACE = "provider-sync";
 export const DB_FILE_BASENAME = "state_5.sqlite";
+export const SQLITE_DIR_BASENAME = "sqlite";
 export const GLOBAL_STATE_FILE_BASENAME = ".codex-global-state.json";
 export const GLOBAL_STATE_BACKUP_FILE_BASENAME = ".codex-global-state.json.bak";
 export const DEFAULT_BACKUP_RETENTION_COUNT = 5;

--- a/src/service.js
+++ b/src/service.js
@@ -33,6 +33,7 @@ import {
 } from "./session-files.js";
 import {
   assertSqliteWritable,
+  detectStateDb,
   readSqliteProviderCounts,
   readSqliteRepairStats,
   updateSqliteProvider
@@ -108,6 +109,7 @@ export async function getStatus({ codexHome: explicitCodexHome } = {}) {
     userEventThreadIds,
     threadCwdById
   } = await collectSessionChanges(codexHome, "__status_only__", { skipLockedReads: true });
+  const stateDbLocation = await detectStateDb(codexHome);
   const sqliteCounts = await readSqliteProviderCounts(codexHome);
   const sqliteRepairStats = sqliteCounts && !sqliteCounts.unreadable
     ? await readSqliteRepairStats(codexHome, { userEventThreadIds, threadCwdById })
@@ -127,6 +129,7 @@ export async function getStatus({ codexHome: explicitCodexHome } = {}) {
     encryptedContentCounts,
     encryptedContentWarning: buildEncryptedContentWarning(encryptedContentCounts, current.provider ?? DEFAULT_PROVIDER),
     sqliteCounts,
+    stateDbLocation,
     sqliteRepairStats,
     projectThreadVisibility,
     backupRoot: defaultBackupRoot(codexHome),
@@ -160,6 +163,12 @@ export function renderStatus(status) {
 
   lines.push("");
   lines.push("SQLite state:");
+  if (status.stateDbLocation) {
+    const legacyNote = status.stateDbLocation.source === "legacy-root" ? " (legacy root)" : "";
+    lines.push(`  database: ${status.stateDbLocation.path}${legacyNote}`);
+  } else {
+    lines.push("  database: not found (checked sqlite/state_5.sqlite, state_5.sqlite)");
+  }
   if (status.sqliteCounts?.unreadable) {
     lines.push(`  ${status.sqliteCounts.error ?? "state_5.sqlite is malformed or unreadable"}`);
   } else if (!status.sqliteCounts) {

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -2,12 +2,47 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
-import { DB_FILE_BASENAME } from "./constants.js";
+import { DB_FILE_BASENAME, SQLITE_DIR_BASENAME } from "./constants.js";
 
 const DEFAULT_BUSY_TIMEOUT_MS = 5000;
 
 export function stateDbPath(codexHome) {
+  return path.join(codexHome, SQLITE_DIR_BASENAME, DB_FILE_BASENAME);
+}
+
+export function legacyStateDbPath(codexHome) {
   return path.join(codexHome, DB_FILE_BASENAME);
+}
+
+export function stateDbCandidates(codexHome) {
+  return [
+    {
+      path: stateDbPath(codexHome),
+      relativePath: path.join(SQLITE_DIR_BASENAME, DB_FILE_BASENAME),
+      source: "sqlite-dir"
+    },
+    {
+      path: legacyStateDbPath(codexHome),
+      relativePath: DB_FILE_BASENAME,
+      source: "legacy-root"
+    }
+  ];
+}
+
+export async function detectStateDb(codexHome) {
+  for (const candidate of stateDbCandidates(codexHome)) {
+    try {
+      await fs.access(candidate.path);
+      return candidate;
+    } catch {
+      // Try the next known Codex state DB location.
+    }
+  }
+  return null;
+}
+
+export async function existingStateDbPath(codexHome) {
+  return (await detectStateDb(codexHome))?.path ?? null;
 }
 
 function openDatabase(dbPath) {
@@ -63,10 +98,8 @@ export function wrapSqliteMalformedError(error, action) {
 }
 
 export async function readSqliteProviderCounts(codexHome) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
     return null;
   }
 
@@ -118,10 +151,8 @@ export async function readSqliteProviderCounts(codexHome) {
 }
 
 export async function readSqliteRepairStats(codexHome, options = {}) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
     return null;
   }
 
@@ -168,10 +199,8 @@ export async function readSqliteRepairStats(codexHome, options = {}) {
 }
 
 export async function assertSqliteWritable(codexHome, options = {}) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
     return { databasePresent: false };
   }
 
@@ -198,10 +227,8 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
     ? (maybeOptions ?? {})
     : (afterUpdateOrOptions ?? {});
 
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
     if (afterUpdate) {
       await afterUpdate({
         updatedRows: 0,

--- a/src/workspace-roots.js
+++ b/src/workspace-roots.js
@@ -7,7 +7,7 @@ import {
   GLOBAL_STATE_FILE_BASENAME
 } from "./constants.js";
 import {
-  stateDbPath,
+  existingStateDbPath,
   wrapSqliteBusyError,
   wrapSqliteMalformedError
 } from "./sqlite-state.js";
@@ -164,10 +164,8 @@ function copyResolvedObjectKeys(input, cwdStats) {
 }
 
 export async function readThreadCwdStats(codexHome) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
     return [];
   }
 
@@ -258,10 +256,8 @@ export async function readProjectThreadVisibility(codexHome, options = {}) {
     return [];
   }
 
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
     return roots.map((root) => ({
       root,
       interactiveThreads: 0,

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -14,7 +14,7 @@ import {
   updateSessionBackupManifest
 } from "../src/backup.js";
 import { getStatus, renderStatus, runRestore, runSwitch, runSync } from "../src/service.js";
-import { DEFAULT_BACKUP_RETENTION_COUNT } from "../src/constants.js";
+import { DB_FILE_BASENAME, DEFAULT_BACKUP_RETENTION_COUNT, SQLITE_DIR_BASENAME } from "../src/constants.js";
 import { getUnsupportedNodeVersionMessage } from "../src/node-version.js";
 import { applySessionChanges, collectSessionChanges } from "../src/session-files.js";
 
@@ -94,8 +94,17 @@ async function writeGlobalState(codexHome, value) {
   await fs.writeFile(path.join(codexHome, ".codex-global-state.json.bak"), text, "utf8");
 }
 
+function stateDbPath(codexHome) {
+  return path.join(codexHome, SQLITE_DIR_BASENAME, DB_FILE_BASENAME);
+}
+
+function legacyStateDbPath(codexHome) {
+  return path.join(codexHome, DB_FILE_BASENAME);
+}
+
 async function writeStateDb(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+  const dbPath = stateDbPath(codexHome);
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -117,7 +126,8 @@ async function writeStateDb(codexHome, rows) {
 }
 
 async function writeStateDbWithUserEventColumn(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+  const dbPath = stateDbPath(codexHome);
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -140,7 +150,8 @@ async function writeStateDbWithUserEventColumn(codexHome, rows) {
 }
 
 async function writeStateDbForProjectVisibility(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+  const dbPath = stateDbPath(codexHome);
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -271,13 +282,18 @@ test("runSync rewrites rollout files and sqlite, then restore reverts both", asy
   assert.equal(syncResult.changedSessionFiles, 2);
   assert.deepEqual(syncResult.skippedLockedRolloutFiles, []);
   assert.equal(syncResult.sqliteRowsUpdated, 2);
+  const backupMetadata = JSON.parse(await fs.readFile(path.join(syncResult.backupDir, "metadata.json"), "utf8"));
+  assert.deepEqual(
+    backupMetadata.dbFiles.map((fileName) => fileName.replaceAll("\\", "/")),
+    ["sqlite/state_5.sqlite"]
+  );
 
   const syncedSession = await fs.readFile(sessionPath, "utf8");
   const syncedArchived = await fs.readFile(archivedPath, "utf8");
   assert.match(syncedSession, /"model_provider":"openai"/);
   assert.match(syncedArchived, /"model_provider":"openai"/);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const providers = db
       .prepare("SELECT id, model_provider FROM threads ORDER BY id")
@@ -352,7 +368,7 @@ test("runSync repairs SQLite has_user_event from rollout user messages", async (
   assert.equal(syncResult.sqliteRowsUpdated, 1);
   assert.equal(syncResult.sqliteUserEventRowsUpdated, 1);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT has_user_event FROM threads WHERE id = ?")
@@ -390,7 +406,7 @@ test("runSync repairs SQLite cwd from rollout session metadata", async () => {
   assert.equal(syncResult.sqliteRowsUpdated, 1);
   assert.equal(syncResult.sqliteCwdRowsUpdated, 1);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT cwd FROM threads WHERE id = ?")
@@ -427,7 +443,7 @@ test("runSync normalizes extended rollout cwd before repairing SQLite", async ()
   assert.equal(syncResult.sqliteRowsUpdated, 1);
   assert.equal(syncResult.sqliteCwdRowsUpdated, 1);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT cwd FROM threads WHERE id = ?")
@@ -536,8 +552,38 @@ test("status reports implicit default provider and rollout/sqlite counts", async
   assert.equal(status.currentProviderImplicit, true);
   assert.deepEqual(status.rolloutCounts.sessions, { apigather: 1 });
   assert.deepEqual(status.sqliteCounts.archived_sessions, { openai: 1 });
+  assert.equal(status.stateDbLocation.source, "sqlite-dir");
+  assert.equal(status.stateDbLocation.path, stateDbPath(codexHome));
   assert.equal(status.backupSummary.count, 2);
   assert.equal(status.backupSummary.totalBytes, backupOneBytes + backupTwoBytes);
+  assert.match(renderStatus(status), new RegExp(`database: ${stateDbPath(codexHome).replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")}`));
+});
+
+test("status falls back to legacy root sqlite database", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome);
+  const sqliteDir = path.dirname(stateDbPath(codexHome));
+  await fs.mkdir(sqliteDir, { recursive: true });
+  const db = new DatabaseSync(legacyStateDbPath(codexHome));
+  try {
+    db.exec(`
+      CREATE TABLE threads (
+        id TEXT PRIMARY KEY,
+        model_provider TEXT,
+        archived INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+    db.prepare("INSERT INTO threads (id, model_provider, archived) VALUES (?, ?, ?)").run("legacy-thread", "openai", 0);
+  } finally {
+    db.close();
+  }
+
+  const status = await getStatus({ codexHome });
+
+  assert.equal(status.stateDbLocation.source, "legacy-root");
+  assert.equal(status.stateDbLocation.path, legacyStateDbPath(codexHome));
+  assert.deepEqual(status.sqliteCounts.sessions, { openai: 1 });
+  assert.match(renderStatus(status), /legacy root/);
 });
 
 test("status reports pending SQLite user-event and cwd repairs", async () => {
@@ -624,7 +670,7 @@ test("runSync leaves rollout files and sqlite untouched when sqlite is locked", 
     { id: "thread-a", model_provider: "apigather", archived: false }
   ]);
 
-  const lockDb = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const lockDb = new DatabaseSync(stateDbPath(codexHome));
   try {
     lockDb.exec("BEGIN IMMEDIATE");
     await assert.rejects(
@@ -643,7 +689,7 @@ test("runSync leaves rollout files and sqlite untouched when sqlite is locked", 
   const rollout = await fs.readFile(sessionPath, "utf8");
   assert.match(rollout, /"model_provider":"apigather"/);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT model_provider FROM threads WHERE id = ?")
@@ -683,7 +729,7 @@ test("runSync skips locked rollout files and still updates sqlite", async () => 
   const rollout = await fs.readFile(sessionPath, "utf8");
   assert.match(rollout, /"model_provider":"apigather"/);
 
-  const db = new DatabaseSync(path.join(codexHome, "state_5.sqlite"));
+  const db = new DatabaseSync(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT model_provider FROM threads WHERE id = ?")
@@ -916,7 +962,8 @@ test("runSync fails before rollout rewrite when SQLite is malformed", async () =
   await writeConfig(codexHome, 'model_provider = "openai"');
   const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-malformed-db.jsonl");
   await writeRollout(sessionPath, "thread-malformed", "apigather");
-  await fs.writeFile(path.join(codexHome, "state_5.sqlite"), "not sqlite", "utf8");
+  await fs.mkdir(path.dirname(stateDbPath(codexHome)), { recursive: true });
+  await fs.writeFile(stateDbPath(codexHome), "not sqlite", "utf8");
 
   await assert.rejects(
     () => runSync({ codexHome }),
@@ -929,7 +976,8 @@ test("status reports malformed SQLite without failing", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"');
   await writeRollout(path.join(codexHome, "sessions", "2026", "03", "19", "rollout-status-db.jsonl"), "thread-status", "openai");
-  await fs.writeFile(path.join(codexHome, "state_5.sqlite"), "not sqlite", "utf8");
+  await fs.mkdir(path.dirname(stateDbPath(codexHome)), { recursive: true });
+  await fs.writeFile(stateDbPath(codexHome), "not sqlite", "utf8");
 
   const status = await getStatus({ codexHome });
   assert.equal(status.sqliteCounts.unreadable, true);


### PR DESCRIPTION
## Summary

- Detect the active Codex state database before reading or writing SQLite metadata.
- Prefer the current `sqlite/state_5.sqlite` layout and fall back to the legacy root `state_5.sqlite` layout.
- Show the detected database path in `status` / GUI status output.
- Back up and restore database files using the detected relative path, so `sqlite/state_5.sqlite` is preserved correctly.

## Testing

- `node --test`
- `dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj`
- `dotnet build desktop/CodexProviderSync.App/CodexProviderSync.App.csproj`
- Read-only real Codex home check: `node src/cli.js status --codex-home <path>` reported `sqlite/state_5.sqlite`

Note: `dotnet build desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj --source https://api.nuget.org/v3/index.json` was attempted, but restore did not complete before the local timeout while downloading Avalonia packages. Package search against nuget.org did resolve `Avalonia.Desktop 12.0.4`.