### PR TITLE
[codex] Support Codex SQLite home path

### DIFF
--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -62,6 +62,70 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSync_UsesConfigSqliteHomeForSqliteStateAndBackupRestore()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        string sqliteHome = Path.Combine(fixture.Root, "codex-sqlite");
+        await fixture.WriteConfigAsync($"model_provider = \"openai\"\nsqlite_home = \"{sqliteHome.Replace('\\', '/')}\"");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-sqlite-home.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-sqlite-home", "apigather");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-sqlite-home", "apigather", false)
+        ], sqliteHome);
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome, provider: "openai");
+
+        Assert.Equal(Path.Combine(sqliteHome, "state_5.sqlite"), result.SqliteDbPath);
+        Assert.Equal(1, result.SqliteRowsUpdated);
+
+        await using (SqliteConnection connection = fixture.OpenSqliteConnection(sqliteHome))
+        {
+            await connection.OpenAsync();
+            SqliteCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT model_provider FROM threads WHERE id = 'thread-sqlite-home'";
+            Assert.Equal("openai", await command.ExecuteScalarAsync());
+        }
+
+        using JsonDocument metadata = JsonDocument.Parse(await File.ReadAllTextAsync(Path.Combine(result.BackupDir, "metadata.json")));
+        Assert.Equal(Path.Combine(sqliteHome, "state_5.sqlite"), metadata.RootElement.GetProperty("dbPath").GetString());
+        Assert.Equal(Path.GetRelativePath(fixture.CodexHome, sqliteHome), metadata.RootElement.GetProperty("dbRelativeDir").GetString());
+
+        await service.RunRestoreAsync(fixture.CodexHome, result.BackupDir);
+        await using SqliteConnection restoredConnection = fixture.OpenSqliteConnection(sqliteHome);
+        await restoredConnection.OpenAsync();
+        SqliteCommand restoredCommand = restoredConnection.CreateCommand();
+        restoredCommand.CommandText = "SELECT model_provider FROM threads WHERE id = 'thread-sqlite-home'";
+        Assert.Equal("apigather", await restoredCommand.ExecuteScalarAsync());
+    }
+
+    [Fact]
+    public async Task StatusAndSync_FallBackToNestedSqliteDirectoryWhenRootDatabaseIsAbsent()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        string sqliteHome = Path.Combine(fixture.CodexHome, "sqlite");
+        await fixture.WriteConfigAsync("model_provider = \"openai\"");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-nested-sqlite.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-nested-sqlite", "apigather");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-nested-sqlite", "apigather", false)
+        ], sqliteHome);
+
+        CodexSyncService service = new();
+        StatusSnapshot status = await service.GetStatusAsync(fixture.CodexHome);
+
+        Assert.Equal(Path.Combine(sqliteHome, "state_5.sqlite"), status.SqliteDbPath);
+        Assert.Equal(1, status.SqliteCounts?.Sessions["apigather"]);
+        Assert.Contains($"DB path: {Path.Combine(sqliteHome, "state_5.sqlite")}", TextFormatter.FormatStatus(status));
+
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome, provider: "openai");
+        Assert.Equal(Path.Combine(sqliteHome, "state_5.sqlite"), result.SqliteDbPath);
+        Assert.Equal(1, result.SqliteRowsUpdated);
+    }
+
+    [Fact]
     public async Task RunSwitch_UpdatesConfigAndSyncsProviderMetadata()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();

--- a/desktop/CodexProviderSync.Core.Tests/SettingsAndDiscoveryTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/SettingsAndDiscoveryTests.cs
@@ -46,6 +46,7 @@ public sealed class SettingsAndDiscoveryTests
             },
             LockedRolloutFiles = [],
             EncryptedContentCounts = new ProviderCounts(),
+            SqliteDbPath = "C:\\Users\\Administrator\\.codex\\state_5.sqlite",
             SqliteCounts = new ProviderCounts
             {
                 Sessions = new Dictionary<string, int>(StringComparer.Ordinal),

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -124,10 +124,9 @@ internal sealed class TestCodexHomeFixture
         return totalBytes;
     }
 
