### PR TITLE
Fix sync for nested SQLite state

### DIFF
--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -62,6 +62,38 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSync_RewritesRootAndNestedSqliteDatabases()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"oneapi\"");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-nested-db.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-nested", "oneapi");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-nested", "openai", false)
+        ]);
+        await fixture.WriteStateDbAsync(
+            Path.Combine("sqlite", "state_5.sqlite"),
+        [
+            ("thread-nested", "openai", false)
+        ]);
+
+        CodexSyncService service = new();
+        SyncResult syncResult = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(2, syncResult.SqliteRowsUpdated);
+        Assert.True(syncResult.SqlitePresent);
+        await AssertSqliteProviderAsync(fixture, "state_5.sqlite", "thread-nested", "oneapi");
+        await AssertSqliteProviderAsync(fixture, Path.Combine("sqlite", "state_5.sqlite"), "thread-nested", "oneapi");
+
+        RestoreResult restoreResult = await service.RunRestoreAsync(fixture.CodexHome, syncResult.BackupDir);
+
+        Assert.Equal("oneapi", restoreResult.TargetProvider);
+        await AssertSqliteProviderAsync(fixture, "state_5.sqlite", "thread-nested", "openai");
+        await AssertSqliteProviderAsync(fixture, Path.Combine("sqlite", "state_5.sqlite"), "thread-nested", "openai");
+    }
+
+    [Fact]
     public async Task RunSwitch_UpdatesConfigAndSyncsProviderMetadata()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
@@ -784,5 +816,20 @@ public sealed class CoreIntegrationTests
 
         Assert.Contains("model_provider = \"manual\"", await File.ReadAllTextAsync(Path.Combine(fixture.CodexHome, "config.toml")));
         Assert.Contains("\"model_provider\":\"manual\"", await File.ReadAllTextAsync(sessionPath));
