### PR TITLE
Support older Node.js with SQLite fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,17 @@ on:
 jobs:
   test:
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - "16"
+          - "24"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml)
 [![Platform](https://img.shields.io/badge/platform-Windows-lightgrey.svg)](https://github.com/Dailin521/codex-provider-sync)
-[![Node](https://img.shields.io/badge/node-24%2B-brightgreen.svg)](https://nodejs.org/)
+[![Node](https://img.shields.io/badge/node-16%2B-brightgreen.svg)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 中文 | [English](docs/README_EN.md)
@@ -42,7 +42,7 @@ npm install -g git+https://github.com/Dailin521/codex-provider-sync.git
 codex-provider sync
 ```
 
-CLI 需要 Node.js `24+`。如果使用 Node 20/22，可能会看到 `node:sqlite` 不存在的错误。
+CLI 需要 Node.js `16+`。Node 24+ 会优先使用内置 `node:sqlite`；旧版 Node 会使用可选依赖 `better-sqlite3`。
 
 更多 CLI 常用命令：
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml)
 [![Platform](https://img.shields.io/badge/platform-Windows-lightgrey.svg)](https://github.com/Dailin521/codex-provider-sync)
-[![Node](https://img.shields.io/badge/node-24%2B-brightgreen.svg)](https://nodejs.org/)
+[![Node](https://img.shields.io/badge/node-16%2B-brightgreen.svg)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 [![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
@@ -55,8 +55,8 @@ npm install -g git+https://github.com/Dailin521/codex-provider-sync.git
 
 Requirements:
 
-- Node.js `24+`
-- Node.js 20/22 can fail with a missing `node:sqlite` built-in module.
+- Node.js `16+`
+- Node.js 24+ uses the built-in `node:sqlite` module; older Node.js releases use the optional `better-sqlite3` dependency.
 - standard `~/.codex` layout
 - Windows is the primary tested target for now
 

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml)
 [![Platform](https://img.shields.io/badge/platform-Windows-lightgrey.svg)](https://github.com/Dailin521/codex-provider-sync)
-[![Node](https://img.shields.io/badge/node-24%2B-brightgreen.svg)](https://nodejs.org/)
+[![Node](https://img.shields.io/badge/node-16%2B-brightgreen.svg)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 
 中文镜像 | [English](README_EN.md) | [主 README](../README.md)
@@ -40,7 +40,7 @@ npm install -g git+https://github.com/Dailin521/codex-provider-sync.git
 codex-provider sync
 ```
 
-CLI 需要 Node.js `24+`。如果使用 Node 20/22，可能会看到 `node:sqlite` 不存在的错误。
+CLI 需要 Node.js `16+`。Node 24+ 会优先使用内置 `node:sqlite`；旧版 Node 会使用可选依赖 `better-sqlite3`。
 
 更多 CLI 常用命令：
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,460 @@
         "codex-provider": "src/cli.js"
       },
       "engines": {
-        "node": ">=24.0.0"
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "8.7.0"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/better-sqlite3": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.7.0.tgz",
+      "integrity": "sha512-99jZU4le+f3G6aIl6PmmV0cxUIWqKieHxsiF7G34CVFiE+/UabpYqkU0NJIkY/96mQKikHeBjtR27vFfs5JpEw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "optional": true
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "optional": true
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "optional": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "optional": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "optional": true
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "optional": true
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "optional": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "optional": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "node --test"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=16.0.0"
   },
   "keywords": [
     "codex",
@@ -24,5 +24,8 @@
     "sessions",
     "provider"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "optionalDependencies": {
+    "better-sqlite3": "8.7.0"
+  }
 }

--- a/src/node-version.js
+++ b/src/node-version.js
@@ -1,4 +1,4 @@
-export const MINIMUM_NODE_MAJOR_VERSION = 24;
+export const MINIMUM_NODE_MAJOR_VERSION = 16;
 
 export function getUnsupportedNodeVersionMessage(nodeVersion = process.versions.node) {
   const majorVersion = Number.parseInt(String(nodeVersion).split(".")[0] ?? "", 10);
@@ -7,7 +7,7 @@ export function getUnsupportedNodeVersionMessage(nodeVersion = process.versions.
   }
 
   const displayVersion = String(nodeVersion).startsWith("v") ? String(nodeVersion) : `v${nodeVersion}`;
-  return `codex-provider-sync requires Node.js ${MINIMUM_NODE_MAJOR_VERSION}+ because it uses node:sqlite. `
+  return `codex-provider-sync requires Node.js ${MINIMUM_NODE_MAJOR_VERSION}+. `
     + `Current Node.js version: ${displayVersion}. `
     + "Please upgrade Node.js, then reinstall or rerun codex-provider.";
 }

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 
 import { DB_FILE_BASENAME, SQLITE_DIR_BASENAME } from "./constants.js";
+import { openDatabase } from "./sqlite.js";
 
 const DEFAULT_BUSY_TIMEOUT_MS = 5000;
 
@@ -43,10 +43,6 @@ export async function detectStateDb(codexHome) {
 
 export async function existingStateDbPath(codexHome) {
   return (await detectStateDb(codexHome))?.path ?? null;
-}
-
-function openDatabase(dbPath) {
-  return new DatabaseSync(dbPath);
 }
 
 function tableHasColumn(db, tableName, columnName) {
@@ -105,7 +101,7 @@ export async function readSqliteProviderCounts(codexHome) {
 
   let db;
   try {
-    db = openDatabase(dbPath);
+    db = await openDatabase(dbPath);
     const rows = db.prepare(`
       SELECT
         CASE
@@ -158,7 +154,7 @@ export async function readSqliteRepairStats(codexHome, options = {}) {
 
   let db;
   try {
-    db = openDatabase(dbPath);
+    db = await openDatabase(dbPath);
     let userEventRowsNeedingRepair = 0;
     if (tableHasColumn(db, "threads", "has_user_event") && options.userEventThreadIds?.size) {
       const stmt = db.prepare("SELECT has_user_event FROM threads WHERE id = ?");
@@ -206,7 +202,7 @@ export async function assertSqliteWritable(codexHome, options = {}) {
 
   let db;
   try {
-    db = openDatabase(dbPath);
+    db = await openDatabase(dbPath);
     setBusyTimeout(db, options.busyTimeoutMs);
     db.exec("BEGIN IMMEDIATE");
     db.exec("ROLLBACK");
@@ -250,7 +246,7 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
   let db;
   let transactionOpen = false;
   try {
-    db = openDatabase(dbPath);
+    db = await openDatabase(dbPath);
     setBusyTimeout(db, options.busyTimeoutMs);
     db.exec("BEGIN IMMEDIATE");
     transactionOpen = true;

--- a/src/sqlite.js
+++ b/src/sqlite.js
@@ -1,0 +1,58 @@
+let databaseFactoryPromise = null;
+
+function normalizeImportDefault(moduleNamespace) {
+  return moduleNamespace.default ?? moduleNamespace;
+}
+
+class BetterSqliteDatabase {
+  constructor(Database, dbPath, options = {}) {
+    this.db = new Database(dbPath, {
+      readonly: Boolean(options.readOnly)
+    });
+  }
+
+  prepare(sql) {
+    return this.db.prepare(sql);
+  }
+
+  exec(sql) {
+    return this.db.exec(sql);
+  }
+
+  close() {
+    return this.db.close();
+  }
+}
+
+async function loadDatabaseFactory() {
+  try {
+    const sqlite = await import("node:sqlite");
+    if (sqlite.DatabaseSync) {
+      return (dbPath, options) => new sqlite.DatabaseSync(dbPath, options);
+    }
+  } catch {
+    // Older Node.js releases do not include node:sqlite.
+  }
+
+  try {
+    const betterSqlite3 = normalizeImportDefault(await import("better-sqlite3"));
+    return (dbPath, options) => new BetterSqliteDatabase(betterSqlite3, dbPath, options);
+  } catch (error) {
+    throw new Error(
+      "SQLite support requires Node.js with node:sqlite, or the optional better-sqlite3 dependency on older Node.js. "
+        + "For local/link installs, run npm install --include=optional in the package directory. "
+        + "For normal installs, reinstall without --omit=optional. "
+        + `Original error: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+async function getDatabaseFactory() {
+  databaseFactoryPromise ??= loadDatabaseFactory();
+  return databaseFactoryPromise;
+}
+
+export async function openDatabase(dbPath, options = {}) {
+  const createDatabase = await getDatabaseFactory();
+  return createDatabase(dbPath, options);
+}

--- a/src/workspace-roots.js
+++ b/src/workspace-roots.js
@@ -1,11 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 
 import {
   GLOBAL_STATE_BACKUP_FILE_BASENAME,
   GLOBAL_STATE_FILE_BASENAME
 } from "./constants.js";
+import { openDatabase } from "./sqlite.js";
 import {
   existingStateDbPath,
   wrapSqliteBusyError,
@@ -171,7 +171,7 @@ export async function readThreadCwdStats(codexHome) {
 
   let db;
   try {
-    db = new DatabaseSync(dbPath, { readOnly: true });
+    db = await openDatabase(dbPath, { readOnly: true });
     if (!tableHasColumn(db, "threads", "cwd")) {
       return [];
     }
@@ -272,7 +272,7 @@ export async function readProjectThreadVisibility(codexHome, options = {}) {
 
   let db;
   try {
-    db = new DatabaseSync(dbPath, { readOnly: true });
+    db = await openDatabase(dbPath, { readOnly: true });
     const columns = new Set(db.prepare('PRAGMA table_info("threads")').all().map((column) => column.name));
     if (!columns.has("cwd")) {
       return [];

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -4,7 +4,6 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 
 import {
   createBackup,
@@ -17,6 +16,7 @@ import { getStatus, renderStatus, runRestore, runSwitch, runSync } from "../src/
 import { DB_FILE_BASENAME, DEFAULT_BACKUP_RETENTION_COUNT, SQLITE_DIR_BASENAME } from "../src/constants.js";
 import { getUnsupportedNodeVersionMessage } from "../src/node-version.js";
 import { applySessionChanges, collectSessionChanges } from "../src/session-files.js";
+import { openDatabase } from "../src/sqlite.js";
 
 async function makeTempCodexHome() {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-provider-sync-"));
@@ -105,7 +105,7 @@ function legacyStateDbPath(codexHome) {
 async function writeStateDb(codexHome, rows) {
   const dbPath = stateDbPath(codexHome);
   await fs.mkdir(path.dirname(dbPath), { recursive: true });
-  const db = new DatabaseSync(dbPath);
+  const db = await openDatabase(dbPath);
   try {
     db.exec(`
       CREATE TABLE threads (
@@ -128,7 +128,7 @@ async function writeStateDb(codexHome, rows) {
 async function writeStateDbWithUserEventColumn(codexHome, rows) {
   const dbPath = stateDbPath(codexHome);
   await fs.mkdir(path.dirname(dbPath), { recursive: true });
-  const db = new DatabaseSync(dbPath);
+  const db = await openDatabase(dbPath);
   try {
     db.exec(`
       CREATE TABLE threads (
@@ -152,7 +152,7 @@ async function writeStateDbWithUserEventColumn(codexHome, rows) {
 async function writeStateDbForProjectVisibility(codexHome, rows) {
   const dbPath = stateDbPath(codexHome);
   await fs.mkdir(path.dirname(dbPath), { recursive: true });
-  const db = new DatabaseSync(dbPath);
+  const db = await openDatabase(dbPath);
   try {
     db.exec(`
       CREATE TABLE threads (
@@ -293,7 +293,7 @@ test("runSync rewrites rollout files and sqlite, then restore reverts both", asy
   assert.match(syncedSession, /"model_provider":"openai"/);
   assert.match(syncedArchived, /"model_provider":"openai"/);
 
-  const db = new DatabaseSync(stateDbPath(codexHome));
+  const db = await openDatabase(stateDbPath(codexHome));
   try {
     const providers = db
       .prepare("SELECT id, model_provider FROM threads ORDER BY id")
@@ -368,7 +368,7 @@ test("runSync repairs SQLite has_user_event from rollout user messages", async (
   assert.equal(syncResult.sqliteRowsUpdated, 1);
   assert.equal(syncResult.sqliteUserEventRowsUpdated, 1);
 
-  const db = new DatabaseSync(stateDbPath(codexHome));
+  const db = await openDatabase(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT has_user_event FROM threads WHERE id = ?")
@@ -406,7 +406,7 @@ test("runSync repairs SQLite cwd from rollout session metadata", async () => {
   assert.equal(syncResult.sqliteRowsUpdated, 1);
   assert.equal(syncResult.sqliteCwdRowsUpdated, 1);
 
-  const db = new DatabaseSync(stateDbPath(codexHome));
+  const db = await openDatabase(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT cwd FROM threads WHERE id = ?")
@@ -443,7 +443,7 @@ test("runSync normalizes extended rollout cwd before repairing SQLite", async ()
   assert.equal(syncResult.sqliteRowsUpdated, 1);
   assert.equal(syncResult.sqliteCwdRowsUpdated, 1);
 
-  const db = new DatabaseSync(stateDbPath(codexHome));
+  const db = await openDatabase(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT cwd FROM threads WHERE id = ?")
@@ -564,7 +564,7 @@ test("status falls back to legacy root sqlite database", async () => {
   await writeConfig(codexHome);
   const sqliteDir = path.dirname(stateDbPath(codexHome));
   await fs.mkdir(sqliteDir, { recursive: true });
-  const db = new DatabaseSync(legacyStateDbPath(codexHome));
+  const db = await openDatabase(legacyStateDbPath(codexHome));
   try {
     db.exec(`
       CREATE TABLE threads (
@@ -670,7 +670,7 @@ test("runSync leaves rollout files and sqlite untouched when sqlite is locked", 
     { id: "thread-a", model_provider: "apigather", archived: false }
   ]);
 
-  const lockDb = new DatabaseSync(stateDbPath(codexHome));
+  const lockDb = await openDatabase(stateDbPath(codexHome));
   try {
     lockDb.exec("BEGIN IMMEDIATE");
     await assert.rejects(
@@ -689,7 +689,7 @@ test("runSync leaves rollout files and sqlite untouched when sqlite is locked", 
   const rollout = await fs.readFile(sessionPath, "utf8");
   assert.match(rollout, /"model_provider":"apigather"/);
 
-  const db = new DatabaseSync(stateDbPath(codexHome));
+  const db = await openDatabase(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT model_provider FROM threads WHERE id = ?")
@@ -729,7 +729,7 @@ test("runSync skips locked rollout files and still updates sqlite", async () => 
   const rollout = await fs.readFile(sessionPath, "utf8");
   assert.match(rollout, /"model_provider":"apigather"/);
 
-  const db = new DatabaseSync(stateDbPath(codexHome));
+  const db = await openDatabase(stateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT model_provider FROM threads WHERE id = ?")
@@ -827,7 +827,7 @@ test("collectSessionChanges reports encrypted_content counts by provider and sco
   });
 });
 
-test("collectSessionChanges scans large rollout content without full-file reads", async (t) => {
+test("collectSessionChanges scans large rollout content without full-file reads", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"');
   const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-streamed.jsonl");
@@ -857,20 +857,24 @@ test("collectSessionChanges scans large rollout content without full-file reads"
   );
 
   const originalReadFile = fs.readFile;
-  t.mock.method(fs, "readFile", async (filePath, ...args) => {
+  fs.readFile = async (filePath, ...args) => {
     if (path.resolve(String(filePath)) === path.resolve(sessionPath)) {
       throw new Error("rollout scan should not read the full file");
     }
     return originalReadFile.call(fs, filePath, ...args);
-  });
+  };
 
-  const { encryptedContentCounts, userEventThreadIds } = await collectSessionChanges(codexHome, "openai");
+  try {
+    const { encryptedContentCounts, userEventThreadIds } = await collectSessionChanges(codexHome, "openai");
 
-  assert.deepEqual(encryptedContentCounts, {
-    sessions: { apigather: 1 },
-    archived_sessions: {}
-  });
-  assert.equal(userEventThreadIds.has("thread-streamed"), true);
+    assert.deepEqual(encryptedContentCounts, {
+      sessions: { apigather: 1 },
+      archived_sessions: {}
+    });
+    assert.equal(userEventThreadIds.has("thread-streamed"), true);
+  } finally {
+    fs.readFile = originalReadFile;
+  }
 });
 
 test("applySessionChanges skips only the rollout file that becomes locked on Windows", async () => {
@@ -1097,11 +1101,11 @@ test("cli rejects non-integer keep values", async () => {
   assert.match(result.stderr, /Invalid --keep value: 1\.5/);
 });
 
-test("node version guard explains node:sqlite requirement", () => {
-  assert.equal(getUnsupportedNodeVersionMessage("24.0.0"), null);
+test("node version guard allows Node 16 and rejects older releases", () => {
+  assert.equal(getUnsupportedNodeVersionMessage("16.0.0"), null);
   assert.match(
-    getUnsupportedNodeVersionMessage("20.18.1"),
-    /requires Node\.js 24\+ because it uses node:sqlite/
+    getUnsupportedNodeVersionMessage("14.21.3"),
+    /requires Node\.js 16\+/
   );
 });
 


### PR DESCRIPTION
## Summary

- Lower the CLI runtime guard from Node.js 24+ to Node.js 16+.
- Add a small SQLite adapter that uses built-in `node:sqlite` when available and falls back to optional `better-sqlite3@8.7.0` on older Node.js.
- Update tests, docs, package metadata, and CI to cover Node.js 16 and 24.

## Notes

The fallback dependency is optional so Node.js 24+ users can continue using the built-in `node:sqlite` path. Older Node.js installs get `better-sqlite3` through normal npm installation unless optional dependencies are explicitly omitted.

## Validation

- `npm ci` on Node.js 16.20.2
- `npm test` on Node.js 16.20.2
- `npm pack --pack-destination /tmp/cps-pr-pack`
- `npm install -g /tmp/cps-pr-pack/codex-provider-sync-0.2.7.tgz --prefix /tmp/cps-pr-prefix`
- `/tmp/cps-pr-prefix/bin/codex-provider help`
- Verified the installed package has `better-sqlite3@8.7.0` and can open an in-memory SQLite database through the adapter.