-    public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
+    public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows, string? sqliteHome = null)
     {
-        string dbPath = Path.Combine(CodexHome, "state_5.sqlite");
-        await using SqliteConnection connection = OpenSqliteConnection();
+        await using SqliteConnection connection = OpenSqliteConnection(sqliteHome);
         await connection.OpenAsync();
         SqliteCommand create = connection.CreateCommand();
         create.CommandText = """
@@ -157,7 +156,6 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbWithUserEventColumnAsync(IEnumerable<(string Id, string ModelProvider, bool Archived, bool HasUserEvent)> rows)
     {
-        string dbPath = Path.Combine(CodexHome, "state_5.sqlite");
         await using SqliteConnection connection = OpenSqliteConnection();
         await connection.OpenAsync();
         SqliteCommand create = connection.CreateCommand();
@@ -288,8 +286,10 @@ internal sealed class TestCodexHomeFixture
         }
     }
 
-    public SqliteConnection OpenSqliteConnection()
+    public SqliteConnection OpenSqliteConnection(string? sqliteHome = null)
     {
-        return new SqliteConnection($"Data Source={Path.Combine(CodexHome, "state_5.sqlite")};Mode=ReadWriteCreate;Pooling=False");
+        string effectiveSqliteHome = sqliteHome ?? CodexHome;
+        Directory.CreateDirectory(effectiveSqliteHome);
+        return new SqliteConnection($"Data Source={Path.Combine(effectiveSqliteHome, "state_5.sqlite")};Mode=ReadWriteCreate;Pooling=False");
     }
 }

--- a/desktop/CodexProviderSync.Core/BackupService.cs
+++ b/desktop/CodexProviderSync.Core/BackupService.cs
@@ -24,12 +24,14 @@ public sealed class BackupService
         string backupDir = Path.Combine(backupRoot, DateTimeOffset.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'"));
         string dbDir = Path.Combine(backupDir, "db");
         Directory.CreateDirectory(dbDir);
+        string sqliteHome = _sqliteStateService.ResolveSqliteHome(codexHome);
+        string dbRelativeDir = Path.GetRelativePath(codexHome, sqliteHome);
 
         List<string> copiedDbFiles = [];
         foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
         {
             string fileName = $"{AppConstants.DbFileBasename}{suffix}";
-            if (await CopyIfPresentAsync(Path.Combine(codexHome, fileName), Path.Combine(dbDir, fileName), overwrite: false))
+            if (await CopyIfPresentAsync(Path.Combine(sqliteHome, fileName), Path.Combine(dbDir, fileName), overwrite: false))
             {
                 copiedDbFiles.Add(fileName);
             }
@@ -78,8 +80,11 @@ public sealed class BackupService
             Version = 1,
             Namespace = AppConstants.BackupNamespace,
             CodexHome = codexHome,
+            SqliteHome = sqliteHome,
             TargetProvider = targetProvider,
             CreatedAt = createdAt,
+            DbPath = Path.Combine(sqliteHome, AppConstants.DbFileBasename),
+            DbRelativeDir = dbRelativeDir,
             DbFiles = copiedDbFiles,
             ChangedSessionFiles = sessionChanges.Count
         };
@@ -136,13 +141,14 @@ public sealed class BackupService
         if (options.RestoreDatabase)
         {
             await _sqliteStateService.AssertSqliteWritableAsync(codexHome);
+            string sqliteHome = _sqliteStateService.ResolveSqliteHome(codexHome);
             string dbDir = Path.Combine(normalizedBackupDir, "db");
             HashSet<string> backedUpFiles = new(metadata.DbFiles, StringComparer.Ordinal);
 
             foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
             {
                 string fileName = $"{AppConstants.DbFileBasename}{suffix}";
-                string targetPath = Path.Combine(codexHome, fileName);
+                string targetPath = Path.Combine(sqliteHome, fileName);
                 if (!backedUpFiles.Contains(fileName) && File.Exists(targetPath))
                 {
                     File.Delete(targetPath);
@@ -151,7 +157,7 @@ public sealed class BackupService
 
             foreach (string fileName in metadata.DbFiles)
             {
-                await CopyIfPresentAsync(Path.Combine(dbDir, fileName), Path.Combine(codexHome, fileName), overwrite: true);
+                await CopyIfPresentAsync(Path.Combine(dbDir, fileName), Path.Combine(sqliteHome, fileName), overwrite: true);
             }
         }
 
@@ -203,8 +209,11 @@ public sealed class BackupService
             Version = metadata.Version,
             Namespace = metadata.Namespace,
             CodexHome = metadata.CodexHome,
+            SqliteHome = metadata.SqliteHome,
             TargetProvider = metadata.TargetProvider,
             CreatedAt = metadata.CreatedAt,
+            DbPath = metadata.DbPath,
+            DbRelativeDir = metadata.DbRelativeDir,
             DbFiles = metadata.DbFiles,
             ChangedSessionFiles = sessionChanges.Count
         };

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -12,15 +12,33 @@ public sealed class CodexSyncService
     private readonly ProviderDiscoveryService _providerDiscoveryService;
 
     public CodexSyncService()
+        : this(CreateDefaultDependencies())
+    {
+    }
+
+    private CodexSyncService(DefaultDependencies dependencies)
         : this(
+            dependencies.CodexHomeService,
+            dependencies.ConfigFileService,
+            dependencies.SessionRolloutService,
+            dependencies.SqliteStateService,
+            dependencies.GlobalStateService,
+            dependencies.LockService,
+            dependencies.ProviderDiscoveryService)
+    {
+    }
+
+    private static DefaultDependencies CreateDefaultDependencies()
+    {
+        SqliteStateService sqliteStateService = new();
+        return new DefaultDependencies(
             new CodexHomeService(),
             new ConfigFileService(),
             new SessionRolloutService(),
-            new SqliteStateService(),
-            new GlobalStateService(),
+            sqliteStateService,
+            new GlobalStateService(sqliteStateService),
             new LockService(),
-            new ProviderDiscoveryService())
-    {
+            new ProviderDiscoveryService());
     }
 
     public CodexSyncService(
@@ -51,6 +69,7 @@ public sealed class CodexSyncService
         IReadOnlyList<string> configuredProviders = _configFileService.ListConfiguredProviderIds(configText);
         SessionChangeCollection rolloutInfo = await _sessionRolloutService.CollectSessionChangesAsync(codexHome, "__status_only__", skipLockedReads: true);
         ProviderCounts? sqliteCounts = await _sqliteStateService.ReadSqliteProviderCountsAsync(codexHome);
+        string sqliteDbPath = _sqliteStateService.StateDbPath(codexHome);
         SqliteRepairStats? sqliteRepairStats = sqliteCounts is not null && !sqliteCounts.Unreadable
             ? await _sqliteStateService.ReadSqliteRepairStatsAsync(
                 codexHome,
@@ -71,6 +90,7 @@ public sealed class CodexSyncService
             LockedRolloutFiles = rolloutInfo.LockedPaths,
             EncryptedContentCounts = rolloutInfo.EncryptedContentCounts,
             EncryptedContentWarning = BuildEncryptedContentWarning(rolloutInfo.EncryptedContentCounts, currentProvider.Provider),
+            SqliteDbPath = sqliteDbPath,
             SqliteCounts = sqliteCounts,
             SqliteRepairStats = sqliteRepairStats,
             ProjectThreadVisibility = projectThreadVisibility,
@@ -107,6 +127,7 @@ public sealed class CodexSyncService
         string configText = await _configFileService.ReadConfigTextAsync(configPath);
         CurrentProviderInfo current = _configFileService.ReadCurrentProviderFromConfigText(configText);
         string targetProvider = provider ?? current.Provider ?? AppConstants.DefaultProvider;
+        string sqliteDbPath = _sqliteStateService.StateDbPath(codexHome);
 
         await using LockHandle _ = await _lockService.AcquireLockAsync(codexHome, "sync");
 
@@ -173,6 +194,7 @@ public sealed class CodexSyncService
                 CodexHome = codexHome,
                 TargetProvider = targetProvider,
                 PreviousProvider = current.Provider ?? AppConstants.DefaultProvider,
+                SqliteDbPath = sqliteDbPath,
                 BackupDir = backupDir,
                 ChangedSessionFiles = applyResult?.AppliedCount ?? 0,
                 SkippedLockedRolloutFiles = skippedRolloutFiles,
@@ -259,6 +281,7 @@ public sealed class CodexSyncService
                 CodexHome = result.CodexHome,
                 TargetProvider = result.TargetProvider,
                 PreviousProvider = result.PreviousProvider,
+                SqliteDbPath = result.SqliteDbPath,
                 BackupDir = result.BackupDir,
                 ChangedSessionFiles = result.ChangedSessionFiles,
                 SkippedLockedRolloutFiles = result.SkippedLockedRolloutFiles,
@@ -332,4 +355,13 @@ public sealed class CodexSyncService
 
         return $"Encrypted content warning: {total} rollout file(s) contain encrypted_content from provider(s) {string.Join(", ", riskyProviders)}. Visibility metadata can be synchronized to {targetProvider}, but continuing or compacting those histories may fail with invalid_encrypted_content. Return to the original provider/account or start a new session if you need reliable continuation.";
     }
+
+    private sealed record DefaultDependencies(
+        CodexHomeService CodexHomeService,
+        ConfigFileService ConfigFileService,
+        SessionRolloutService SessionRolloutService,
+        SqliteStateService SqliteStateService,
+        GlobalStateService GlobalStateService,
+        LockService LockService,
+        ProviderDiscoveryService ProviderDiscoveryService);
 }

--- a/desktop/CodexProviderSync.Core/ConfigFileService.cs
+++ b/desktop/CodexProviderSync.Core/ConfigFileService.cs
@@ -46,6 +46,31 @@ public sealed partial class ConfigFileService
         return new CurrentProviderInfo(AppConstants.DefaultProvider, true);
     }
 
+    public string? ReadSqliteHomeFromConfigText(string configText)
+    {
+        foreach (string rawLine in SplitLines(configText))
+        {
+            string trimmed = rawLine.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (trimmed.StartsWith('['))
+            {
+                break;
+            }
+
+            Match match = Regex.Match(trimmed, "^sqlite_home\\s*=\\s*\"([^\"]+)\"\\s*$");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+
+        return null;
+    }
+
     public IReadOnlyList<string> ListConfiguredProviderIds(string configText)
     {
         HashSet<string> providerIds = new(StringComparer.Ordinal)

--- a/desktop/CodexProviderSync.Core/GlobalStateService.cs
+++ b/desktop/CodexProviderSync.Core/GlobalStateService.cs
@@ -6,6 +6,18 @@ namespace CodexProviderSync.Core;
 
 public sealed class GlobalStateService
 {
+    private readonly SqliteStateService _sqliteStateService;
+
+    public GlobalStateService()
+        : this(new SqliteStateService())
+    {
+    }
+
+    public GlobalStateService(SqliteStateService sqliteStateService)
+    {
+        _sqliteStateService = sqliteStateService;
+    }
+
     public string StatePath(string codexHome)
     {
         return Path.Combine(codexHome, AppConstants.GlobalStateFileBasename);
@@ -18,7 +30,7 @@ public sealed class GlobalStateService
 
     public async Task<IReadOnlyList<ThreadCwdStat>> ReadThreadCwdStatsAsync(string codexHome)
     {
-        string dbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
+        string dbPath = _sqliteStateService.StateDbPath(codexHome);
         if (!File.Exists(dbPath))
         {
             return [];
@@ -191,7 +203,7 @@ public sealed class GlobalStateService
             return [];
         }
 
-        string dbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
+        string dbPath = _sqliteStateService.StateDbPath(codexHome);
         if (!File.Exists(dbPath))
         {
             return roots

--- a/desktop/CodexProviderSync.Core/Models.cs
+++ b/desktop/CodexProviderSync.Core/Models.cs
@@ -22,6 +22,7 @@ public sealed class StatusSnapshot
     public required IReadOnlyList<string> LockedRolloutFiles { get; init; }
     public required ProviderCounts EncryptedContentCounts { get; init; }
     public string? EncryptedContentWarning { get; init; }
+    public required string SqliteDbPath { get; init; }
     public required ProviderCounts? SqliteCounts { get; init; }
     public SqliteRepairStats? SqliteRepairStats { get; init; }
     public IReadOnlyList<ProjectThreadVisibility> ProjectThreadVisibility { get; init; } = [];
@@ -90,6 +91,7 @@ public sealed class SyncResult
     public required string CodexHome { get; init; }
     public required string TargetProvider { get; init; }
     public required string PreviousProvider { get; init; }
+    public required string SqliteDbPath { get; init; }
     public required string BackupDir { get; init; }
     public required int ChangedSessionFiles { get; init; }
     public required IReadOnlyList<string> SkippedLockedRolloutFiles { get; init; }
@@ -175,8 +177,11 @@ internal sealed class BackupMetadataFile
     public int Version { get; init; }
     public required string Namespace { get; init; }
     public required string CodexHome { get; init; }
+    public string? SqliteHome { get; init; }
     public required string TargetProvider { get; init; }
     public required DateTimeOffset CreatedAt { get; init; }
+    public string? DbPath { get; init; }
+    public string? DbRelativeDir { get; init; }
     public required List<string> DbFiles { get; init; }
     public int ChangedSessionFiles { get; init; }
 }

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -5,6 +5,7 @@ namespace CodexProviderSync.Core;
 public sealed class SqliteStateService
 {
     private const int DefaultBusyTimeoutMs = 5000;
+    private readonly ConfigFileService _configFileService = new();
 
     static SqliteStateService()
     {
@@ -13,7 +14,36 @@ public sealed class SqliteStateService
 
     public string StateDbPath(string codexHome)
     {
-        return Path.Combine(codexHome, AppConstants.DbFileBasename);
+        return Path.Combine(ResolveSqliteHome(codexHome), AppConstants.DbFileBasename);
+    }
+
+    public string ResolveSqliteHome(string codexHome)
+    {
+        string configPath = Path.Combine(codexHome, "config.toml");
+        if (File.Exists(configPath))
+        {
+            string? configuredSqliteHome = _configFileService.ReadSqliteHomeFromConfigText(File.ReadAllText(configPath));
+            if (!string.IsNullOrWhiteSpace(configuredSqliteHome))
+            {
+                return Path.GetFullPath(configuredSqliteHome.Trim());
+            }
+        }
+
+        string? environmentSqliteHome = Environment.GetEnvironmentVariable("CODEX_SQLITE_HOME");
+        if (!string.IsNullOrWhiteSpace(environmentSqliteHome))
+        {
+            return Path.GetFullPath(environmentSqliteHome.Trim());
+        }
+
+        string defaultDbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
+        string nestedSqliteHome = Path.Combine(codexHome, "sqlite");
+        string nestedDbPath = Path.Combine(nestedSqliteHome, AppConstants.DbFileBasename);
+        if (!File.Exists(defaultDbPath) && File.Exists(nestedDbPath))
+        {
+            return nestedSqliteHome;
+        }
+
+        return codexHome;
     }
 
     public async Task<ProviderCounts?> ReadSqliteProviderCountsAsync(string codexHome)

--- a/desktop/CodexProviderSync.Core/TextFormatter.cs
+++ b/desktop/CodexProviderSync.Core/TextFormatter.cs
@@ -21,7 +21,8 @@ public static class TextFormatter
             $"  encrypted_content sessions: {FormatCounts(status.EncryptedContentCounts.Sessions)}",
             $"  encrypted_content archived_sessions: {FormatCounts(status.EncryptedContentCounts.ArchivedSessions)}",
             string.Empty,
-            "SQLite state:"
+            "SQLite state:",
+            $"  DB path: {status.SqliteDbPath}"
         ];
 
         if (!string.IsNullOrWhiteSpace(status.EncryptedContentWarning))
@@ -77,6 +78,7 @@ public static class TextFormatter
         [
             $"{label} provider: {result.TargetProvider}",
             $"Codex home: {result.CodexHome}",
+            $"SQLite state DB: {result.SqliteDbPath}",
             $"Backup: {result.BackupDir}",
             $"Updated rollout files: {result.ChangedSessionFiles}",
             $"Updated SQLite rows: {result.SqliteRowsUpdated}{(result.SqlitePresent ? string.Empty : " (state_5.sqlite not found)")}"

--- a/src/backup.js
+++ b/src/backup.js
@@ -10,7 +10,7 @@ import {
   GLOBAL_STATE_FILE_BASENAME
 } from "./constants.js";
 import { assertSessionFilesWritable, restoreSessionChanges } from "./session-files.js";
-import { assertSqliteWritable } from "./sqlite-state.js";
+import { assertSqliteWritable, resolveSqliteHome } from "./sqlite-state.js";
 
 function timestampSlug(date = new Date()) {
   return date.toISOString().replaceAll(":", "").replaceAll("-", "").replace(".", "");
@@ -53,11 +53,13 @@ export async function createBackup({
   const backupDir = path.join(backupRoot, timestampSlug());
   const dbDir = path.join(backupDir, "db");
   await fs.mkdir(dbDir, { recursive: true });
+  const sqliteHome = await resolveSqliteHome(codexHome);
+  const dbRelativeDir = path.relative(codexHome, sqliteHome) || ".";
 
   const copiedDbFiles = [];
   for (const suffix of ["", "-shm", "-wal"]) {
     const fileName = `${DB_FILE_BASENAME}${suffix}`;
-    const copied = await copyIfPresent(path.join(codexHome, fileName), path.join(dbDir, fileName));
+    const copied = await copyIfPresent(path.join(sqliteHome, fileName), path.join(dbDir, fileName));
     if (copied) {
       copiedDbFiles.push(fileName);
     }
@@ -96,8 +98,11 @@ export async function createBackup({
         version: 1,
         namespace: BACKUP_NAMESPACE,
         codexHome,
+        sqliteHome,
         targetProvider,
         createdAt: sessionManifest.createdAt,
+        dbPath: path.join(sqliteHome, DB_FILE_BASENAME),
+        dbRelativeDir,
         dbFiles: copiedDbFiles,
         changedSessionFiles: sessionChanges.length
       },
@@ -191,17 +196,18 @@ export async function restoreBackup(backupDir, codexHome, options = {}) {
 
   if (restoreDatabase) {
     await assertSqliteWritable(codexHome);
+    const sqliteHome = await resolveSqliteHome(codexHome);
 
     const dbDir = path.join(backupDir, "db");
     const backedUpFiles = new Set(metadata.dbFiles ?? []);
     for (const suffix of ["", "-shm", "-wal"]) {
       const fileName = `${DB_FILE_BASENAME}${suffix}`;
       if (!backedUpFiles.has(fileName)) {
-        await removeIfPresent(path.join(codexHome, fileName));
+        await removeIfPresent(path.join(sqliteHome, fileName));
       }
     }
     for (const fileName of metadata.dbFiles ?? []) {
-      await copyIfPresent(path.join(dbDir, fileName), path.join(codexHome, fileName));
+      await copyIfPresent(path.join(dbDir, fileName), path.join(sqliteHome, fileName));
     }
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -56,6 +56,7 @@ function summarizeSync(result, label) {
   const lines = [
     `${label} provider: ${result.targetProvider}`,
     `Codex home: ${result.codexHome}`,
+    `SQLite state DB: ${result.sqliteDbPath}`,
     `Backup: ${result.backupDir}`,
     `Backup creation time: ${formatDuration(result.backupDurationMs ?? 0)}`,
     `Updated rollout files: ${result.changedSessionFiles}`,

--- a/src/config-file.js
+++ b/src/config-file.js
@@ -32,6 +32,24 @@ export function readCurrentProviderFromConfigText(configText) {
   return { provider: DEFAULT_PROVIDER, implicit: true };
 }
 
+export function readSqliteHomeFromConfigText(configText) {
+  const lines = splitLines(configText);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    if (trimmed.startsWith("[")) {
+      break;
+    }
+    const match = trimmed.match(/^sqlite_home\s*=\s*"([^"]+)"\s*$/);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
 export function listConfiguredProviderIds(configText) {
   const providerIds = new Set([DEFAULT_PROVIDER]);
   const regex = /^\[model_providers\.([A-Za-z0-9_.-]+)]\s*$/gm;

--- a/src/service.js
+++ b/src/service.js
@@ -35,6 +35,7 @@ import {
   assertSqliteWritable,
   readSqliteProviderCounts,
   readSqliteRepairStats,
+  resolveStateDbPath,
   updateSqliteProvider
 } from "./sqlite-state.js";
 import {
@@ -109,6 +110,7 @@ export async function getStatus({ codexHome: explicitCodexHome } = {}) {
     threadCwdById
   } = await collectSessionChanges(codexHome, "__status_only__", { skipLockedReads: true });
   const sqliteCounts = await readSqliteProviderCounts(codexHome);
+  const sqliteDbPath = await resolveStateDbPath(codexHome);
   const sqliteRepairStats = sqliteCounts && !sqliteCounts.unreadable
     ? await readSqliteRepairStats(codexHome, { userEventThreadIds, threadCwdById })
     : null;
@@ -126,6 +128,7 @@ export async function getStatus({ codexHome: explicitCodexHome } = {}) {
     lockedRolloutFiles: lockedPaths,
     encryptedContentCounts,
     encryptedContentWarning: buildEncryptedContentWarning(encryptedContentCounts, current.provider ?? DEFAULT_PROVIDER),
+    sqliteDbPath,
     sqliteCounts,
     sqliteRepairStats,
     projectThreadVisibility,
@@ -160,6 +163,7 @@ export function renderStatus(status) {
 
   lines.push("");
   lines.push("SQLite state:");
+  lines.push(`  DB path: ${status.sqliteDbPath}`);
   if (status.sqliteCounts?.unreadable) {
     lines.push(`  ${status.sqliteCounts.error ?? "state_5.sqlite is malformed or unreadable"}`);
   } else if (!status.sqliteCounts) {
@@ -204,6 +208,7 @@ export async function runSync({
 
   const codexHome = normalizeCodexHome(explicitCodexHome);
   await ensureCodexHome(codexHome);
+  const sqliteDbPath = await resolveStateDbPath(codexHome);
   const configPath = path.join(codexHome, "config.toml");
   const configText = await readConfigText(configPath);
   const current = readCurrentProviderFromConfigText(configText);
@@ -337,6 +342,7 @@ export async function runSync({
       });
       return {
         codexHome,
+        sqliteDbPath,
         targetProvider,
         previousProvider: current.provider,
         backupDir,

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -3,11 +3,63 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
 import { DB_FILE_BASENAME } from "./constants.js";
+import { readConfigText, readSqliteHomeFromConfigText } from "./config-file.js";
 
 const DEFAULT_BUSY_TIMEOUT_MS = 5000;
 
 export function stateDbPath(codexHome) {
   return path.join(codexHome, DB_FILE_BASENAME);
+}
+
+export function sqliteDbPath(sqliteHome) {
+  return path.join(sqliteHome, DB_FILE_BASENAME);
+}
+
+function resolveSqliteHomeValue(value) {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+  return path.resolve(value.trim());
+}
+
+export async function resolveSqliteHome(codexHome) {
+  const configPath = path.join(codexHome, "config.toml");
+  try {
+    const configText = await readConfigText(configPath);
+    const configuredSqliteHome = resolveSqliteHomeValue(readSqliteHomeFromConfigText(configText));
+    if (configuredSqliteHome) {
+      return configuredSqliteHome;
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const environmentSqliteHome = resolveSqliteHomeValue(process.env.CODEX_SQLITE_HOME);
+  if (environmentSqliteHome) {
+    return environmentSqliteHome;
+  }
+
+  const defaultDbPath = stateDbPath(codexHome);
+  const nestedSqliteHome = path.join(codexHome, "sqlite");
+  const nestedDbPath = sqliteDbPath(nestedSqliteHome);
+  try {
+    await fs.access(defaultDbPath);
+  } catch {
+    try {
+      await fs.access(nestedDbPath);
+      return nestedSqliteHome;
+    } catch {
+      // Fall back to Codex's documented default when neither database is present.
+    }
+  }
+
+  return codexHome;
+}
+
+export async function resolveStateDbPath(codexHome) {
+  return sqliteDbPath(await resolveSqliteHome(codexHome));
 }
 
 function openDatabase(dbPath) {
@@ -63,7 +115,7 @@ export function wrapSqliteMalformedError(error, action) {
 }
 
 export async function readSqliteProviderCounts(codexHome) {
-  const dbPath = stateDbPath(codexHome);
+  const dbPath = await resolveStateDbPath(codexHome);
   try {
     await fs.access(dbPath);
   } catch {
@@ -118,7 +170,7 @@ export async function readSqliteProviderCounts(codexHome) {
 }
 
 export async function readSqliteRepairStats(codexHome, options = {}) {
-  const dbPath = stateDbPath(codexHome);
+  const dbPath = await resolveStateDbPath(codexHome);
   try {
     await fs.access(dbPath);
   } catch {
@@ -168,7 +220,7 @@ export async function readSqliteRepairStats(codexHome, options = {}) {
 }
 
 export async function assertSqliteWritable(codexHome, options = {}) {
-  const dbPath = stateDbPath(codexHome);
+  const dbPath = await resolveStateDbPath(codexHome);
   try {
     await fs.access(dbPath);
   } catch {
@@ -198,7 +250,7 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
     ? (maybeOptions ?? {})
     : (afterUpdateOrOptions ?? {});
 
-  const dbPath = stateDbPath(codexHome);
+  const dbPath = await resolveStateDbPath(codexHome);
   try {
     await fs.access(dbPath);
   } catch {

--- a/src/workspace-roots.js
+++ b/src/workspace-roots.js
@@ -7,7 +7,7 @@ import {
   GLOBAL_STATE_FILE_BASENAME
 } from "./constants.js";
 import {
-  stateDbPath,
+  resolveStateDbPath,
   wrapSqliteBusyError,
   wrapSqliteMalformedError
 } from "./sqlite-state.js";
@@ -164,7 +164,7 @@ function copyResolvedObjectKeys(input, cwdStats) {
 }
 
 export async function readThreadCwdStats(codexHome) {
-  const dbPath = stateDbPath(codexHome);
+  const dbPath = await resolveStateDbPath(codexHome);
   try {
     await fs.access(dbPath);
   } catch {
@@ -258,7 +258,7 @@ export async function readProjectThreadVisibility(codexHome, options = {}) {
     return [];
   }
 
-  const dbPath = stateDbPath(codexHome);
+  const dbPath = await resolveStateDbPath(codexHome);
   try {
     await fs.access(dbPath);
   } catch {

--- a/test/config-file.test.js
+++ b/test/config-file.test.js
@@ -5,6 +5,7 @@ import {
   configDeclaresProvider,
   listConfiguredProviderIds,
   readCurrentProviderFromConfigText,
+  readSqliteHomeFromConfigText,
   setRootProviderInConfigText
 } from "../src/config-file.js";
 
@@ -53,4 +54,19 @@ base_url = "https://example.org"
   assert.deepEqual(listConfiguredProviderIds(input), ["apigather", "newapi", "openai"]);
   assert.equal(configDeclaresProvider(input, "apigather"), true);
   assert.equal(configDeclaresProvider(input, "missing"), false);
+});
+
+test("readSqliteHomeFromConfigText reads only root-level sqlite_home", () => {
+  assert.equal(readSqliteHomeFromConfigText(`
+model_provider = "openai"
+sqlite_home = "/tmp/codex-state"
+
+[features]
+sqlite_home = "/ignored"
+`), "/tmp/codex-state");
+
+  assert.equal(readSqliteHomeFromConfigText(`
+[features]
+sqlite_home = "/ignored"
+`), null);
 });

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -94,8 +94,10 @@ async function writeGlobalState(codexHome, value) {
   await fs.writeFile(path.join(codexHome, ".codex-global-state.json.bak"), text, "utf8");
 }
 
-async function writeStateDb(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+async function writeStateDb(codexHome, rows, options = {}) {
+  const sqliteHome = options.sqliteHome ?? codexHome;
+  await fs.mkdir(sqliteHome, { recursive: true });
+  const dbPath = path.join(sqliteHome, "state_5.sqlite");
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -116,8 +118,10 @@ async function writeStateDb(codexHome, rows) {
   }
 }
 
-async function writeStateDbWithUserEventColumn(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+async function writeStateDbWithUserEventColumn(codexHome, rows, options = {}) {
+  const sqliteHome = options.sqliteHome ?? codexHome;
+  await fs.mkdir(sqliteHome, { recursive: true });
+  const dbPath = path.join(sqliteHome, "state_5.sqlite");
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -139,8 +143,10 @@ async function writeStateDbWithUserEventColumn(codexHome, rows) {
   }
 }
 
-async function writeStateDbForProjectVisibility(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+async function writeStateDbForProjectVisibility(codexHome, rows, options = {}) {
+  const sqliteHome = options.sqliteHome ?? codexHome;
+  await fs.mkdir(sqliteHome, { recursive: true });
+  const dbPath = path.join(sqliteHome, "state_5.sqlite");
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -297,6 +303,62 @@ test("runSync rewrites rollout files and sqlite, then restore reverts both", asy
   const restoredArchived = await fs.readFile(archivedPath, "utf8");
   assert.match(restoredSession, /"model_provider":"apigather"/);
   assert.match(restoredArchived, /"model_provider":"newapi"/);
+});
+
+test("runSync uses config sqlite_home for SQLite state and backup restore", async () => {
+  const { codexHome, root } = await makeTempCodexHome();
+  const sqliteHome = path.join(root, "codex-sqlite");
+  await writeConfig(codexHome, `model_provider = "openai"\nsqlite_home = "${sqliteHome.replaceAll("\\", "\\\\")}"`);
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-sqlite-home.jsonl");
+  await writeRollout(sessionPath, "thread-sqlite-home", "apigather");
+  await writeStateDb(codexHome, [
+    { id: "thread-sqlite-home", model_provider: "apigather", archived: false }
+  ], { sqliteHome });
+
+  const result = await runSync({ codexHome, provider: "openai" });
+  assert.equal(result.sqliteDbPath, path.join(sqliteHome, "state_5.sqlite"));
+  assert.equal(result.sqliteRowsUpdated, 1);
+
+  const db = new DatabaseSync(path.join(sqliteHome, "state_5.sqlite"));
+  try {
+    const row = db.prepare("SELECT model_provider FROM threads WHERE id = ?").get("thread-sqlite-home");
+    assert.equal(row.model_provider, "openai");
+  } finally {
+    db.close();
+  }
+
+  const metadata = JSON.parse(await fs.readFile(path.join(result.backupDir, "metadata.json"), "utf8"));
+  assert.equal(metadata.dbPath, path.join(sqliteHome, "state_5.sqlite"));
+  assert.equal(metadata.dbRelativeDir, path.relative(codexHome, sqliteHome));
+
+  await runRestore({ codexHome, backupDir: result.backupDir });
+  const restoredDb = new DatabaseSync(path.join(sqliteHome, "state_5.sqlite"));
+  try {
+    const row = restoredDb.prepare("SELECT model_provider FROM threads WHERE id = ?").get("thread-sqlite-home");
+    assert.equal(row.model_provider, "apigather");
+  } finally {
+    restoredDb.close();
+  }
+});
+
+test("status and sync fall back to nested sqlite directory when root database is absent", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const sqliteHome = path.join(codexHome, "sqlite");
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-nested-sqlite.jsonl");
+  await writeRollout(sessionPath, "thread-nested-sqlite", "apigather");
+  await writeStateDb(codexHome, [
+    { id: "thread-nested-sqlite", model_provider: "apigather", archived: false }
+  ], { sqliteHome });
+
+  const status = await getStatus({ codexHome });
+  assert.equal(status.sqliteDbPath, path.join(sqliteHome, "state_5.sqlite"));
+  assert.deepEqual(status.sqliteCounts.sessions, { apigather: 1 });
+  assert.match(renderStatus(status), new RegExp(`DB path: ${path.join(sqliteHome, "state_5.sqlite").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+
+  const result = await runSync({ codexHome, provider: "openai" });
+  assert.equal(result.sqliteDbPath, path.join(sqliteHome, "state_5.sqlite"));
+  assert.equal(result.sqliteRowsUpdated, 1);
 });
 
 test("runSync reports stage progress and backup duration", async () => {


### PR DESCRIPTION
## Summary

- resolve Codex SQLite state from root-level `sqlite_home`, then `CODEX_SQLITE_HOME`, then the documented `CODEX_HOME` default
- fall back to `CODEX_HOME/sqlite/state_5.sqlite` when the default DB is absent and the nested DB exists, which covers current Codex Desktop app-server layouts launched outside the user's shell environment
- use the resolved SQLite path consistently for provider counts, sync updates, workspace-root diagnostics, backup, and restore in both the Node CLI and .NET Core/GUI code
- print the resolved SQLite DB path in status/sync output and record it in backup metadata

## Root Cause

Recent Codex builds can store SQLite-backed runtime state outside `CODEX_HOME`. The current Codex manual documents `sqlite_home` as an optional config setting and `CODEX_SQLITE_HOME` as the SQLite state location, with `sqlite_home` taking precedence.

Before this change, `codex-provider-sync` always used `path.join(codexHome, "state_5.sqlite")` / `Path.Combine(codexHome, "state_5.sqlite")`. On systems where Codex Desktop reads `~/.codex/sqlite/state_5.sqlite`, sync can update the legacy root database while the app-server continues to display unchanged sessions.

## Validation

- `npm test` passes: 41 tests
- Added Node regression coverage for `sqlite_home` and nested `sqlite/state_5.sqlite` fallback
- Added .NET Core regression coverage for the same cases
- Could not run `dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj` locally because `dotnet` is not installed in my environment