+    }
+
+    private static async Task AssertSqliteProviderAsync(
+        TestCodexHomeFixture fixture,
+        string relativeDbPath,
+        string threadId,
+        string expectedProvider)
+    {
+        await using SqliteConnection connection = fixture.OpenSqliteConnection(relativeDbPath);
+        await connection.OpenAsync();
+        SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT model_provider FROM threads WHERE id = $id";
+        command.Parameters.AddWithValue("$id", threadId);
+        string provider = (string)(await command.ExecuteScalarAsync())!;
+        Assert.Equal(expectedProvider, provider);
     }
 }

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -126,8 +126,12 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
     {
-        string dbPath = Path.Combine(CodexHome, "state_5.sqlite");
-        await using SqliteConnection connection = OpenSqliteConnection();
+        await WriteStateDbAsync("state_5.sqlite", rows);
+    }
+
+    public async Task WriteStateDbAsync(string relativeDbPath, IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
+    {
+        await using SqliteConnection connection = OpenSqliteConnection(relativeDbPath);
         await connection.OpenAsync();
         SqliteCommand create = connection.CreateCommand();
         create.CommandText = """
@@ -290,6 +294,13 @@ internal sealed class TestCodexHomeFixture
 
     public SqliteConnection OpenSqliteConnection()
     {
-        return new SqliteConnection($"Data Source={Path.Combine(CodexHome, "state_5.sqlite")};Mode=ReadWriteCreate;Pooling=False");
+        return OpenSqliteConnection("state_5.sqlite");
+    }
+
+    public SqliteConnection OpenSqliteConnection(string relativeDbPath)
+    {
+        string dbPath = Path.Combine(CodexHome, relativeDbPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        return new SqliteConnection($"Data Source={dbPath};Mode=ReadWriteCreate;Pooling=False");
     }
 }

--- a/desktop/CodexProviderSync.Core/BackupService.cs
+++ b/desktop/CodexProviderSync.Core/BackupService.cs
@@ -26,12 +26,16 @@ public sealed class BackupService
         Directory.CreateDirectory(dbDir);
 
         List<string> copiedDbFiles = [];
-        foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
+        foreach (string dbPath in _sqliteStateService.StateDbPaths(codexHome))
         {
-            string fileName = $"{AppConstants.DbFileBasename}{suffix}";
-            if (await CopyIfPresentAsync(Path.Combine(codexHome, fileName), Path.Combine(dbDir, fileName), overwrite: false))
+            string relativeDbPath = Path.GetRelativePath(codexHome, dbPath);
+            foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
             {
-                copiedDbFiles.Add(fileName);
+                string relativePath = $"{relativeDbPath}{suffix}";
+                if (await CopyIfPresentAsync(Path.Combine(codexHome, relativePath), Path.Combine(dbDir, relativePath), overwrite: false))
+                {
+                    copiedDbFiles.Add(relativePath);
+                }
             }
         }
 
@@ -139,13 +143,17 @@ public sealed class BackupService
             string dbDir = Path.Combine(normalizedBackupDir, "db");
             HashSet<string> backedUpFiles = new(metadata.DbFiles, StringComparer.Ordinal);
 
-            foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
+            foreach (string dbPath in _sqliteStateService.StateDbPaths(codexHome))
             {
-                string fileName = $"{AppConstants.DbFileBasename}{suffix}";
-                string targetPath = Path.Combine(codexHome, fileName);
-                if (!backedUpFiles.Contains(fileName) && File.Exists(targetPath))
+                string relativeDbPath = Path.GetRelativePath(codexHome, dbPath);
+                foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
                 {
-                    File.Delete(targetPath);
+                    string relativePath = $"{relativeDbPath}{suffix}";
+                    string targetPath = Path.Combine(codexHome, relativePath);
+                    if (!backedUpFiles.Contains(relativePath) && File.Exists(targetPath))
+                    {
+                        File.Delete(targetPath);
+                    }
                 }
             }
 

--- a/desktop/CodexProviderSync.Core/GlobalStateService.cs
+++ b/desktop/CodexProviderSync.Core/GlobalStateService.cs
@@ -6,6 +6,8 @@ namespace CodexProviderSync.Core;
 
 public sealed class GlobalStateService
 {
+    private readonly SqliteStateService _sqliteStateService = new();
+
     public string StatePath(string codexHome)
     {
         return Path.Combine(codexHome, AppConstants.GlobalStateFileBasename);
@@ -18,8 +20,8 @@ public sealed class GlobalStateService
 
     public async Task<IReadOnlyList<ThreadCwdStat>> ReadThreadCwdStatsAsync(string codexHome)
     {
-        string dbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
-        if (!File.Exists(dbPath))
+        string? dbPath = _sqliteStateService.StateDbPaths(codexHome).LastOrDefault();
+        if (dbPath is null)
         {
             return [];
         }
@@ -191,8 +193,8 @@ public sealed class GlobalStateService
             return [];
         }
 
-        string dbPath = Path.Combine(codexHome, AppConstants.DbFileBasename);
-        if (!File.Exists(dbPath))
+        string? dbPath = _sqliteStateService.StateDbPaths(codexHome).LastOrDefault();
+        if (dbPath is null)
         {
             return roots
                 .Select(static root => new ProjectThreadVisibility

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -16,42 +16,55 @@ public sealed class SqliteStateService
         return Path.Combine(codexHome, AppConstants.DbFileBasename);
     }
 
+    public IReadOnlyList<string> StateDbPaths(string codexHome)
+    {
+        string rootDbPath = StateDbPath(codexHome);
+        string nestedDbPath = Path.Combine(codexHome, "sqlite", AppConstants.DbFileBasename);
+        return new[] { rootDbPath, nestedDbPath }
+            .Where(File.Exists)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+
     public async Task<ProviderCounts?> ReadSqliteProviderCountsAsync(string codexHome)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        IReadOnlyList<string> dbPaths = StateDbPaths(codexHome);
+        if (dbPaths.Count == 0)
         {
             return null;
         }
 
         try
         {
-            await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadOnly);
-            await connection.OpenAsync();
-            await using SqliteCommand command = connection.CreateCommand();
-            command.CommandText = """
-                SELECT
-                  CASE
-                    WHEN model_provider IS NULL OR model_provider = '' THEN '(missing)'
-                    ELSE model_provider
-                  END AS model_provider,
-                  archived,
-                  COUNT(*) AS count
-                FROM threads
-                GROUP BY model_provider, archived
-                ORDER BY archived, model_provider
-                """;
-
             Dictionary<string, int> sessions = new(StringComparer.Ordinal);
             Dictionary<string, int> archivedSessions = new(StringComparer.Ordinal);
-            await using SqliteDataReader reader = await command.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            foreach (string dbPath in dbPaths)
             {
-                string provider = reader.GetString(0);
-                bool archived = reader.GetInt64(1) != 0;
-                int count = reader.GetInt32(2);
-                Dictionary<string, int> bucket = archived ? archivedSessions : sessions;
-                bucket[provider] = count;
+                await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadOnly);
+                await connection.OpenAsync();
+                await using SqliteCommand command = connection.CreateCommand();
+                command.CommandText = """
+                    SELECT
+                      CASE
+                        WHEN model_provider IS NULL OR model_provider = '' THEN '(missing)'
+                        ELSE model_provider
+                      END AS model_provider,
+                      archived,
+                      COUNT(*) AS count
+                    FROM threads
+                    GROUP BY model_provider, archived
+                    ORDER BY archived, model_provider
+                    """;
+
+                await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    string provider = reader.GetString(0);
+                    bool archived = reader.GetInt64(1) != 0;
+                    int count = reader.GetInt32(2);
+                    Dictionary<string, int> bucket = archived ? archivedSessions : sessions;
+                    bucket[provider] = bucket.GetValueOrDefault(provider) + count;
+                }
             }
 
             return new ProviderCounts
@@ -151,27 +164,31 @@ public sealed class SqliteStateService
 
     public async Task<bool> AssertSqliteWritableAsync(string codexHome, int? busyTimeoutMs = null)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        IReadOnlyList<string> dbPaths = StateDbPaths(codexHome);
+        if (dbPaths.Count == 0)
         {
             return false;
         }
 
-        await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
-        try
+        foreach (string dbPath in dbPaths)
         {
-            await connection.OpenAsync();
-            await SetBusyTimeoutAsync(connection, busyTimeoutMs);
-            await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
-            await ExecuteNonQueryAsync(connection, "ROLLBACK");
-            return true;
+            await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
+            try
+            {
+                await connection.OpenAsync();
+                await SetBusyTimeoutAsync(connection, busyTimeoutMs);
+                await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
+                await ExecuteNonQueryAsync(connection, "ROLLBACK");
+            }
+            catch (Exception error)
+            {
+                throw WrapSqliteMalformedError(
+                    WrapSqliteBusyError(error, "update session provider metadata"),
+                    "update session provider metadata");
+            }
         }
-        catch (Exception error)
-        {
-            throw WrapSqliteMalformedError(
-                WrapSqliteBusyError(error, "update session provider metadata"),
-                "update session provider metadata");
-        }
+
+        return true;
     }
 
     public async Task<(int UpdatedRows, int ProviderRowsUpdated, int UserEventRowsUpdated, int CwdRowsUpdated, bool DatabasePresent)> UpdateSqliteProviderAsync(
@@ -182,8 +199,8 @@ public sealed class SqliteStateService
         IReadOnlyCollection<string>? userEventThreadIds = null,
         IReadOnlyDictionary<string, string>? threadCwdsById = null)
     {
-        string dbPath = StateDbPath(codexHome);
-        if (!File.Exists(dbPath))
+        IReadOnlyList<string> dbPaths = StateDbPaths(codexHome);
+        if (dbPaths.Count == 0)
         {
             if (afterUpdate is not null)
             {
@@ -193,61 +210,71 @@ public sealed class SqliteStateService
             return (0, 0, 0, 0, false);
         }
 
-        await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
+        List<SqliteConnection> connections = [];
         bool transactionOpen = false;
         try
         {
-            await connection.OpenAsync();
-            await SetBusyTimeoutAsync(connection, busyTimeoutMs);
-            await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
+            foreach (string dbPath in dbPaths)
+            {
+                SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
+                connections.Add(connection);
+                await connection.OpenAsync();
+                await SetBusyTimeoutAsync(connection, busyTimeoutMs);
+                await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
+            }
             transactionOpen = true;
 
-            await using SqliteCommand command = connection.CreateCommand();
-            command.CommandText = """
-                UPDATE threads
-                SET model_provider = $provider
-                WHERE COALESCE(model_provider, '') <> $provider
-                """;
-            command.Parameters.AddWithValue("$provider", targetProvider);
-            int providerRowsUpdated = await command.ExecuteNonQueryAsync();
+            int providerRowsUpdated = 0;
             int userEventRowsUpdated = 0;
-            if (userEventThreadIds?.Count > 0 && await TableHasColumnAsync(connection, "threads", "has_user_event"))
-            {
-                await using SqliteCommand userEventCommand = connection.CreateCommand();
-                userEventCommand.CommandText = """
-                    UPDATE threads
-                    SET has_user_event = 1
-                    WHERE id = $id AND COALESCE(has_user_event, 0) <> 1
-                    """;
-                SqliteParameter idParameter = userEventCommand.Parameters.Add("$id", SqliteType.Text);
-                foreach (string threadId in userEventThreadIds)
-                {
-                    idParameter.Value = threadId;
-                    userEventRowsUpdated += await userEventCommand.ExecuteNonQueryAsync();
-                }
-            }
-
             int cwdRowsUpdated = 0;
-            if (threadCwdsById?.Count > 0 && await TableHasColumnAsync(connection, "threads", "cwd"))
+            foreach (SqliteConnection connection in connections)
             {
-                await using SqliteCommand cwdCommand = connection.CreateCommand();
-                cwdCommand.CommandText = """
+                await using SqliteCommand command = connection.CreateCommand();
+                command.CommandText = """
                     UPDATE threads
-                    SET cwd = $cwd
-                    WHERE id = $id AND COALESCE(cwd, '') <> $cwd
+                    SET model_provider = $provider
+                    WHERE COALESCE(model_provider, '') <> $provider
                     """;
-                SqliteParameter cwdIdParameter = cwdCommand.Parameters.Add("$id", SqliteType.Text);
-                SqliteParameter cwdParameter = cwdCommand.Parameters.Add("$cwd", SqliteType.Text);
-                foreach ((string threadId, string cwd) in threadCwdsById)
-                {
-                    if (string.IsNullOrWhiteSpace(threadId) || string.IsNullOrWhiteSpace(cwd))
-                    {
-                        continue;
-                    }
+                command.Parameters.AddWithValue("$provider", targetProvider);
+                providerRowsUpdated += await command.ExecuteNonQueryAsync();
 
-                    cwdIdParameter.Value = threadId;
-                    cwdParameter.Value = cwd;
-                    cwdRowsUpdated += await cwdCommand.ExecuteNonQueryAsync();
+                if (userEventThreadIds?.Count > 0 && await TableHasColumnAsync(connection, "threads", "has_user_event"))
+                {
+                    await using SqliteCommand userEventCommand = connection.CreateCommand();
+                    userEventCommand.CommandText = """
+                        UPDATE threads
+                        SET has_user_event = 1
+                        WHERE id = $id AND COALESCE(has_user_event, 0) <> 1
+                        """;
+                    SqliteParameter idParameter = userEventCommand.Parameters.Add("$id", SqliteType.Text);
+                    foreach (string threadId in userEventThreadIds)
+                    {
+                        idParameter.Value = threadId;
+                        userEventRowsUpdated += await userEventCommand.ExecuteNonQueryAsync();
+                    }
+                }
+
+                if (threadCwdsById?.Count > 0 && await TableHasColumnAsync(connection, "threads", "cwd"))
+                {
+                    await using SqliteCommand cwdCommand = connection.CreateCommand();
+                    cwdCommand.CommandText = """
+                        UPDATE threads
+                        SET cwd = $cwd
+                        WHERE id = $id AND COALESCE(cwd, '') <> $cwd
+                        """;
+                    SqliteParameter cwdIdParameter = cwdCommand.Parameters.Add("$id", SqliteType.Text);
+                    SqliteParameter cwdParameter = cwdCommand.Parameters.Add("$cwd", SqliteType.Text);
+                    foreach ((string threadId, string cwd) in threadCwdsById)
+                    {
+                        if (string.IsNullOrWhiteSpace(threadId) || string.IsNullOrWhiteSpace(cwd))
+                        {
+                            continue;
+                        }
+
+                        cwdIdParameter.Value = threadId;
+                        cwdParameter.Value = cwd;
+                        cwdRowsUpdated += await cwdCommand.ExecuteNonQueryAsync();
+                    }
                 }
             }
 
@@ -258,7 +285,10 @@ public sealed class SqliteStateService
                 await afterUpdate((updatedRows, providerRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true));
             }
 
-            await ExecuteNonQueryAsync(connection, "COMMIT");
+            foreach (SqliteConnection connection in connections)
+            {
+                await ExecuteNonQueryAsync(connection, "COMMIT");
+            }
             transactionOpen = false;
             return (updatedRows, providerRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true);
         }
@@ -266,19 +296,29 @@ public sealed class SqliteStateService
         {
             if (transactionOpen)
             {
-                try
+                foreach (SqliteConnection connection in connections)
                 {
-                    await ExecuteNonQueryAsync(connection, "ROLLBACK");
-                }
-                catch
-                {
-                    // Ignore rollback failures and surface the original error.
+                    try
+                    {
+                        await ExecuteNonQueryAsync(connection, "ROLLBACK");
+                    }
+                    catch
+                    {
+                        // Ignore rollback failures and surface the original error.
+                    }
                 }
             }
 
             throw WrapSqliteMalformedError(
                 WrapSqliteBusyError(error, "update session provider metadata"),
                 "update session provider metadata");
+        }
+        finally
+        {
+            foreach (SqliteConnection connection in connections)
+            {
+                await connection.DisposeAsync();
+            }
         }
     }
 

--- a/src/backup.js
+++ b/src/backup.js
@@ -10,7 +10,7 @@ import {
   GLOBAL_STATE_FILE_BASENAME
 } from "./constants.js";
 import { assertSessionFilesWritable, restoreSessionChanges } from "./session-files.js";
-import { assertSqliteWritable } from "./sqlite-state.js";
+import { assertSqliteWritable, stateDbPaths } from "./sqlite-state.js";
 
 function timestampSlug(date = new Date()) {
   return date.toISOString().replaceAll(":", "").replaceAll("-", "").replace(".", "");
@@ -22,6 +22,7 @@ async function copyIfPresent(sourcePath, destinationPath) {
   } catch {
     return false;
   }
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
   await fs.copyFile(sourcePath, destinationPath);
   return true;
 }
@@ -55,11 +56,14 @@ export async function createBackup({
   await fs.mkdir(dbDir, { recursive: true });
 
   const copiedDbFiles = [];
-  for (const suffix of ["", "-shm", "-wal"]) {
-    const fileName = `${DB_FILE_BASENAME}${suffix}`;
-    const copied = await copyIfPresent(path.join(codexHome, fileName), path.join(dbDir, fileName));
-    if (copied) {
-      copiedDbFiles.push(fileName);
+  for (const dbPath of await stateDbPaths(codexHome)) {
+    const relativeDbPath = path.relative(codexHome, dbPath);
+    for (const suffix of ["", "-shm", "-wal"]) {
+      const relativePath = `${relativeDbPath}${suffix}`;
+      const copied = await copyIfPresent(path.join(codexHome, relativePath), path.join(dbDir, relativePath));
+      if (copied) {
+        copiedDbFiles.push(relativePath);
+      }
     }
   }
 
@@ -194,10 +198,13 @@ export async function restoreBackup(backupDir, codexHome, options = {}) {
 
     const dbDir = path.join(backupDir, "db");
     const backedUpFiles = new Set(metadata.dbFiles ?? []);
-    for (const suffix of ["", "-shm", "-wal"]) {
-      const fileName = `${DB_FILE_BASENAME}${suffix}`;
-      if (!backedUpFiles.has(fileName)) {
-        await removeIfPresent(path.join(codexHome, fileName));
+    for (const dbPath of await stateDbPaths(codexHome)) {
+      const relativeDbPath = path.relative(codexHome, dbPath);
+      for (const suffix of ["", "-shm", "-wal"]) {
+        const relativePath = `${relativeDbPath}${suffix}`;
+        if (!backedUpFiles.has(relativePath)) {
+          await removeIfPresent(path.join(codexHome, relativePath));
+        }
       }
     }
     for (const fileName of metadata.dbFiles ?? []) {

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -10,6 +10,23 @@ export function stateDbPath(codexHome) {
   return path.join(codexHome, DB_FILE_BASENAME);
 }
 
+export async function stateDbPaths(codexHome) {
+  const candidates = [
+    stateDbPath(codexHome),
+    path.join(codexHome, "sqlite", DB_FILE_BASENAME)
+  ];
+  const existing = [];
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      existing.push(candidate);
+    } catch {
+      // Missing SQLite files are allowed.
+    }
+  }
+  return [...new Set(existing)];
+}
+
 function openDatabase(dbPath) {
   return new DatabaseSync(dbPath);
 }
@@ -63,35 +80,38 @@ export function wrapSqliteMalformedError(error, action) {
 }
 
 export async function readSqliteProviderCounts(codexHome) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPaths = await stateDbPaths(codexHome);
+  if (dbPaths.length === 0) {
     return null;
   }
 
-  let db;
   try {
-    db = openDatabase(dbPath);
-    const rows = db.prepare(`
-      SELECT
-        CASE
-          WHEN model_provider IS NULL OR model_provider = '' THEN '(missing)'
-          ELSE model_provider
-        END AS model_provider,
-        archived,
-        COUNT(*) AS count
-      FROM threads
-      GROUP BY model_provider, archived
-      ORDER BY archived, model_provider
-    `).all();
     const result = {
       sessions: {},
       archived_sessions: {}
     };
-    for (const row of rows) {
-      const bucket = row.archived ? result.archived_sessions : result.sessions;
-      bucket[row.model_provider] = row.count;
+    for (const dbPath of dbPaths) {
+      const db = openDatabase(dbPath);
+      try {
+        const rows = db.prepare(`
+          SELECT
+            CASE
+              WHEN model_provider IS NULL OR model_provider = '' THEN '(missing)'
+              ELSE model_provider
+            END AS model_provider,
+            archived,
+            COUNT(*) AS count
+          FROM threads
+          GROUP BY model_provider, archived
+          ORDER BY archived, model_provider
+        `).all();
+        for (const row of rows) {
+          const bucket = row.archived ? result.archived_sessions : result.sessions;
+          bucket[row.model_provider] = (bucket[row.model_provider] ?? 0) + row.count;
+        }
+      } finally {
+        db.close();
+      }
     }
     return result;
   } catch (error) {
@@ -112,8 +132,6 @@ export async function readSqliteProviderCounts(codexHome) {
       };
     }
     throw error;
-  } finally {
-    db?.close();
   }
 }
 
@@ -168,27 +186,28 @@ export async function readSqliteRepairStats(codexHome, options = {}) {
 }
 
 export async function assertSqliteWritable(codexHome, options = {}) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPaths = await stateDbPaths(codexHome);
+  if (dbPaths.length === 0) {
     return { databasePresent: false };
   }
 
-  let db;
   try {
-    db = openDatabase(dbPath);
-    setBusyTimeout(db, options.busyTimeoutMs);
-    db.exec("BEGIN IMMEDIATE");
-    db.exec("ROLLBACK");
+    for (const dbPath of dbPaths) {
+      const db = openDatabase(dbPath);
+      try {
+        setBusyTimeout(db, options.busyTimeoutMs);
+        db.exec("BEGIN IMMEDIATE");
+        db.exec("ROLLBACK");
+      } finally {
+        db.close();
+      }
+    }
     return { databasePresent: true };
   } catch (error) {
     throw wrapSqliteMalformedError(
       wrapSqliteBusyError(error, "update session provider metadata"),
       "update session provider metadata"
     );
-  } finally {
-    db?.close();
   }
 }
 
@@ -198,10 +217,8 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
     ? (maybeOptions ?? {})
     : (afterUpdateOrOptions ?? {});
 
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPaths = await stateDbPaths(codexHome);
+  if (dbPaths.length === 0) {
     if (afterUpdate) {
       await afterUpdate({
         updatedRows: 0,
@@ -220,69 +237,82 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
     };
   }
 
-  let db;
+  const dbs = [];
   let transactionOpen = false;
   try {
-    db = openDatabase(dbPath);
-    setBusyTimeout(db, options.busyTimeoutMs);
-    db.exec("BEGIN IMMEDIATE");
+    for (const dbPath of dbPaths) {
+      const db = openDatabase(dbPath);
+      dbs.push(db);
+      setBusyTimeout(db, options.busyTimeoutMs);
+      db.exec("BEGIN IMMEDIATE");
+    }
     transactionOpen = true;
-    const stmt = db.prepare(`
-      UPDATE threads
-      SET model_provider = ?
-      WHERE COALESCE(model_provider, '') <> ?
-    `);
-    const result = stmt.run(targetProvider, targetProvider);
+    let providerRowsUpdated = 0;
     let userEventUpdatedRows = 0;
-    if (tableHasColumn(db, "threads", "has_user_event") && options.userEventThreadIds?.size) {
-      const userEventStmt = db.prepare(`
-        UPDATE threads
-        SET has_user_event = 1
-        WHERE id = ? AND COALESCE(has_user_event, 0) <> 1
-      `);
-      for (const threadId of options.userEventThreadIds) {
-        userEventUpdatedRows += userEventStmt.run(threadId).changes ?? 0;
-      }
-    }
     let cwdUpdatedRows = 0;
-    if (tableHasColumn(db, "threads", "cwd") && options.threadCwdById?.size) {
-      const cwdStmt = db.prepare(`
+    for (const db of dbs) {
+      const stmt = db.prepare(`
         UPDATE threads
-        SET cwd = ?
-        WHERE id = ? AND COALESCE(cwd, '') <> ?
+        SET model_provider = ?
+        WHERE COALESCE(model_provider, '') <> ?
       `);
-      for (const [threadId, cwd] of options.threadCwdById) {
-        if (typeof threadId !== "string" || !threadId || typeof cwd !== "string" || !cwd.trim()) {
-          continue;
+      const result = stmt.run(targetProvider, targetProvider);
+      providerRowsUpdated += result.changes ?? 0;
+
+      if (tableHasColumn(db, "threads", "has_user_event") && options.userEventThreadIds?.size) {
+        const userEventStmt = db.prepare(`
+          UPDATE threads
+          SET has_user_event = 1
+          WHERE id = ? AND COALESCE(has_user_event, 0) <> 1
+        `);
+        for (const threadId of options.userEventThreadIds) {
+          userEventUpdatedRows += userEventStmt.run(threadId).changes ?? 0;
         }
-        cwdUpdatedRows += cwdStmt.run(cwd, threadId, cwd).changes ?? 0;
+      }
+
+      if (tableHasColumn(db, "threads", "cwd") && options.threadCwdById?.size) {
+        const cwdStmt = db.prepare(`
+          UPDATE threads
+          SET cwd = ?
+          WHERE id = ? AND COALESCE(cwd, '') <> ?
+        `);
+        for (const [threadId, cwd] of options.threadCwdById) {
+          if (typeof threadId !== "string" || !threadId || typeof cwd !== "string" || !cwd.trim()) {
+            continue;
+          }
+          cwdUpdatedRows += cwdStmt.run(cwd, threadId, cwd).changes ?? 0;
+        }
       }
     }
-    const updatedRows = (result.changes ?? 0) + userEventUpdatedRows + cwdUpdatedRows;
+    const updatedRows = providerRowsUpdated + userEventUpdatedRows + cwdUpdatedRows;
     if (afterUpdate) {
       await afterUpdate({
         updatedRows,
-        providerRowsUpdated: result.changes ?? 0,
+        providerRowsUpdated,
         userEventRowsUpdated: userEventUpdatedRows,
         cwdRowsUpdated: cwdUpdatedRows,
         databasePresent: true
       });
     }
-    db.exec("COMMIT");
+    for (const db of dbs) {
+      db.exec("COMMIT");
+    }
     transactionOpen = false;
     return {
       updatedRows,
-      providerRowsUpdated: result.changes ?? 0,
+      providerRowsUpdated,
       userEventRowsUpdated: userEventUpdatedRows,
       cwdRowsUpdated: cwdUpdatedRows,
       databasePresent: true
     };
   } catch (error) {
     if (transactionOpen) {
-      try {
-        db.exec("ROLLBACK");
-      } catch {
-        // Ignore rollback failures and surface the original error.
+      for (const db of dbs) {
+        try {
+          db.exec("ROLLBACK");
+        } catch {
+          // Ignore rollback failures and surface the original error.
+        }
       }
     }
     throw wrapSqliteMalformedError(
@@ -290,6 +320,8 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
       "update session provider metadata"
     );
   } finally {
-    db?.close();
+    for (const db of dbs) {
+      db.close();
+    }
   }
 }

--- a/src/workspace-roots.js
+++ b/src/workspace-roots.js
@@ -7,7 +7,7 @@ import {
   GLOBAL_STATE_FILE_BASENAME
 } from "./constants.js";
 import {
-  stateDbPath,
+  stateDbPaths,
   wrapSqliteBusyError,
   wrapSqliteMalformedError
 } from "./sqlite-state.js";
@@ -164,10 +164,8 @@ function copyResolvedObjectKeys(input, cwdStats) {
 }
 
 export async function readThreadCwdStats(codexHome) {
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = (await stateDbPaths(codexHome)).at(-1);
+  if (!dbPath) {
     return [];
   }
 
@@ -258,10 +256,8 @@ export async function readProjectThreadVisibility(codexHome, options = {}) {
     return [];
   }
 
-  const dbPath = stateDbPath(codexHome);
-  try {
-    await fs.access(dbPath);
-  } catch {
+  const dbPath = (await stateDbPaths(codexHome)).at(-1);
+  if (!dbPath) {
     return roots.map((root) => ({
       root,
       interactiveThreads: 0,

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -95,7 +95,11 @@ async function writeGlobalState(codexHome, value) {
 }
 
 async function writeStateDb(codexHome, rows) {
-  const dbPath = path.join(codexHome, "state_5.sqlite");
+  return writeStateDbAtPath(path.join(codexHome, "state_5.sqlite"), rows);
+}
+
+async function writeStateDbAtPath(dbPath, rows) {
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
   const db = new DatabaseSync(dbPath);
   try {
     db.exec(`
@@ -166,6 +170,15 @@ async function writeStateDbForProjectVisibility(codexHome, rows) {
         row.updated_at_ms ?? 0
       );
     }
+  } finally {
+    db.close();
+  }
+}
+
+function readThreadProvider(dbPath, threadId) {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    return db.prepare("SELECT model_provider FROM threads WHERE id = ?").get(threadId)?.model_provider;
   } finally {
     db.close();
   }
@@ -297,6 +310,30 @@ test("runSync rewrites rollout files and sqlite, then restore reverts both", asy
   const restoredArchived = await fs.readFile(archivedPath, "utf8");
   assert.match(restoredSession, /"model_provider":"apigather"/);
   assert.match(restoredArchived, /"model_provider":"newapi"/);
+});
+
+test("runSync rewrites root and nested sqlite databases", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "oneapi"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-nested-db.jsonl");
+  await writeRollout(sessionPath, "thread-nested", "oneapi");
+  await writeStateDb(codexHome, [
+    { id: "thread-nested", model_provider: "openai", archived: false }
+  ]);
+  await writeStateDbAtPath(path.join(codexHome, "sqlite", "state_5.sqlite"), [
+    { id: "thread-nested", model_provider: "openai", archived: false }
+  ]);
+
+  const syncResult = await runSync({ codexHome });
+
+  assert.equal(syncResult.sqliteRowsUpdated, 2);
+  assert.equal(readThreadProvider(path.join(codexHome, "state_5.sqlite"), "thread-nested"), "oneapi");
+  assert.equal(readThreadProvider(path.join(codexHome, "sqlite", "state_5.sqlite"), "thread-nested"), "oneapi");
+
+  await runRestore({ codexHome, backupDir: syncResult.backupDir });
+
+  assert.equal(readThreadProvider(path.join(codexHome, "state_5.sqlite"), "thread-nested"), "openai");
+  assert.equal(readThreadProvider(path.join(codexHome, "sqlite", "state_5.sqlite"), "thread-nested"), "openai");
 });
 
 test("runSync reports stage progress and backup duration", async () => {


### PR DESCRIPTION
## Summary

- Detect both `~/.codex/state_5.sqlite` and `~/.codex/sqlite/state_5.sqlite` when reading status and synchronizing provider metadata.
- Update backup/restore handling so nested SQLite databases and their WAL/SHM files are preserved using relative paths.
- Make workspace visibility diagnostics prefer the active nested SQLite database when present, and add regression coverage for CLI and Core.

## Why

Recent Codex installations can keep thread metadata under `~/.codex/sqlite/state_5.sqlite` while this tool only updated the root `~/.codex/state_5.sqlite`. In that setup, rollout files may be synchronized but the desktop history list can still hide older sessions because the nested SQLite index retains old `model_provider` values.

## Test Plan

- `npm test`
- `dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj`
