### PR TITLE
Fix/switch sync top level model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,14 +62,6 @@ to leave the root-level `model` untouched, or
 the new provider section has no `model` field of its own, or when the
 user wants to call a non-default model through a relay provider).
 
-Use `codex-provider watch` when:
-
-- the user wants the tool to keep rollout + SQLite aligned with the
-  current `config.toml` automatically, without manually running `sync`
-  after each provider change
-- another tool (Echobird, Codex Desktop, hand edits) is also editing
-  `config.toml` and the user wants the sync to follow
-
 Use `codex-provider restore <backup-dir>` when:
 
 - the user wants to roll back a previous sync
@@ -148,8 +140,6 @@ codex-provider sync --provider openai
 codex-provider switch apigather
 codex-provider switch apigather --model "MiniMax-M3"
 codex-provider switch apigather --keep-root-model
-codex-provider watch
-codex-provider watch --once
 codex-provider prune-backups --keep 5
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\20260319T042708906Z
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,21 @@ Use `codex-provider switch <provider-id>` when:
 - the user wants to change the root `model_provider`
 - the user wants one command to both switch provider and resync history
 
+By default `switch` also aligns the root-level `model` with the new
+provider section's `model`. Use `switch <provider-id> --keep-root-model`
+to leave the root-level `model` untouched, or
+`switch <provider-id> --model <name>` to set it explicitly (e.g. when
+the new provider section has no `model` field of its own, or when the
+user wants to call a non-default model through a relay provider).
+
+Use `codex-provider watch` when:
+
+- the user wants the tool to keep rollout + SQLite aligned with the
+  current `config.toml` automatically, without manually running `sync`
+  after each provider change
+- another tool (Echobird, Codex Desktop, hand edits) is also editing
+  `config.toml` and the user wants the sync to follow
+
 Use `codex-provider restore <backup-dir>` when:
 
 - the user wants to roll back a previous sync
@@ -131,6 +146,10 @@ codex-provider sync
 codex-provider sync --keep 5
 codex-provider sync --provider openai
 codex-provider switch apigather
+codex-provider switch apigather --model "MiniMax-M3"
+codex-provider switch apigather --keep-root-model
+codex-provider watch
+codex-provider watch --once
 codex-provider prune-backups --keep 5
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\20260319T042708906Z
 ```

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ codex-provider sync --provider openai
 codex-provider switch apigather
 codex-provider switch apigather --model "MiniMax-M3"     # 同时改顶层 model
 codex-provider switch apigather --keep-root-model        # 只改 model_provider，不动顶层 model
-codex-provider watch                                   # config.toml 改了自动同步
-codex-provider watch --once                             # 跑一次同步就退出
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\<timestamp>
 codex-provider prune-backups --keep 5
 ```
@@ -64,7 +62,6 @@ codex-provider prune-backups --keep 5
 - `status`：只检查当前 provider、rollout、SQLite、项目可见性诊断。
 - `sync`：不切换登录状态，只把历史会话 metadata 同步到当前 provider。
 - `switch <provider-id>`：修改 `config.toml` 根级 `model_provider` 并默认把顶层 `model` 同步到新 provider section 里的 `model`（可用 `--keep-root-model` 关闭，或用 `--model <NAME>` 显式覆盖），然后执行同步。
-- `watch`：守护进程，监听 `config.toml` 与 Codex 状态数据库变化，自动跑 `sync`；可配 `--debounce-ms`、`--once`、`--no-state-db`。
 - `restore <backup-dir>`：从备份恢复，支持 `--no-config`、`--no-db`、`--no-sessions`。
 - `prune-backups --keep <n>`：只清理本工具创建的旧备份。
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ codex-provider status
 codex-provider sync
 codex-provider sync --provider openai
 codex-provider switch apigather
+codex-provider switch apigather --model "MiniMax-M3"     # 同时改顶层 model
+codex-provider switch apigather --keep-root-model        # 只改 model_provider，不动顶层 model
+codex-provider watch                                   # config.toml 改了自动同步
+codex-provider watch --once                             # 跑一次同步就退出
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\<timestamp>
 codex-provider prune-backups --keep 5
 ```
@@ -59,7 +63,8 @@ codex-provider prune-backups --keep 5
 
 - `status`：只检查当前 provider、rollout、SQLite、项目可见性诊断。
 - `sync`：不切换登录状态，只把历史会话 metadata 同步到当前 provider。
-- `switch <provider-id>`：修改 `config.toml` 根级 `model_provider`，然后执行同步。
+- `switch <provider-id>`：修改 `config.toml` 根级 `model_provider` 并默认把顶层 `model` 同步到新 provider section 里的 `model`（可用 `--keep-root-model` 关闭，或用 `--model <NAME>` 显式覆盖），然后执行同步。
+- `watch`：守护进程，监听 `config.toml` 与 Codex 状态数据库变化，自动跑 `sync`；可配 `--debounce-ms`、`--once`、`--no-state-db`。
 - `restore <backup-dir>`：从备份恢复，支持 `--no-config`、`--no-db`、`--no-sessions`。
 - `prune-backups --keep <n>`：只清理本工具创建的旧备份。
 

--- a/desktop/CodexProviderSync.App/MainForm.cs
+++ b/desktop/CodexProviderSync.App/MainForm.cs
@@ -43,6 +43,30 @@ public sealed class MainForm : Form
         AutoSize = true,
         Margin = new Padding(0, 4, 8, 0)
     };
+    private readonly RadioButton _modelAutoRadio = new()
+    {
+        Text = "跟随 provider 里的 model (默认)",
+        AutoSize = true,
+        Checked = true,
+        Margin = new Padding(0, 2, 12, 2)
+    };
+    private readonly RadioButton _modelKeepRadio = new()
+    {
+        Text = "保留当前顶层 model",
+        AutoSize = true,
+        Margin = new Padding(0, 2, 12, 2)
+    };
+    private readonly RadioButton _modelCustomRadio = new()
+    {
+        Text = "自定义:",
+        AutoSize = true,
+        Margin = new Padding(0, 2, 6, 2)
+    };
+    private readonly TextBox _modelCustomText = new()
+    {
+        Width = 240,
+        Margin = new Padding(0, 0, 0, 2)
+    };
     private readonly CheckBox _restoreConfigCheck = new() { Text = "恢复配置文件（config.toml）", Checked = false, AutoSize = true };
     private readonly CheckBox _restoreDatabaseCheck = new() { Text = "恢复线程数据库（SQLite）", Checked = true, AutoSize = true };
     private readonly CheckBox _restoreSessionsCheck = new() { Text = "恢复会话文件元数据（rollout）", Checked = true, AutoSize = true };
@@ -122,13 +146,16 @@ public sealed class MainForm : Form
     /// <summary>
     /// Brings the running form back to the foreground. Invoked by the
     /// single-instance focus broker when a second copy of CodexProviderSync
-    /// is launched and asks the first copy to take focus.
+    /// is launched and asks the first copy to take focus. We name it
+    /// `RequestBringToFront` rather than overriding `Form.BringToFront`
+    /// with the `new` keyword so we do not silently break if a future
+    /// .NET version changes the base signature or marks it virtual.
     /// </summary>
-    public new void BringToFront()
+    public void RequestBringToFront()
     {
         if (InvokeRequired)
         {
-            BeginInvoke(new Action(BringToFront));
+            BeginInvoke(new Action(RequestBringToFront));
             return;
         }
         if (WindowState == FormWindowState.Minimized)
@@ -331,7 +358,44 @@ public sealed class MainForm : Form
         panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
         panel.Controls.Add(_updateConfigCheck, 0, 0);
         panel.Controls.Add(_updateConfigLabel, 1, 0);
+
+        FlowLayoutPanel modelOptions = new()
+        {
+            FlowDirection = FlowDirection.LeftToRight,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Margin = new Padding(24, 0, 0, 0),
+            Dock = DockStyle.Fill
+        };
+        Label modelHeader = new()
+        {
+            Text = "顶层 model:",
+            AutoSize = true,
+            Margin = new Padding(0, 4, 8, 0)
+        };
+        modelOptions.Controls.Add(modelHeader);
+        modelOptions.Controls.Add(_modelAutoRadio);
+        modelOptions.Controls.Add(_modelKeepRadio);
+        modelOptions.Controls.Add(_modelCustomRadio);
+        modelOptions.Controls.Add(_modelCustomText);
+        panel.Controls.Add(modelOptions, 0, 1);
+        panel.SetColumnSpan(modelOptions, 2);
+
+        _modelAutoRadio.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
+        _modelKeepRadio.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
+        _modelCustomRadio.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
+        _updateConfigCheck.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
+        UpdateModelOptionsEnabled();
         return panel;
+    }
+
+    private void UpdateModelOptionsEnabled()
+    {
+        bool enabled = _updateConfigCheck.Checked;
+        _modelAutoRadio.Enabled = enabled;
+        _modelKeepRadio.Enabled = enabled;
+        _modelCustomRadio.Enabled = enabled;
+        _modelCustomText.Enabled = enabled && _modelCustomRadio.Checked;
     }
 
     private Control BuildWarningPanel()
@@ -565,14 +629,33 @@ public sealed class MainForm : Form
         {
             string codexHome = CurrentCodexHome();
             int backupRetentionCount = CurrentBackupRetentionCount();
-            SyncResult result = _updateConfigCheck.Checked
-                ? await Task.Run(async () => await _syncService.RunSwitchAsync(codexHome, provider, backupRetentionCount))
-                : await Task.Run(async () => await _syncService.RunSyncAsync(codexHome, provider: provider, keepCount: backupRetentionCount));
+            SyncResult result;
+            if (_updateConfigCheck.Checked)
+            {
+                bool keepRootModel = _modelKeepRadio.Checked;
+                string? explicitModel = _modelCustomRadio.Checked ? _modelCustomText.Text.Trim() : null;
+                if (_modelCustomRadio.Checked && string.IsNullOrEmpty(explicitModel))
+                {
+                    MessageBox.Show(this, "请填写自定义 model 名称,或改成 \"跟随 provider\"。", Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return;
+                }
+                result = await Task.Run(async () => await _syncService.RunSwitchAsync(
+                    codexHome,
+                    provider,
+                    backupRetentionCount,
+                    model: explicitModel,
+                    keepRootModel: keepRootModel));
+            }
+            else
+            {
+                result = await Task.Run(async () => await _syncService.RunSyncAsync(codexHome, provider: provider, keepCount: backupRetentionCount));
+            }
 
             _settings = _settingsService.UpdateState(_settings, provider, result.BackupDir, CaptureWindowBounds(), backupRetentionCount);
             await _settingsService.SaveAsync(_settings);
             AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] 执行完成");
             AppendLog(TextFormatter.FormatSyncResult(result, _updateConfigCheck.Checked ? "已切换并同步" : "已同步"));
+            AppendLog(FormatModelSyncOutcome(result.ModelSync));
             AppendLog(string.Empty);
             await RefreshStatusCoreAsync(codexHome);
             SelectProvider(provider);
@@ -871,6 +954,23 @@ public sealed class MainForm : Form
         _logBox.AppendText(message);
         _logBox.SelectionStart = _logBox.TextLength;
         _logBox.ScrollToCaret();
+    }
+
+    private static string FormatModelSyncOutcome(ModelSyncOutcome outcome)
+    {
+        if (outcome.Source == "not-applicable")
+        {
+            return string.Empty;
+        }
+        if (outcome.Applied)
+        {
+            return $"顶层 model: {outcome.Model} (来源: {outcome.Source})";
+        }
+        if (!string.IsNullOrEmpty(outcome.Warning))
+        {
+            return $"顶层 model: 未改写 ({outcome.Warning})";
+        }
+        return "顶层 model: 未改写 (已请求保留)";
     }
 
     private bool ConfirmCodexClosed(string message)

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -914,6 +914,166 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSync_RewritesPerThreadModelColumnFromConfig()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"MiniMax-M3\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-a", "openai");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-a", "openai", false)
+        ],
+            model: "gpt-5.4-mini");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(1, result.SqliteModelRowsUpdated);
+        await using SqliteConnection connection = new($"Data Source={fixture.StateDbPath()};Mode=ReadOnly;Pooling=False");
+        await connection.OpenAsync();
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT model, model_provider FROM threads WHERE id = 'thread-a'";
+        await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal("MiniMax-M3", reader.GetString(0));
+        Assert.Equal("openai", reader.GetString(1));
+    }
+
+    [Fact]
+    public async Task RunSync_LeavesPerThreadModelAlone_WhenNoRootModelConfigured()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-a", "openai");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-a", "openai", false)
+        ],
+            model: "gpt-5.4-mini");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(0, result.SqliteModelRowsUpdated);
+        await using SqliteConnection connection = new($"Data Source={fixture.StateDbPath()};Mode=ReadOnly;Pooling=False");
+        await connection.OpenAsync();
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT model FROM threads WHERE id = 'thread-a'";
+        Assert.Equal("gpt-5.4-mini", Convert.ToString(await command.ExecuteScalarAsync()));
+    }
+
+    [Fact]
+    public async Task RunSwitch_PropagatesNewModelToSqlitePerThreadColumn()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("""
+            model_provider = "openai"
+            model = "gpt-5.4"
+
+            [model_providers.apigather]
+            name = "apigather"
+            base_url = "https://example.com"
+            model = "MiniMax-M3"
+            """);
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-a", "openai");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-a", "openai", false)
+        ],
+            model: "gpt-5.4");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSwitchAsync(
+            fixture.CodexHome,
+            "apigather",
+            keepRootModel: false,
+            model: null);
+
+        Assert.True(result.ModelSync.Applied);
+        Assert.Equal("MiniMax-M3", result.ModelSync.Model);
+        Assert.Equal(1, result.SqliteModelRowsUpdated);
+
+        await using SqliteConnection connection = new($"Data Source={fixture.StateDbPath()};Mode=ReadOnly;Pooling=False");
+        await connection.OpenAsync();
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT model, model_provider FROM threads WHERE id = 'thread-a'";
+        await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal("MiniMax-M3", reader.GetString(0));
+        Assert.Equal("apigather", reader.GetString(1));
+    }
+
+    [Fact]
+    public async Task RunSync_RewritesTurnContextModelFieldInRolloutFiles()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"MiniMax-M3\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutWithTurnContextAsync(sessionPath, "thread-a", "apigather", "gpt-5.4");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(1, result.ChangedSessionFiles);
+        string rewritten = await File.ReadAllTextAsync(sessionPath);
+        using StringReader reader = new(rewritten);
+        string? line;
+        int turnContextCount = 0;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+            {
+                continue;
+            }
+            using JsonDocument doc = JsonDocument.Parse(line);
+            string model = doc.RootElement.GetProperty("payload").GetProperty("model").GetString()!;
+            string collabModel = doc.RootElement
+                .GetProperty("payload")
+                .GetProperty("collaboration_mode")
+                .GetProperty("settings")
+                .GetProperty("model")
+                .GetString()!;
+            Assert.Equal("MiniMax-M3", model);
+            Assert.Equal("MiniMax-M3", collabModel);
+            turnContextCount += 1;
+        }
+        Assert.Equal(2, turnContextCount);
+    }
+
+    [Fact]
+    public async Task RunSync_LeavesTurnContextModelFieldAlone_WhenNoRootModelConfigured()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutWithTurnContextAsync(sessionPath, "thread-a", "apigather", "gpt-5.4");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(1, result.ChangedSessionFiles);
+        string rewritten = await File.ReadAllTextAsync(sessionPath);
+        using StringReader reader = new(rewritten);
+        string? line;
+        int turnContextCount = 0;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+            {
+                continue;
+            }
+            using JsonDocument doc = JsonDocument.Parse(line);
+            string model = doc.RootElement.GetProperty("payload").GetProperty("model").GetString()!;
+            Assert.Equal("gpt-5.4", model);
+            turnContextCount += 1;
+        }
+        Assert.Equal(2, turnContextCount);
+    }
+
+    [Fact]
     public async Task Status_ReturnsMalformedSqliteAsUnreadable()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
@@ -959,5 +1119,119 @@ public sealed class CoreIntegrationTests
 
         Assert.Contains("model_provider = \"manual\"", await File.ReadAllTextAsync(Path.Combine(fixture.CodexHome, "config.toml")));
         Assert.Contains("\"model_provider\":\"manual\"", await File.ReadAllTextAsync(sessionPath));
+    }
+
+    [Fact]
+    public async Task RunSync_RewritesTurnContextModelField_LinesLargerThan64KB()
+    {
+        // Regression guard for the long-line reader. Codex can pack a
+        // `developer_instructions` blob into a single `turn_context`
+        // payload, easily pushing the encoded JSON past 64 KB. The
+        // previous 64 KB scanner silently returned null for those
+        // files, so the rollout model rewrite was a no-op for
+        // sessions whose first turn was a long planning step.
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"MiniMax-M3\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-huge.jsonl");
+
+        await fixture.WriteRolloutWithTurnContextPayloadAsync(
+            sessionPath,
+            "thread-huge",
+            "apigather",
+            "gpt-5.4",
+            new Dictionary<string, object>
+            {
+                ["developer_instructions"] = new string('x', 150 * 1024)
+            });
+
+        string onDisk = await File.ReadAllTextAsync(sessionPath);
+        long longestLine = onDisk.Split('\n').Where(line => !string.IsNullOrEmpty(line)).Max(line => (long)line.Length);
+        Assert.True(longestLine > 64 * 1024, $"test setup: longest line should exceed 64 KB; got {longestLine}");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+        Assert.Equal(1, result.ChangedSessionFiles);
+
+        string rewritten = await File.ReadAllTextAsync(sessionPath);
+        int rewrittenCount = 0;
+        using (StringReader reader = new(rewritten))
+        {
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                using JsonDocument doc = JsonDocument.Parse(line);
+                Assert.Equal("MiniMax-M3", doc.RootElement.GetProperty("payload").GetProperty("model").GetString());
+                Assert.Equal("MiniMax-M3", doc.RootElement
+                    .GetProperty("payload")
+                    .GetProperty("collaboration_mode")
+                    .GetProperty("settings")
+                    .GetProperty("model")
+                    .GetString());
+                rewrittenCount += 1;
+            }
+        }
+
+        Assert.Equal(2, rewrittenCount);
+    }
+
+    [Fact]
+    public async Task RunSync_RewritesTurnContextModelField_WithRegexMetacharactersInModelName()
+    {
+        // Regression guard for regex escaping in the per-turn
+        // rewrite. A model name containing '.', '+', '*', '?', or
+        // '(' is a regex hazard: '.' is a regex any-char, '+' is a
+        // quantifier, and an unbalanced '{' would refuse to compile.
+        // The rewrite must match literally and not poison a decoy
+        // sibling whose pattern over-matches.
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"weird(target)+v2\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-rewrite.jsonl");
+        await fixture.WriteRolloutWithTurnContextAsync(sessionPath, "thread-rewrite", "apigather", "weird(target)+v2");
+        await File.AppendAllTextAsync(sessionPath, JsonSerializer.Serialize(new
+        {
+            timestamp = "2026-06-09T09:16:03.881Z",
+            type = "turn_context",
+            payload = new
+            {
+                turn_id = "decoy",
+                model = "weirdAtargetAv2"
+            }
+        }) + "\n");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+        Assert.Equal(1, result.ChangedSessionFiles);
+
+        string rewritten = await File.ReadAllTextAsync(sessionPath);
+        int totalContext = 0;
+        using (StringReader reader = new(rewritten))
+        {
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                totalContext += 1;
+                using JsonDocument doc = JsonDocument.Parse(line);
+                string turnId = doc.RootElement.GetProperty("payload").GetProperty("turn_id").GetString()!;
+                string model = doc.RootElement.GetProperty("payload").GetProperty("model").GetString()!;
+                if (turnId == "decoy")
+                {
+                    Assert.Equal("weirdAtargetAv2", model);
+                }
+                else
+                {
+                    Assert.Equal("weird(target)+v2", model);
+                }
+            }
+        }
+        Assert.Equal(3, totalContext);
     }
 }

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -1007,6 +1007,41 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSwitch_KeepRootModelStillAlignsRolloutAndSqlite()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"kept-root-model\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-keep-root.jsonl");
+        await fixture.WriteRolloutWithTurnContextAsync(
+            sessionPath,
+            "thread-keep-root",
+            "openai",
+            "old-model");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-keep-root", "openai", false)
+        ],
+            model: "old-model");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSwitchAsync(
+            fixture.CodexHome,
+            "apigather",
+            keepRootModel: true);
+
+        Assert.False(result.ModelSync.Applied);
+        Assert.Equal(1, result.SqliteModelRowsUpdated);
+        foreach (string line in (await File.ReadAllLinesAsync(sessionPath))
+            .Where(line => line.Contains("\"turn_context\"", StringComparison.Ordinal)))
+        {
+            using JsonDocument document = JsonDocument.Parse(line);
+            Assert.Equal(
+                "kept-root-model",
+                document.RootElement.GetProperty("payload").GetProperty("model").GetString());
+        }
+    }
+
+    [Fact]
     public async Task RunSync_RewritesTurnContextModelFieldInRolloutFiles()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
@@ -1224,7 +1259,7 @@ public sealed class CoreIntegrationTests
                 string model = doc.RootElement.GetProperty("payload").GetProperty("model").GetString()!;
                 if (turnId == "decoy")
                 {
-                    Assert.Equal("weirdAtargetAv2", model);
+                    Assert.Equal("weird(target)+v2", model);
                 }
                 else
                 {
@@ -1233,5 +1268,138 @@ public sealed class CoreIntegrationTests
             }
         }
         Assert.Equal(3, totalContext);
+    }
+
+    [Fact]
+    public async Task RunSync_RewritesModelOnlyChange_AndRestorePreservesOriginalFile()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\r\nmodel = \"MiniMax-M3\"\r\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-model-only.jsonl");
+        await fixture.WriteRolloutWithTurnContextAsync(
+            sessionPath,
+            "thread-model-only",
+            "openai",
+            "gpt-5.4");
+        string crlfContent = (await File.ReadAllTextAsync(sessionPath)).Replace("\n", "\r\n", StringComparison.Ordinal);
+        await File.WriteAllTextAsync(sessionPath, crlfContent);
+        DateTime originalTime = new(2026, 6, 9, 9, 0, 0, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(sessionPath, originalTime);
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-model-only", "openai", false)
+        ],
+            model: "gpt-5.4");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(1, result.ChangedSessionFiles);
+        Assert.Equal(1, result.SqliteModelRowsUpdated);
+        byte[] syncedBytes = await File.ReadAllBytesAsync(sessionPath);
+        Assert.Contains((byte)'\r', syncedBytes);
+        Assert.EndsWith("\r\n", await File.ReadAllTextAsync(sessionPath), StringComparison.Ordinal);
+        Assert.Equal(originalTime, File.GetLastWriteTimeUtc(sessionPath));
+
+        await service.RunRestoreAsync(fixture.CodexHome, result.BackupDir);
+
+        Assert.Equal(crlfContent, await File.ReadAllTextAsync(sessionPath));
+        Assert.Equal(originalTime, File.GetLastWriteTimeUtc(sessionPath));
+    }
+
+    [Fact]
+    public async Task RunSync_DetectsStaleModelsAfterAnAlreadyMatchingFirstTurn()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"target-model\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-mixed-models.jsonl");
+        await fixture.WriteRolloutWithTurnContextAsync(
+            sessionPath,
+            "thread-mixed-models",
+            "openai",
+            "target-model");
+        await File.AppendAllTextAsync(sessionPath, JsonSerializer.Serialize(new
+        {
+            timestamp = "2026-06-09T11:16:03.880Z",
+            type = "turn_context",
+            payload = new
+            {
+                turn_id = "stale-turn",
+                model = "stale-top-level",
+                collaboration_mode = new
+                {
+                    mode = "default",
+                    settings = new
+                    {
+                        model = "stale-nested"
+                    }
+                }
+            }
+        }) + "\n");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(1, result.ChangedSessionFiles);
+        foreach (string line in (await File.ReadAllLinesAsync(sessionPath))
+            .Where(line => line.Contains("\"turn_context\"", StringComparison.Ordinal)))
+        {
+            using JsonDocument document = JsonDocument.Parse(line);
+            JsonElement payload = document.RootElement.GetProperty("payload");
+            Assert.Equal("target-model", payload.GetProperty("model").GetString());
+            Assert.Equal(
+                "target-model",
+                payload.GetProperty("collaboration_mode").GetProperty("settings").GetProperty("model").GetString());
+        }
+
+        await service.RunRestoreAsync(fixture.CodexHome, result.BackupDir);
+        string restoredStaleLine = (await File.ReadAllLinesAsync(sessionPath))
+            .Single(line => line.Contains("\"stale-turn\"", StringComparison.Ordinal));
+        using JsonDocument restoredDocument = JsonDocument.Parse(restoredStaleLine);
+        JsonElement restoredPayload = restoredDocument.RootElement.GetProperty("payload");
+        Assert.Equal("stale-top-level", restoredPayload.GetProperty("model").GetString());
+        Assert.Equal(
+            "stale-nested",
+            restoredPayload.GetProperty("collaboration_mode").GetProperty("settings").GetProperty("model").GetString());
+    }
+
+    [Fact]
+    public async Task RestoreBackup_AcceptsVersionOneSessionManifest()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-legacy-manifest.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-legacy-manifest", "apigather");
+        string originalFirstLine = (await File.ReadAllLinesAsync(sessionPath))[0];
+        await fixture.WriteRolloutAsync(sessionPath, "thread-legacy-manifest", "openai");
+
+        string sessionManifest = JsonSerializer.Serialize(new
+        {
+            version = 1,
+            @namespace = AppConstants.BackupNamespace,
+            codexHome = fixture.CodexHome,
+            targetProvider = "openai",
+            createdAt = DateTimeOffset.UtcNow,
+            files = new[]
+            {
+                new
+                {
+                    path = sessionPath,
+                    originalFirstLine,
+                    originalSeparator = "\n"
+                }
+            }
+        });
+        await fixture.WriteBackupAsync(
+            "20260723T000000000Z",
+            ("session-meta-backup.json", sessionManifest),
+            ("config.toml", await File.ReadAllTextAsync(Path.Combine(fixture.CodexHome, "config.toml"))));
+
+        CodexSyncService service = new();
+        await service.RunRestoreAsync(
+            fixture.CodexHome,
+            fixture.BackupPath("20260723T000000000Z"));
+
+        Assert.Equal(originalFirstLine, (await File.ReadAllLinesAsync(sessionPath))[0]);
     }
 }

--- a/desktop/CodexProviderSync.Core.Tests/SettingsAndDiscoveryTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/SettingsAndDiscoveryTests.cs
@@ -3,6 +3,29 @@ namespace CodexProviderSync.Core.Tests;
 public sealed class SettingsAndDiscoveryTests
 {
     [Fact]
+    public void ConfigFileService_UpdatesCompactRootModelAssignment()
+    {
+        ConfigFileService service = new();
+
+        string updated = service.SetRootModelInConfigText(
+            "model_provider=\"openai\"\nmodel=\"old\"\n\n[model_providers.apigather]\nmodel=\"section\"\n",
+            "new");
+
+        Assert.Contains("model = \"new\"", updated);
+        Assert.Contains("model=\"section\"", updated);
+        Assert.Equal(1, updated.Split("model = \"new\"", StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
+    public void ConfigFileService_ReadsProviderModel_WhenProviderIdContainsRegexCharacters()
+    {
+        ConfigFileService service = new();
+        string config = "[model_providers.foo.bar+v2]\nmodel = \"special\"\n";
+
+        Assert.Equal("special", service.ReadProviderModel(config, "foo.bar+v2"));
+    }
+
+    [Fact]
     public async Task SettingsService_PersistsRecentPathsAndProviders()
     {
         string uniqueSettingsRoot = Path.Combine(Path.GetTempPath(), $"codex-provider-settings-{Guid.NewGuid():N}");

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -94,6 +94,88 @@ internal sealed class TestCodexHomeFixture
         await File.WriteAllTextAsync(filePath, $"{first}\n{second}\n");
     }
 
+    public async Task WriteRolloutWithTurnContextAsync(string filePath, string id, string provider, string model)
+    {
+        await WriteRolloutWithTurnContextPayloadAsync(filePath, id, provider, model, extraFields: null);
+    }
+
+    public async Task WriteRolloutWithTurnContextPayloadAsync(
+        string filePath,
+        string id,
+        string provider,
+        string model,
+        Dictionary<string, object>? extraFields)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        object payload = new
+        {
+            id,
+            timestamp = "2026-06-09T09:16:03.878Z",
+            cwd = "C:\\AITemp",
+            source = "cli",
+            cli_version = "0.115.0",
+            model_provider = provider
+        };
+        string first = JsonSerializer.Serialize(new
+        {
+            timestamp = "2026-06-09T09:16:03.878Z",
+            type = "session_meta",
+            payload
+        });
+        Dictionary<string, object> turnPayload = new()
+        {
+            ["turn_id"] = "019eabaa-e391-7e21-89cd-e761b5dee114",
+            ["cwd"] = "C:\\AITemp",
+            ["current_date"] = "2026-06-09",
+            ["model"] = model,
+            ["collaboration_mode"] = new
+            {
+                mode = "default",
+                settings = new
+                {
+                    model,
+                    reasoning_effort = "xhigh"
+                }
+            }
+        };
+        if (extraFields is not null)
+        {
+            foreach ((string key, object value) in extraFields)
+            {
+                turnPayload[key] = value;
+            }
+        }
+        string turnContext = JsonSerializer.Serialize(new
+        {
+            timestamp = "2026-06-09T09:16:03.880Z",
+            type = "turn_context",
+            payload = turnPayload
+        });
+        string heartbeat = JsonSerializer.Serialize(new
+        {
+            timestamp = "2026-06-09T10:16:03.880Z",
+            type = "turn_context",
+            payload = new
+            {
+                turn_id = "019eabaa-e391-7e21-89cd-e761b5dee115",
+                cwd = "C:\\AITemp",
+                current_date = "2026-06-09",
+                model,
+                collaboration_mode = new
+                {
+                    mode = "default",
+                    settings = new
+                    {
+                        model,
+                        reasoning_effort = "xhigh"
+                    }
+                }
+            }
+        });
+
+        await File.WriteAllTextAsync(filePath, $"{first}\n{turnContext}\n{heartbeat}\n");
+    }
+
     public async Task AppendEncryptedContentAsync(string filePath)
     {
         await File.AppendAllTextAsync(filePath, "{\"type\":\"event_msg\",\"payload\":{\"encrypted_content\":\"gAAA\"}}\n");
@@ -136,15 +218,20 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
     {
-        await WriteStateDbAtAsync(StateDbPath(), rows);
+        await WriteStateDbAtAsync(StateDbPath(), rows, model: null);
+    }
+
+    public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows, string? model)
+    {
+        await WriteStateDbAtAsync(StateDbPath(), rows, model: model);
     }
 
     public async Task WriteLegacyStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
     {
-        await WriteStateDbAtAsync(LegacyStateDbPath(), rows);
+        await WriteStateDbAtAsync(LegacyStateDbPath(), rows, model: null);
     }
 
-    private static async Task WriteStateDbAtAsync(string dbPath, IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
+    public async Task WriteStateDbAtAsync(string dbPath, IEnumerable<(string Id, string ModelProvider, bool Archived)> rows, string? model)
     {
         await using SqliteConnection connection = OpenSqliteConnection(dbPath);
         await connection.OpenAsync();
@@ -155,7 +242,8 @@ internal sealed class TestCodexHomeFixture
               model_provider TEXT,
               cwd TEXT NOT NULL DEFAULT '',
               archived INTEGER NOT NULL DEFAULT 0,
-              first_user_message TEXT NOT NULL DEFAULT ''
+              first_user_message TEXT NOT NULL DEFAULT '',
+              model TEXT
             )
             """;
         await create.ExecuteNonQueryAsync();
@@ -164,12 +252,13 @@ internal sealed class TestCodexHomeFixture
         {
             SqliteCommand insert = connection.CreateCommand();
             insert.CommandText = """
-                INSERT INTO threads (id, model_provider, cwd, archived, first_user_message)
-                VALUES ($id, $provider, 'C:\AITemp', $archived, 'hello')
+                INSERT INTO threads (id, model_provider, cwd, archived, first_user_message, model)
+                VALUES ($id, $provider, 'C:\AITemp', $archived, 'hello', $model)
                 """;
             insert.Parameters.AddWithValue("$id", id);
             insert.Parameters.AddWithValue("$provider", modelProvider);
             insert.Parameters.AddWithValue("$archived", archived ? 1 : 0);
+            insert.Parameters.AddWithValue("$model", (object?)model ?? DBNull.Value);
             await insert.ExecuteNonQueryAsync();
         }
     }

--- a/desktop/CodexProviderSync.Core/BackupService.cs
+++ b/desktop/CodexProviderSync.Core/BackupService.cs
@@ -60,7 +60,7 @@ public sealed class BackupService
         DateTimeOffset createdAt = DateTimeOffset.UtcNow;
         SessionBackupManifest sessionManifest = new()
         {
-            Version = 1,
+            Version = 2,
             Namespace = AppConstants.BackupNamespace,
             CodexHome = codexHome,
             TargetProvider = targetProvider,
@@ -70,7 +70,9 @@ public sealed class BackupService
                 Path = change.Path,
                 OriginalFirstLine = change.OriginalFirstLine,
                 OriginalSeparator = change.OriginalSeparator,
-                OriginalLastWriteTimeUtcTicks = change.OriginalLastWriteTimeUtcTicks
+                OriginalLastWriteTimeUtcTicks = change.OriginalLastWriteTimeUtcTicks,
+                ModelOnlyChange = change.ModelOnlyChange,
+                OriginalTurnContextModels = [.. change.OriginalTurnContextModels]
             }).ToList()
         };
         await File.WriteAllTextAsync(
@@ -193,7 +195,7 @@ public sealed class BackupService
 
         sessionManifest = new SessionBackupManifest
         {
-            Version = sessionManifest.Version,
+            Version = 2,
             Namespace = sessionManifest.Namespace,
             CodexHome = sessionManifest.CodexHome,
             TargetProvider = sessionManifest.TargetProvider,
@@ -203,7 +205,9 @@ public sealed class BackupService
                 Path = change.Path,
                 OriginalFirstLine = change.OriginalFirstLine,
                 OriginalSeparator = change.OriginalSeparator,
-                OriginalLastWriteTimeUtcTicks = change.OriginalLastWriteTimeUtcTicks
+                OriginalLastWriteTimeUtcTicks = change.OriginalLastWriteTimeUtcTicks,
+                ModelOnlyChange = change.ModelOnlyChange,
+                OriginalTurnContextModels = [.. change.OriginalTurnContextModels]
             }).ToList()
         };
         metadata = new BackupMetadataFile

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -97,7 +97,8 @@ public sealed class CodexSyncService
         string? provider = null,
         string? configBackupText = null,
         int keepCount = AppConstants.DefaultBackupRetentionCount,
-        int? sqliteBusyTimeoutMs = null)
+        int? sqliteBusyTimeoutMs = null,
+        string? model = null)
     {
         if (keepCount < 1)
         {
@@ -110,6 +111,17 @@ public sealed class CodexSyncService
         string configText = await _configFileService.ReadConfigTextAsync(configPath);
         CurrentProviderInfo current = _configFileService.ReadCurrentProviderFromConfigText(configText);
         string targetProvider = provider ?? current.Provider ?? AppConstants.DefaultProvider;
+
+        // When the caller did not pin a model, mirror the active root-level
+        // `model = "..."` field from config.toml into the per-thread SQLite
+        // `model` column. Without this, old sessions keep showing the model
+        // they were created with in Codex's bottom-right UI label, even after
+        // the root-level `model` changes.
+        string? targetModel = model;
+        if (string.IsNullOrEmpty(targetModel))
+        {
+            targetModel = _configFileService.ReadRootModelFromConfigText(configText);
+        }
 
         await using LockHandle _ = await _lockService.AcquireLockAsync(codexHome, "sync");
 
@@ -141,14 +153,15 @@ public sealed class CodexSyncService
         try
         {
             SessionApplyResult? applyResult = null;
-            (int updatedRows, int providerRowsUpdated, int userEventRowsUpdated, int cwdRowsUpdated, bool databasePresent) = await _sqliteStateService.UpdateSqliteProviderAsync(
+            (int updatedRows, int providerRowsUpdated, int modelRowsUpdated, int userEventRowsUpdated, int cwdRowsUpdated, bool databasePresent) = await _sqliteStateService.UpdateSqliteProviderAsync(
                 codexHome,
                 targetProvider,
+                targetModel,
                 async _ =>
                 {
                     if (writableChanges.Count > 0)
                     {
-                        applyResult = await _sessionRolloutService.ApplySessionChangesAsync(writableChanges);
+                        applyResult = await _sessionRolloutService.ApplySessionChangesAsync(writableChanges, targetModel);
                         HashSet<string> appliedPathSet = new(applyResult.AppliedPaths, StringComparer.Ordinal);
                         appliedSessionChanges = writableChanges.Where(change => appliedPathSet.Contains(change.Path)).ToList();
                         sessionRestoreNeeded = appliedSessionChanges.Count > 0;
@@ -186,6 +199,7 @@ public sealed class CodexSyncService
                 SkippedUnreadableRolloutFiles = skippedUnreadableRolloutFiles,
                 SqliteRowsUpdated = updatedRows,
                 SqliteProviderRowsUpdated = providerRowsUpdated,
+                SqliteModelRowsUpdated = modelRowsUpdated,
                 SqliteUserEventRowsUpdated = userEventRowsUpdated,
                 SqliteCwdRowsUpdated = cwdRowsUpdated,
                 UpdatedWorkspaceRoots = workspaceRootResult.UpdatedWorkspaceRoots,
@@ -238,7 +252,9 @@ public sealed class CodexSyncService
     public async Task<SyncResult> RunSwitchAsync(
         string? explicitCodexHome,
         string provider,
-        int keepCount = AppConstants.DefaultBackupRetentionCount)
+        int keepCount = AppConstants.DefaultBackupRetentionCount,
+        string? model = null,
+        bool keepRootModel = false)
     {
         if (string.IsNullOrWhiteSpace(provider))
         {
@@ -257,11 +273,22 @@ public sealed class CodexSyncService
         }
 
         string nextConfigText = _configFileService.SetRootProviderInConfigText(originalConfigText, provider);
+        ModelSyncOutcome modelSync = ResolveModelSyncOutcome(originalConfigText, provider, model, keepRootModel);
+        if (modelSync.Applied)
+        {
+            nextConfigText = _configFileService.SetRootModelInConfigText(nextConfigText, modelSync.Model!);
+        }
+
         await _configFileService.WriteConfigTextAsync(configPath, nextConfigText);
 
         try
         {
-            SyncResult result = await RunSyncAsync(codexHome, provider, originalConfigText, keepCount);
+            // Forward the resolved model to RunSyncAsync so the per-thread
+            // SQLite `model` column also gets aligned with the new value. If
+            // the switch did not apply a model (keepRootModel, no model
+            // found, etc.), pass null so the legacy behaviour is preserved.
+            string? modelForThreads = modelSync.Applied ? modelSync.Model : null;
+            SyncResult result = await RunSyncAsync(codexHome, provider, originalConfigText, keepCount, model: modelForThreads);
             return new SyncResult
             {
                 CodexHome = result.CodexHome,
@@ -273,6 +300,7 @@ public sealed class CodexSyncService
                 SkippedUnreadableRolloutFiles = result.SkippedUnreadableRolloutFiles,
                 SqliteRowsUpdated = result.SqliteRowsUpdated,
                 SqliteProviderRowsUpdated = result.SqliteProviderRowsUpdated,
+                SqliteModelRowsUpdated = result.SqliteModelRowsUpdated,
                 SqliteUserEventRowsUpdated = result.SqliteUserEventRowsUpdated,
                 SqliteCwdRowsUpdated = result.SqliteCwdRowsUpdated,
                 UpdatedWorkspaceRoots = result.UpdatedWorkspaceRoots,
@@ -282,6 +310,7 @@ public sealed class CodexSyncService
                 EncryptedContentCounts = result.EncryptedContentCounts,
                 EncryptedContentWarning = result.EncryptedContentWarning,
                 ConfigUpdated = true,
+                ModelSync = modelSync,
                 AutoPruneResult = result.AutoPruneResult,
                 AutoPruneWarning = result.AutoPruneWarning
             };
@@ -291,6 +320,44 @@ public sealed class CodexSyncService
             await _configFileService.WriteConfigTextAsync(configPath, originalConfigText);
             throw;
         }
+    }
+
+    private ModelSyncOutcome ResolveModelSyncOutcome(
+        string originalConfigText,
+        string provider,
+        string? model,
+        bool keepRootModel)
+    {
+        if (model is not null)
+        {
+            if (model.Length == 0)
+            {
+                throw new ArgumentException(
+                    "Invalid --model value. Expected a non-empty string.",
+                    nameof(model));
+            }
+            return ModelSyncOutcome.CreateApplied("explicit", model);
+        }
+
+        if (keepRootModel)
+        {
+            return ModelSyncOutcome.CreateSkipped("keep-root-model", warning: null);
+        }
+
+        string? providerModel = _configFileService.ReadProviderModel(originalConfigText, provider);
+        if (providerModel is not null)
+        {
+            return ModelSyncOutcome.CreateApplied("provider-section", providerModel);
+        }
+
+        if (!string.Equals(provider, AppConstants.DefaultProvider, StringComparison.Ordinal))
+        {
+            return ModelSyncOutcome.CreateSkipped(
+                "none",
+                warning: $"Provider \"{provider}\" has no model field in [model_providers.{provider}]; root-level model left unchanged. Use --model <name> to set it explicitly, or pass keepRootModel to suppress this warning.");
+        }
+
+        return ModelSyncOutcome.CreateSkipped("none", warning: null);
     }
 
     public async Task<RestoreResult> RunRestoreAsync(string? explicitCodexHome, string backupDir)

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -125,7 +125,11 @@ public sealed class CodexSyncService
 
         await using LockHandle _ = await _lockService.AcquireLockAsync(codexHome, "sync");
 
-        SessionChangeCollection sessionInfo = await _sessionRolloutService.CollectSessionChangesAsync(codexHome, targetProvider, skipLockedReads: true);
+        SessionChangeCollection sessionInfo = await _sessionRolloutService.CollectSessionChangesAsync(
+            codexHome,
+            targetProvider,
+            skipLockedReads: true,
+            targetModel: targetModel);
         IReadOnlyList<ThreadCwdStat> workspaceCwdStats = await _globalStateService.ReadThreadCwdStatsAsync(codexHome);
         string? encryptedContentWarning = BuildEncryptedContentWarning(sessionInfo.EncryptedContentCounts, targetProvider);
         (IReadOnlyList<SessionChange> writableChanges, IReadOnlyList<SessionChange> lockedChanges) =
@@ -283,11 +287,11 @@ public sealed class CodexSyncService
 
         try
         {
-            // Forward the resolved model to RunSyncAsync so the per-thread
-            // SQLite `model` column also gets aligned with the new value. If
-            // the switch did not apply a model (keepRootModel, no model
-            // found, etc.), pass null so the legacy behaviour is preserved.
-            string? modelForThreads = modelSync.Applied ? modelSync.Model : null;
+            // Even when the switch keeps the existing root model, keep
+            // SQLite and rollout turn_context fields aligned with it.
+            string? modelForThreads = modelSync.Applied
+                ? modelSync.Model
+                : _configFileService.ReadRootModelFromConfigText(nextConfigText);
             SyncResult result = await RunSyncAsync(codexHome, provider, originalConfigText, keepCount, model: modelForThreads);
             return new SyncResult
             {

--- a/desktop/CodexProviderSync.Core/ConfigFileService.cs
+++ b/desktop/CodexProviderSync.Core/ConfigFileService.cs
@@ -11,6 +11,9 @@ public sealed partial class ConfigFileService
     [GeneratedRegex("""^\[model_providers\.([A-Za-z0-9_.-]+)]\s*$""", RegexOptions.Multiline)]
     private static partial Regex ProviderRegex();
 
+    [GeneratedRegex("""^\s*model\s*=\s*"([^"]+)"\s*$""")]
+    private static partial Regex ModelAssignmentRegex();
+
     public Task<string> ReadConfigTextAsync(string configPath)
     {
         return File.ReadAllTextAsync(configPath);
@@ -66,6 +69,48 @@ public sealed partial class ConfigFileService
         return ListConfiguredProviderIds(configText).Contains(provider, StringComparer.Ordinal);
     }
 
+    public string? ReadRootModelFromConfigText(string configText)
+    {
+        if (string.IsNullOrEmpty(configText))
+        {
+            return null;
+        }
+
+        // The root-level `model` field lives in the preamble before any
+        // [table] header. We scan line-by-line, stop at the first [section],
+        // and return the value of `model = "..."` if present. This mirrors
+        // the JS side's `^\s*model\s*=\s*"([^"]+)"\s*$/m` walk, and is what
+        // Sync uses to mirror the active model into the per-thread SQLite
+        // `model` column. Commented-out lines (starting with `#`) and blank
+        // lines are skipped, matching the JS behavior.
+        foreach (string raw in SplitLines(configText))
+        {
+            string line = raw.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            if (line.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (line.StartsWith('['))
+            {
+                break;
+            }
+
+            Match match = ModelAssignmentRegex().Match(line);
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+
+        return null;
+    }
+
     public string SetRootProviderInConfigText(string configText, string provider)
     {
         string newline = DetectNewline(configText);
@@ -99,6 +144,88 @@ public sealed partial class ConfigFileService
         lines.Insert(insertIndex, $"model_provider = \"{EscapeTomlString(provider)}\"");
         string nextText = string.Join(newline, lines);
         return configText.EndsWith(newline, StringComparison.Ordinal) ? nextText + newline : nextText;
+    }
+
+    public string SetRootModelInConfigText(string configText, string model)
+    {
+        if (string.IsNullOrEmpty(model))
+        {
+            throw new ArgumentException("Model must be a non-empty string.", nameof(model));
+        }
+
+        string newline = DetectNewline(configText);
+        List<string> lines = SplitLines(configText).ToList();
+        int insertIndex = lines.Count;
+
+        for (int index = 0; index < lines.Count; index += 1)
+        {
+            string trimmed = lines[index].Trim();
+            if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith('#'))
+            {
+                insertIndex = index + 1;
+                continue;
+            }
+
+            if (trimmed.StartsWith('['))
+            {
+                insertIndex = index;
+                break;
+            }
+
+            if (trimmed.StartsWith("model =", StringComparison.Ordinal))
+            {
+                lines[index] = $"model = \"{EscapeTomlString(model)}\"";
+                return string.Join(newline, lines) + (configText.EndsWith(newline, StringComparison.Ordinal) ? newline : string.Empty);
+            }
+
+            insertIndex = index + 1;
+        }
+
+        lines.Insert(insertIndex, $"model = \"{EscapeTomlString(model)}\"");
+        string nextText = string.Join(newline, lines);
+        return configText.EndsWith(newline, StringComparison.Ordinal) ? nextText + newline : nextText;
+    }
+
+    public string? ReadProviderModel(string configText, string provider)
+    {
+        if (string.Equals(provider, AppConstants.DefaultProvider, StringComparison.Ordinal))
+        {
+            // Built-in openai has no [model_providers.openai] section.
+            return null;
+        }
+
+        List<string> lines = SplitLines(configText).ToList();
+        string sectionHeader = $"[model_providers.{Regex.Escape(provider)}]";
+        int sectionStartIndex = -1;
+        for (int index = 0; index < lines.Count; index += 1)
+        {
+            if (lines[index].Trim().Equals(sectionHeader, StringComparison.Ordinal))
+            {
+                sectionStartIndex = index;
+                break;
+            }
+        }
+
+        if (sectionStartIndex < 0)
+        {
+            return null;
+        }
+
+        for (int index = sectionStartIndex + 1; index < lines.Count; index += 1)
+        {
+            string trimmed = lines[index].Trim();
+            if (trimmed.StartsWith('['))
+            {
+                break;
+            }
+            Match match = ModelAssignmentRegex().Match(lines[index]);
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+
+        return null;
     }
 
     private static IEnumerable<string> SplitLines(string text)

--- a/desktop/CodexProviderSync.Core/ConfigFileService.cs
+++ b/desktop/CodexProviderSync.Core/ConfigFileService.cs
@@ -132,7 +132,7 @@ public sealed partial class ConfigFileService
                 break;
             }
 
-            if (trimmed.StartsWith("model_provider =", StringComparison.Ordinal))
+            if (Regex.IsMatch(trimmed, "^model_provider\\s*="))
             {
                 lines[index] = $"model_provider = \"{EscapeTomlString(provider)}\"";
                 return string.Join(newline, lines) + (configText.EndsWith(newline, StringComparison.Ordinal) ? newline : string.Empty);
@@ -172,7 +172,7 @@ public sealed partial class ConfigFileService
                 break;
             }
 
-            if (trimmed.StartsWith("model =", StringComparison.Ordinal))
+            if (Regex.IsMatch(trimmed, "^model\\s*="))
             {
                 lines[index] = $"model = \"{EscapeTomlString(model)}\"";
                 return string.Join(newline, lines) + (configText.EndsWith(newline, StringComparison.Ordinal) ? newline : string.Empty);
@@ -195,7 +195,7 @@ public sealed partial class ConfigFileService
         }
 
         List<string> lines = SplitLines(configText).ToList();
-        string sectionHeader = $"[model_providers.{Regex.Escape(provider)}]";
+        string sectionHeader = $"[model_providers.{provider}]";
         int sectionStartIndex = -1;
         for (int index = 0; index < lines.Count; index += 1)
         {

--- a/desktop/CodexProviderSync.Core/Models.cs
+++ b/desktop/CodexProviderSync.Core/Models.cs
@@ -76,6 +76,15 @@ public sealed class SessionChange
     public required long OriginalFileLength { get; init; }
     public required long OriginalLastWriteTimeUtcTicks { get; init; }
     public required string OriginalProvider { get; init; }
+    // The model that the rollout's first `turn_context` event
+    // currently advertises. Used by the rewrite pass to know which
+    // value to swap out across every turn_context line in the file
+    // so that the Codex GUI bottom-right of an old conversation
+    // reflects the active provider's model. Null when the rollout
+    // does not expose a model field we recognise (e.g. legacy or
+    // unusually formatted files), in which case the model rewrite
+    // pass is a no-op.
+    public string? OriginalModel { get; init; }
     public required string UpdatedFirstLine { get; init; }
 }
 
@@ -101,6 +110,7 @@ public sealed class SyncResult
     public required IReadOnlyList<string> SkippedUnreadableRolloutFiles { get; init; }
     public required int SqliteRowsUpdated { get; init; }
     public int SqliteProviderRowsUpdated { get; init; }
+    public int SqliteModelRowsUpdated { get; init; }
     public int SqliteUserEventRowsUpdated { get; init; }
     public int SqliteCwdRowsUpdated { get; init; }
     public int UpdatedWorkspaceRoots { get; init; }
@@ -110,8 +120,37 @@ public sealed class SyncResult
     public required ProviderCounts EncryptedContentCounts { get; init; }
     public string? EncryptedContentWarning { get; init; }
     public bool ConfigUpdated { get; init; }
+    public ModelSyncOutcome ModelSync { get; init; } = ModelSyncOutcome.NotApplicable();
     public BackupPruneResult? AutoPruneResult { get; init; }
     public string? AutoPruneWarning { get; init; }
+}
+
+public sealed class ModelSyncOutcome
+{
+    public required bool Applied { get; init; }
+    public string Source { get; init; } = "none";
+    public string? Model { get; init; }
+    public string? Warning { get; init; }
+
+    public static ModelSyncOutcome CreateApplied(string source, string model) => new()
+    {
+        Applied = true,
+        Source = source,
+        Model = model
+    };
+
+    public static ModelSyncOutcome CreateSkipped(string source, string? warning) => new()
+    {
+        Applied = false,
+        Source = source,
+        Warning = warning
+    };
+
+    public static ModelSyncOutcome NotApplicable() => new()
+    {
+        Applied = false,
+        Source = "not-applicable"
+    };
 }
 
 public sealed class SessionApplyResult

--- a/desktop/CodexProviderSync.Core/Models.cs
+++ b/desktop/CodexProviderSync.Core/Models.cs
@@ -76,16 +76,16 @@ public sealed class SessionChange
     public required long OriginalFileLength { get; init; }
     public required long OriginalLastWriteTimeUtcTicks { get; init; }
     public required string OriginalProvider { get; init; }
-    // The model that the rollout's first `turn_context` event
-    // currently advertises. Used by the rewrite pass to know which
-    // value to swap out across every turn_context line in the file
-    // so that the Codex GUI bottom-right of an old conversation
-    // reflects the active provider's model. Null when the rollout
-    // does not expose a model field we recognise (e.g. legacy or
-    // unusually formatted files), in which case the model rewrite
-    // pass is a no-op.
-    public string? OriginalModel { get; init; }
     public required string UpdatedFirstLine { get; init; }
+    public bool ModelOnlyChange { get; init; }
+    public IReadOnlyList<TurnContextModelBackup> OriginalTurnContextModels { get; set; } = [];
+}
+
+public sealed class TurnContextModelBackup
+{
+    public required int LineIndex { get; init; }
+    public required string OriginalModel { get; init; }
+    public IReadOnlyList<string> OriginalModels { get; init; } = [];
 }
 
 public sealed class SessionChangeCollection
@@ -242,6 +242,8 @@ internal sealed class SessionBackupManifestEntry
     public required string OriginalFirstLine { get; init; }
     public required string OriginalSeparator { get; init; }
     public long? OriginalLastWriteTimeUtcTicks { get; init; }
+    public bool ModelOnlyChange { get; init; }
+    public List<TurnContextModelBackup> OriginalTurnContextModels { get; init; } = [];
 }
 
 public sealed class WorkspaceRootSyncResult

--- a/desktop/CodexProviderSync.Core/SessionRolloutService.cs
+++ b/desktop/CodexProviderSync.Core/SessionRolloutService.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace CodexProviderSync.Core;
@@ -97,6 +98,12 @@ public sealed class SessionRolloutService
                 {
                     FileSnapshot snapshot = GetFileSnapshot(rolloutPath);
                     payload["model_provider"] = targetProvider;
+                    // Peek at the first turn_context event in the rollout
+                    // to capture the per-turn `model` field that the
+                    // Codex GUI bottom-right of an old conversation
+                    // reads. This is the value the model rewrite pass
+                    // will swap to the active root-level model.
+                    string? originalModel = await ReadFirstTurnContextModelAsync(rolloutPath, record);
                     changes.Add(new SessionChange
                     {
                         Path = rolloutPath,
@@ -108,6 +115,7 @@ public sealed class SessionRolloutService
                         OriginalFileLength = snapshot.Length,
                         OriginalLastWriteTimeUtcTicks = snapshot.LastWriteTimeUtcTicks,
                         OriginalProvider = currentProvider,
+                        OriginalModel = originalModel,
                         UpdatedFirstLine = root!.ToJsonString()
                     });
                 }
@@ -134,7 +142,9 @@ public sealed class SessionRolloutService
         };
     }
 
-    public async Task<SessionApplyResult> ApplySessionChangesAsync(IEnumerable<SessionChange> changes)
+    public async Task<SessionApplyResult> ApplySessionChangesAsync(
+        IEnumerable<SessionChange> changes,
+        string? targetModel = null)
     {
         int appliedCount = 0;
         List<string> appliedPaths = [];
@@ -147,6 +157,16 @@ public sealed class SessionRolloutService
                 TryRestoreLastWriteTimeUtc(change.Path, change.OriginalLastWriteTimeUtcTicks);
                 appliedCount += 1;
                 appliedPaths.Add(change.Path);
+                // After the first-line rewrite succeeds, do a
+                // second pass that updates the per-turn `model`
+                // field in every turn_context event of the file.
+                // The Codex GUI bottom-right of an old conversation
+                // reads that field, so we have to keep it in sync
+                // with the active root-level model.
+                if (!string.IsNullOrEmpty(targetModel))
+                {
+                    await TryRewriteRolloutModelFieldAsync(change, targetModel);
+                }
             }
             else
             {
@@ -298,7 +318,7 @@ public sealed class SessionRolloutService
             await RewriteFirstLineAsync(
                 sourceStream,
                 change.Path,
-                change.UpdatedFirstLine,
+                change.UpdatedFirstLine!,
                 change.OriginalSeparator,
                 change.OriginalOffset,
                 headerOnly: change.OriginalOffset >= change.OriginalFileLength);
@@ -378,6 +398,216 @@ public sealed class SessionRolloutService
         {
             ArrayPool<byte>.Shared.Return(buffer);
         }
+    }
+
+    // Scan the start of a rollout file looking for the first
+    // `turn_context` event and return its `payload.model` field.
+    // This is the field that the Codex GUI bottom-right of an old
+    // conversation reads, so we have to capture it here and rewrite
+    // it (along with `payload.collaboration_mode.settings.model`)
+    // on every sync, in addition to the per-thread SQLite `model`
+    // column. We stream line-by-line because individual
+    // `turn_context` lines can easily exceed 64 KB once Codex
+    // embeds a `developer_instructions` blob into the payload — the
+    // previous 64 KB scanner silently missed those, which made the
+    // rollout model rewrite a no-op for sessions whose first turn
+    // was a long planning step. We stop as soon as we find a
+    // matching line.
+    // `turn_context` after the leading `session_meta` line is
+    // enough to know what model the rest of the file uses.
+    private static async Task<string?> ReadFirstTurnContextModelAsync(
+        string rolloutPath,
+        FirstLineRecord record)
+    {
+        try
+        {
+            await using FileStream stream = new(
+                rolloutPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            stream.Seek(record.Offset, SeekOrigin.Begin);
+            using StreamReader reader = new(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 4096, leaveOpen: true);
+            string? line;
+            while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
+            {
+                if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    JsonNode? node = JsonNode.Parse(line);
+                    if (node is null)
+                    {
+                        continue;
+                    }
+
+                    string? type = node["type"]?.GetValue<string>();
+                    if (!string.Equals(type, "turn_context", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    string? model = node["payload"]?["model"]?.GetValue<string>();
+                    if (!string.IsNullOrEmpty(model))
+                    {
+                        return model;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Skip malformed lines and keep scanning.
+                }
+            }
+            return null;
+        }
+        catch (Exception error) when (IsRolloutFileBusyError(error))
+        {
+            throw WrapRolloutFileBusyError(error, rolloutPath, "read");
+        }
+    }
+
+    // Rewrite the per-turn `model` field in every `turn_context`
+    // event of the rollout. The Codex GUI bottom-right of an old
+    // conversation reads that field, so we have to keep it aligned
+    // with the active root-level model. We do a line-by-line
+    // regex rewrite instead of round-tripping the JSON tree to
+    // avoid mangling the multi-megabyte `developer_instructions`
+    // blob Codex writes into every `turn_context`.
+    private async Task TryRewriteRolloutModelFieldAsync(SessionChange change, string targetModel)
+    {
+        if (string.IsNullOrEmpty(change.OriginalModel))
+        {
+            return;
+        }
+        if (string.IsNullOrEmpty(targetModel))
+        {
+            return;
+        }
+        if (string.Equals(change.OriginalModel, targetModel, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Snapshot the file as it stands after the first-line
+        // rewrite. We cannot compare against `change.OriginalFileLength`
+        // because the first-line rewrite already changed the size
+        // (the new first line is often a different length than the
+        // original one).
+        FileInfo beforeInfo = new(change.Path);
+        long beforeSize = beforeInfo.Length;
+        DateTime beforeMtimeUtc = beforeInfo.LastWriteTimeUtc;
+
+        string tempPath = $"{change.Path}.provider-sync-model.{Environment.ProcessId}.{DateTime.UtcNow.Ticks}.{Guid.NewGuid():N}.tmp";
+        // If a previous run left a leftover at the same path (which
+        // shouldn't normally happen because of the Guid suffix, but
+        // can occur when tests share a process and timestamps
+        // collide), clean it up before opening.
+        if (File.Exists(tempPath))
+        {
+            File.Delete(tempPath);
+        }
+
+        bool replacements = false;
+        try
+        {
+            await using (FileStream sourceStream = OpenExclusiveRewriteStream(change.Path))
+            {
+                await using FileStream writeStream = new(
+                    tempPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None);
+                await using StreamWriter writer = new(writeStream, new UTF8Encoding(false));
+                using StreamReader reader = new(sourceStream, Encoding.UTF8, false, 64 * 1024, leaveOpen: true);
+                bool firstLine = true;
+                string? line;
+                while ((line = await reader.ReadLineAsync()) is not null)
+                {
+                    string next = firstLine
+                        ? line
+                        : RewriteTurnContextModelInLine(line, change.OriginalModel!, targetModel);
+                    if (!string.Equals(next, line, StringComparison.Ordinal))
+                    {
+                        replacements = true;
+                    }
+                    if (!firstLine)
+                    {
+                        await writer.WriteAsync('\n');
+                    }
+                    firstLine = false;
+                    await writer.WriteAsync(next);
+                }
+            }
+
+            if (!replacements)
+            {
+                File.Delete(tempPath);
+                return;
+            }
+
+            // Refuse to swap in the new file if Codex appended
+            // anything between our snapshot and the rename, so we
+            // do not silently drop trailing events.
+            FileInfo afterInfo = new(change.Path);
+            if (afterInfo.Length != beforeSize || afterInfo.LastWriteTimeUtc != beforeMtimeUtc)
+            {
+                File.Delete(tempPath);
+                return;
+            }
+
+            File.Move(tempPath, change.Path, overwrite: true);
+        }
+        catch (Exception error)
+        {
+            try
+            {
+                File.Delete(tempPath);
+            }
+            catch
+            {
+                // Ignore cleanup failures and surface the original error.
+            }
+            throw WrapRolloutFileBusyError(error, change.Path, "rewrite model field");
+        }
+    }
+
+    private static string RewriteTurnContextModelInLine(string line, string oldModel, string newModel)
+    {
+        if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+        {
+            return line;
+        }
+        // We need TWO escapes here:
+        //   - JSON-string escape so the old/new model name can be
+        //     embedded back into a JSON string value (handle `\` and
+        //     `"`).
+        //   - regex escape so model names that happen to contain
+        //     regex metacharacters (`.`, `+`, `*`, `?`, `(`, `)`,
+        //     `|`, `[`, `]`, `{`, `}`, `^`, `$`, `\`) do not
+        //     over-match or break the pattern. Without this, a
+        //     model named `gpt-5.4-mini` would also match
+        //     `gpt-5X4Xmini` and a model named `foo+bar` would
+        //     either fail to compile or behave unexpectedly.
+        // The order matters: regex-escape first so the JSON-string
+        // escape of `\` (which inserts a backslash before every
+        // `\`) does not double up the regex escapes we just
+        // inserted.
+        string escapedOld = System.Text.RegularExpressions.Regex.Escape(EscapeForJsonString(oldModel));
+        string escapedNew = EscapeForJsonString(newModel);
+        return System.Text.RegularExpressions.Regex.Replace(
+            line,
+            "\"model\"\\s*:\\s*\"" + escapedOld + "\"",
+            m => "\"model\":\"" + escapedNew + "\"");
+    }
+
+    private static string EscapeForJsonString(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
     }
 
     private static async Task RewriteFirstLineAsync(

--- a/desktop/CodexProviderSync.Core/SessionRolloutService.cs
+++ b/desktop/CodexProviderSync.Core/SessionRolloutService.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 
 namespace CodexProviderSync.Core;
 
@@ -13,7 +14,8 @@ public sealed class SessionRolloutService
     public async Task<SessionChangeCollection> CollectSessionChangesAsync(
         string codexHome,
         string targetProvider,
-        bool skipLockedReads = false)
+        bool skipLockedReads = false,
+        string? targetModel = null)
     {
         List<SessionChange> changes = [];
         List<string> lockedPaths = [];
@@ -93,17 +95,36 @@ public sealed class SessionRolloutService
                     encryptedBucket[currentProvider] = encryptedBucket.TryGetValue(currentProvider, out int encryptedCount) ? encryptedCount + 1 : 1;
                 }
 
-                if (!string.Equals(targetProvider, StatusOnlyProvider, StringComparison.Ordinal)
-                    && !string.Equals(currentProvider, targetProvider, StringComparison.Ordinal))
+                bool providerChanged = !string.Equals(targetProvider, StatusOnlyProvider, StringComparison.Ordinal)
+                    && !string.Equals(currentProvider, targetProvider, StringComparison.Ordinal);
+                IReadOnlyList<string> currentModels = [];
+                bool modelChanged = false;
+                if (!string.IsNullOrEmpty(targetModel))
+                {
+                    try
+                    {
+                        currentModels = await ReadTurnContextModelsAsync(rolloutPath, record);
+                        modelChanged = currentModels.Any(model => !string.Equals(model, targetModel, StringComparison.Ordinal));
+                    }
+                    catch (Exception error) when (skipLockedReads && IsRolloutFileBusyError(error))
+                    {
+                        lockedPaths.Add(rolloutPath);
+                        continue;
+                    }
+                    catch (Exception error) when (skipLockedReads && IsRolloutFileUnreadableError(error))
+                    {
+                        unreadablePaths.Add(rolloutPath);
+                        continue;
+                    }
+                }
+
+                if (providerChanged || modelChanged)
                 {
                     FileSnapshot snapshot = GetFileSnapshot(rolloutPath);
-                    payload["model_provider"] = targetProvider;
-                    // Peek at the first turn_context event in the rollout
-                    // to capture the per-turn `model` field that the
-                    // Codex GUI bottom-right of an old conversation
-                    // reads. This is the value the model rewrite pass
-                    // will swap to the active root-level model.
-                    string? originalModel = await ReadFirstTurnContextModelAsync(rolloutPath, record);
+                    if (providerChanged)
+                    {
+                        payload["model_provider"] = targetProvider;
+                    }
                     changes.Add(new SessionChange
                     {
                         Path = rolloutPath,
@@ -115,8 +136,8 @@ public sealed class SessionRolloutService
                         OriginalFileLength = snapshot.Length,
                         OriginalLastWriteTimeUtcTicks = snapshot.LastWriteTimeUtcTicks,
                         OriginalProvider = currentProvider,
-                        OriginalModel = originalModel,
-                        UpdatedFirstLine = root!.ToJsonString()
+                        UpdatedFirstLine = providerChanged ? root!.ToJsonString() : record.FirstLine,
+                        ModelOnlyChange = !providerChanged && modelChanged
                     });
                 }
             }
@@ -152,26 +173,43 @@ public sealed class SessionRolloutService
 
         foreach (SessionChange change in changes)
         {
-            if (await TryRewriteCollectedSessionChangeAsync(change))
-            {
-                TryRestoreLastWriteTimeUtc(change.Path, change.OriginalLastWriteTimeUtcTicks);
-                appliedCount += 1;
-                appliedPaths.Add(change.Path);
-                // After the first-line rewrite succeeds, do a
-                // second pass that updates the per-turn `model`
-                // field in every turn_context event of the file.
-                // The Codex GUI bottom-right of an old conversation
-                // reads that field, so we have to keep it in sync
-                // with the active root-level model.
-                if (!string.IsNullOrEmpty(targetModel))
-                {
-                    await TryRewriteRolloutModelFieldAsync(change, targetModel);
-                }
-            }
-            else
+            bool providerApplied = change.ModelOnlyChange || await TryRewriteCollectedSessionChangeAsync(change);
+            if (!providerApplied)
             {
                 skippedPaths.Add(change.Path);
+                continue;
             }
+
+            ModelRewriteResult modelResult = ModelRewriteResult.Empty;
+            try
+            {
+                if (!string.IsNullOrEmpty(targetModel))
+                {
+                    modelResult = await TryRewriteRolloutModelFieldAsync(change, targetModel);
+                    change.OriginalTurnContextModels = modelResult.OriginalModels;
+                }
+            }
+            catch
+            {
+                if (!change.ModelOnlyChange)
+                {
+                    await RewriteFirstLineAsync(
+                        change.Path,
+                        change.OriginalFirstLine,
+                        change.OriginalSeparator);
+                }
+                TryRestoreLastWriteTimeUtc(change.Path, change.OriginalLastWriteTimeUtcTicks);
+                throw;
+            }
+            if (change.ModelOnlyChange && modelResult.ReplacedLines == 0)
+            {
+                skippedPaths.Add(change.Path);
+                continue;
+            }
+
+            TryRestoreLastWriteTimeUtc(change.Path, change.OriginalLastWriteTimeUtcTicks);
+            appliedCount += 1;
+            appliedPaths.Add(change.Path);
         }
 
         appliedPaths.Sort(StringComparer.Ordinal);
@@ -231,7 +269,17 @@ public sealed class SessionRolloutService
     {
         foreach (SessionBackupManifestEntry entry in manifestEntries)
         {
-            await RewriteFirstLineAsync(entry.Path, entry.OriginalFirstLine, entry.OriginalSeparator);
+            if (!entry.ModelOnlyChange)
+            {
+                await RewriteFirstLineAsync(entry.Path, entry.OriginalFirstLine, entry.OriginalSeparator);
+            }
+            if (entry.OriginalTurnContextModels.Count > 0)
+            {
+                await RestoreTurnContextModelsAsync(
+                    entry.Path,
+                    entry.OriginalTurnContextModels,
+                    entry.OriginalSeparator);
+            }
             TryRestoreLastWriteTimeUtc(entry.Path, entry.OriginalLastWriteTimeUtcTicks);
         }
     }
@@ -244,7 +292,9 @@ public sealed class SessionRolloutService
                 Path = change.Path,
                 OriginalFirstLine = change.OriginalFirstLine,
                 OriginalSeparator = change.OriginalSeparator,
-                OriginalLastWriteTimeUtcTicks = change.OriginalLastWriteTimeUtcTicks
+                OriginalLastWriteTimeUtcTicks = change.OriginalLastWriteTimeUtcTicks,
+                ModelOnlyChange = change.ModelOnlyChange,
+                OriginalTurnContextModels = [.. change.OriginalTurnContextModels]
             }));
     }
 
@@ -415,10 +465,19 @@ public sealed class SessionRolloutService
     // matching line.
     // `turn_context` after the leading `session_meta` line is
     // enough to know what model the rest of the file uses.
-    private static async Task<string?> ReadFirstTurnContextModelAsync(
+    private static readonly Regex TurnContextTypeRegex = new(
+        "\"type\"\\s*:\\s*\"turn_context\"",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex TurnContextModelFieldRegex = new(
+        "\"model\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\"",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static async Task<IReadOnlyList<string>> ReadTurnContextModelsAsync(
         string rolloutPath,
         FirstLineRecord record)
     {
+        List<string> models = [];
         try
         {
             await using FileStream stream = new(
@@ -431,37 +490,28 @@ public sealed class SessionRolloutService
             string? line;
             while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
             {
-                if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+                if (!TurnContextTypeRegex.IsMatch(line))
                 {
                     continue;
                 }
 
-                try
+                foreach (Match match in TurnContextModelFieldRegex.Matches(line))
                 {
-                    JsonNode? node = JsonNode.Parse(line);
-                    if (node is null)
+                    try
                     {
-                        continue;
+                        string? model = JsonSerializer.Deserialize<string>($"\"{match.Groups[1].Value}\"");
+                        if (!string.IsNullOrEmpty(model))
+                        {
+                            models.Add(model);
+                        }
                     }
-
-                    string? type = node["type"]?.GetValue<string>();
-                    if (!string.Equals(type, "turn_context", StringComparison.Ordinal))
+                    catch (JsonException)
                     {
-                        continue;
+                        // Leave malformed model literals untouched.
                     }
-
-                    string? model = node["payload"]?["model"]?.GetValue<string>();
-                    if (!string.IsNullOrEmpty(model))
-                    {
-                        return model;
-                    }
-                }
-                catch (JsonException)
-                {
-                    // Skip malformed lines and keep scanning.
                 }
             }
-            return null;
+            return models;
         }
         catch (Exception error) when (IsRolloutFileBusyError(error))
         {
@@ -476,89 +526,87 @@ public sealed class SessionRolloutService
     // regex rewrite instead of round-tripping the JSON tree to
     // avoid mangling the multi-megabyte `developer_instructions`
     // blob Codex writes into every `turn_context`.
-    private async Task TryRewriteRolloutModelFieldAsync(SessionChange change, string targetModel)
+    private async Task<ModelRewriteResult> TryRewriteRolloutModelFieldAsync(
+        SessionChange change,
+        string targetModel)
     {
-        if (string.IsNullOrEmpty(change.OriginalModel))
-        {
-            return;
-        }
         if (string.IsNullOrEmpty(targetModel))
         {
-            return;
+            return ModelRewriteResult.Empty;
         }
-        if (string.Equals(change.OriginalModel, targetModel, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        // Snapshot the file as it stands after the first-line
-        // rewrite. We cannot compare against `change.OriginalFileLength`
-        // because the first-line rewrite already changed the size
-        // (the new first line is often a different length than the
-        // original one).
-        FileInfo beforeInfo = new(change.Path);
-        long beforeSize = beforeInfo.Length;
-        DateTime beforeMtimeUtc = beforeInfo.LastWriteTimeUtc;
 
         string tempPath = $"{change.Path}.provider-sync-model.{Environment.ProcessId}.{DateTime.UtcNow.Ticks}.{Guid.NewGuid():N}.tmp";
-        // If a previous run left a leftover at the same path (which
-        // shouldn't normally happen because of the Guid suffix, but
-        // can occur when tests share a process and timestamps
-        // collide), clean it up before opening.
-        if (File.Exists(tempPath))
-        {
-            File.Delete(tempPath);
-        }
-
-        bool replacements = false;
         try
         {
-            await using (FileStream sourceStream = OpenExclusiveRewriteStream(change.Path))
+            await using FileStream sourceStream = OpenExclusiveRewriteStream(change.Path);
+            if (change.ModelOnlyChange
+                && (sourceStream.Length != change.OriginalFileLength
+                    || File.GetLastWriteTimeUtc(change.Path).Ticks != change.OriginalLastWriteTimeUtcTicks))
+            {
+                return ModelRewriteResult.Empty;
+            }
+
+            bool hasTrailingNewline = await EndsWithNewlineAsync(sourceStream);
+            sourceStream.Seek(0, SeekOrigin.Begin);
+            string separator = change.OriginalSeparator == "\r\n" ? "\r\n" : "\n";
+            List<TurnContextModelBackup> originalModels = [];
+            int replacements = 0;
+
+            using (StreamReader reader = new(
+                sourceStream,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: false,
+                bufferSize: 64 * 1024,
+                leaveOpen: true))
             {
                 await using FileStream writeStream = new(
                     tempPath,
                     FileMode.CreateNew,
                     FileAccess.Write,
                     FileShare.None);
-                await using StreamWriter writer = new(writeStream, new UTF8Encoding(false));
-                using StreamReader reader = new(sourceStream, Encoding.UTF8, false, 64 * 1024, leaveOpen: true);
+                await using StreamWriter writer = new(writeStream, new UTF8Encoding(false), 64 * 1024);
                 bool firstLine = true;
+                int lineIndex = 0;
                 string? line;
                 while ((line = await reader.ReadLineAsync()) is not null)
                 {
-                    string next = firstLine
-                        ? line
-                        : RewriteTurnContextModelInLine(line, change.OriginalModel!, targetModel);
-                    if (!string.Equals(next, line, StringComparison.Ordinal))
+                    ModelLineRewrite lineResult = firstLine
+                        ? new ModelLineRewrite(line, false, [])
+                        : RewriteTurnContextModelInLine(line, targetModel);
+                    if (lineResult.Replaced)
                     {
-                        replacements = true;
+                        replacements += 1;
+                        originalModels.Add(new TurnContextModelBackup
+                        {
+                            LineIndex = lineIndex,
+                            OriginalModel = lineResult.OriginalModels[0],
+                            OriginalModels = lineResult.OriginalModels
+                        });
                     }
                     if (!firstLine)
                     {
-                        await writer.WriteAsync('\n');
+                        await writer.WriteAsync(separator);
                     }
                     firstLine = false;
-                    await writer.WriteAsync(next);
+                    await writer.WriteAsync(lineResult.Line);
+                    lineIndex += 1;
+                }
+                if (hasTrailingNewline && !firstLine)
+                {
+                    await writer.WriteAsync(separator);
                 }
             }
 
-            if (!replacements)
+            if (replacements == 0)
             {
                 File.Delete(tempPath);
-                return;
+                return ModelRewriteResult.Empty;
             }
 
-            // Refuse to swap in the new file if Codex appended
-            // anything between our snapshot and the rename, so we
-            // do not silently drop trailing events.
-            FileInfo afterInfo = new(change.Path);
-            if (afterInfo.Length != beforeSize || afterInfo.LastWriteTimeUtc != beforeMtimeUtc)
-            {
-                File.Delete(tempPath);
-                return;
-            }
+            await OverwriteOpenFileFromTempAsync(sourceStream, tempPath);
 
-            File.Move(tempPath, change.Path, overwrite: true);
+            File.Delete(tempPath);
+            return new ModelRewriteResult(replacements, originalModels);
         }
         catch (Exception error)
         {
@@ -574,40 +622,231 @@ public sealed class SessionRolloutService
         }
     }
 
-    private static string RewriteTurnContextModelInLine(string line, string oldModel, string newModel)
+    private static ModelLineRewrite RewriteTurnContextModelInLine(string line, string newModel)
     {
-        if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+        if (!TurnContextTypeRegex.IsMatch(line))
+        {
+            return new ModelLineRewrite(line, false, []);
+        }
+
+        MatchCollection matches = TurnContextModelFieldRegex.Matches(line);
+        if (matches.Count == 0)
+        {
+            return new ModelLineRewrite(line, false, []);
+        }
+
+        List<string> originals = [];
+        try
+        {
+            foreach (Match match in matches)
+            {
+                string? model = JsonSerializer.Deserialize<string>($"\"{match.Groups[1].Value}\"");
+                if (model is null)
+                {
+                    return new ModelLineRewrite(line, false, []);
+                }
+                originals.Add(model);
+            }
+        }
+        catch (JsonException)
+        {
+            return new ModelLineRewrite(line, false, []);
+        }
+
+        if (originals.All(model => string.Equals(model, newModel, StringComparison.Ordinal)))
+        {
+            return new ModelLineRewrite(line, false, originals);
+        }
+
+        string encodedModel = JsonSerializer.Serialize(newModel);
+        string rewritten = TurnContextModelFieldRegex.Replace(line, $"\"model\":{encodedModel}");
+        return new ModelLineRewrite(rewritten, true, originals);
+    }
+
+    private static async Task RestoreTurnContextModelsAsync(
+        string filePath,
+        IReadOnlyList<TurnContextModelBackup> backups,
+        string originalSeparator)
+    {
+        Dictionary<int, TurnContextModelBackup> backupsByLine = backups
+            .GroupBy(static backup => backup.LineIndex)
+            .ToDictionary(static group => group.Key, static group => group.Last());
+        if (backupsByLine.Count == 0)
+        {
+            return;
+        }
+
+        string tempPath = $"{filePath}.provider-sync-model-restore.{Environment.ProcessId}.{DateTime.UtcNow.Ticks}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            await using FileStream sourceStream = OpenExclusiveRewriteStream(filePath);
+            bool hasTrailingNewline = await EndsWithNewlineAsync(sourceStream);
+            sourceStream.Seek(0, SeekOrigin.Begin);
+            string separator = originalSeparator == "\r\n" ? "\r\n" : "\n";
+            int replacements = 0;
+
+            using (StreamReader reader = new(
+                sourceStream,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: false,
+                bufferSize: 64 * 1024,
+                leaveOpen: true))
+            {
+                await using FileStream writeStream = new(
+                    tempPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None);
+                await using StreamWriter writer = new(writeStream, new UTF8Encoding(false), 64 * 1024);
+                bool firstLine = true;
+                int lineIndex = 0;
+                string? line;
+                while ((line = await reader.ReadLineAsync()) is not null)
+                {
+                    string next = line;
+                    if (!firstLine && backupsByLine.TryGetValue(lineIndex, out TurnContextModelBackup? backup))
+                    {
+                        next = RestoreTurnContextModelInLine(line, backup);
+                        if (!string.Equals(next, line, StringComparison.Ordinal))
+                        {
+                            replacements += 1;
+                        }
+                    }
+                    if (!firstLine)
+                    {
+                        await writer.WriteAsync(separator);
+                    }
+                    firstLine = false;
+                    await writer.WriteAsync(next);
+                    lineIndex += 1;
+                }
+                if (hasTrailingNewline && !firstLine)
+                {
+                    await writer.WriteAsync(separator);
+                }
+            }
+
+            if (replacements == 0)
+            {
+                File.Delete(tempPath);
+                return;
+            }
+
+            await OverwriteOpenFileFromTempAsync(sourceStream, tempPath);
+            File.Delete(tempPath);
+        }
+        catch (Exception error)
+        {
+            try
+            {
+                File.Delete(tempPath);
+            }
+            catch
+            {
+                // Ignore cleanup failures and surface the original error.
+            }
+            throw WrapRolloutFileBusyError(error, filePath, "restore model field");
+        }
+    }
+
+    private static string RestoreTurnContextModelInLine(
+        string line,
+        TurnContextModelBackup backup)
+    {
+        if (!TurnContextTypeRegex.IsMatch(line))
         {
             return line;
         }
-        // We need TWO escapes here:
-        //   - JSON-string escape so the old/new model name can be
-        //     embedded back into a JSON string value (handle `\` and
-        //     `"`).
-        //   - regex escape so model names that happen to contain
-        //     regex metacharacters (`.`, `+`, `*`, `?`, `(`, `)`,
-        //     `|`, `[`, `]`, `{`, `}`, `^`, `$`, `\`) do not
-        //     over-match or break the pattern. Without this, a
-        //     model named `gpt-5.4-mini` would also match
-        //     `gpt-5X4Xmini` and a model named `foo+bar` would
-        //     either fail to compile or behave unexpectedly.
-        // The order matters: regex-escape first so the JSON-string
-        // escape of `\` (which inserts a backslash before every
-        // `\`) does not double up the regex escapes we just
-        // inserted.
-        string escapedOld = System.Text.RegularExpressions.Regex.Escape(EscapeForJsonString(oldModel));
-        string escapedNew = EscapeForJsonString(newModel);
-        return System.Text.RegularExpressions.Regex.Replace(
+
+        MatchCollection matches = TurnContextModelFieldRegex.Matches(line);
+        if (matches.Count == 0)
+        {
+            return line;
+        }
+
+        IReadOnlyList<string> originals = backup.OriginalModels.Count == matches.Count
+            ? backup.OriginalModels
+            : Enumerable.Repeat(backup.OriginalModel, matches.Count).ToList();
+        int index = 0;
+        return TurnContextModelFieldRegex.Replace(
             line,
-            "\"model\"\\s*:\\s*\"" + escapedOld + "\"",
-            m => "\"model\":\"" + escapedNew + "\"");
+            _ => $"\"model\":{JsonSerializer.Serialize(originals[index++])}");
     }
 
-    private static string EscapeForJsonString(string value)
+    private static async Task<bool> EndsWithNewlineAsync(FileStream stream)
     {
-        return value
-            .Replace("\\", "\\\\", StringComparison.Ordinal)
-            .Replace("\"", "\\\"", StringComparison.Ordinal);
+        if (stream.Length == 0)
+        {
+            return false;
+        }
+
+        stream.Seek(-1, SeekOrigin.End);
+        byte[] tail = new byte[1];
+        int bytesRead = await stream.ReadAsync(tail);
+        return bytesRead == 1 && tail[0] == (byte)'\n';
+    }
+
+    private static async Task OverwriteOpenFileFromTempAsync(
+        FileStream destination,
+        string tempPath)
+    {
+        string rollbackPath = $"{tempPath}.rollback";
+        try
+        {
+            destination.Seek(0, SeekOrigin.Begin);
+            await using (FileStream rollbackWriter = new(
+                rollbackPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                64 * 1024,
+                FileOptions.Asynchronous | FileOptions.SequentialScan))
+            {
+                await destination.CopyToAsync(rollbackWriter);
+                await rollbackWriter.FlushAsync();
+            }
+
+            try
+            {
+                await using FileStream tempReader = new(
+                    tempPath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    64 * 1024,
+                    FileOptions.Asynchronous | FileOptions.SequentialScan);
+                destination.SetLength(0);
+                destination.Seek(0, SeekOrigin.Begin);
+                await tempReader.CopyToAsync(destination);
+                await destination.FlushAsync();
+            }
+            catch
+            {
+                await using FileStream rollbackReader = new(
+                    rollbackPath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    64 * 1024,
+                    FileOptions.Asynchronous | FileOptions.SequentialScan);
+                destination.SetLength(0);
+                destination.Seek(0, SeekOrigin.Begin);
+                await rollbackReader.CopyToAsync(destination);
+                await destination.FlushAsync();
+                throw;
+            }
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(rollbackPath);
+            }
+            catch
+            {
+                // The original exception, if any, is more useful than cleanup failure.
+            }
+        }
     }
 
     private static async Task RewriteFirstLineAsync(
@@ -1010,4 +1249,14 @@ public sealed class SessionRolloutService
 
     private readonly record struct FirstLineRecord(string FirstLine, string Separator, int Offset);
     private readonly record struct FileSnapshot(long Length, long LastWriteTimeUtcTicks);
+    private readonly record struct ModelLineRewrite(
+        string Line,
+        bool Replaced,
+        IReadOnlyList<string> OriginalModels);
+    private readonly record struct ModelRewriteResult(
+        int ReplacedLines,
+        IReadOnlyList<TurnContextModelBackup> OriginalModels)
+    {
+        public static ModelRewriteResult Empty { get; } = new(0, []);
+    }
 }

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -256,10 +256,11 @@ public sealed class SqliteStateService
         }
     }
 
-    public async Task<(int UpdatedRows, int ProviderRowsUpdated, int UserEventRowsUpdated, int CwdRowsUpdated, bool DatabasePresent)> UpdateSqliteProviderAsync(
+    public async Task<(int UpdatedRows, int ProviderRowsUpdated, int ModelRowsUpdated, int UserEventRowsUpdated, int CwdRowsUpdated, bool DatabasePresent)> UpdateSqliteProviderAsync(
         string codexHome,
         string targetProvider,
-        Func<(int UpdatedRows, int ProviderRowsUpdated, int UserEventRowsUpdated, int CwdRowsUpdated, bool DatabasePresent), Task>? afterUpdate = null,
+        string? targetModel = null,
+        Func<(int UpdatedRows, int ProviderRowsUpdated, int ModelRowsUpdated, int UserEventRowsUpdated, int CwdRowsUpdated, bool DatabasePresent), Task>? afterUpdate = null,
         int? busyTimeoutMs = null,
         IReadOnlyCollection<string>? userEventThreadIds = null,
         IReadOnlyDictionary<string, string>? threadCwdsById = null)
@@ -269,10 +270,10 @@ public sealed class SqliteStateService
         {
             if (afterUpdate is not null)
             {
-                await afterUpdate((0, 0, 0, 0, false));
+                await afterUpdate((0, 0, 0, 0, 0, false));
             }
 
-            return (0, 0, 0, 0, false);
+            return (0, 0, 0, 0, 0, false);
         }
 
         await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
@@ -292,6 +293,26 @@ public sealed class SqliteStateService
                 """;
             command.Parameters.AddWithValue("$provider", targetProvider);
             int providerRowsUpdated = await command.ExecuteNonQueryAsync();
+
+            // When a target model is provided, align every thread's `model`
+            // column with it alongside `model_provider`. This is what makes
+            // the bottom-right of the Codex UI show the active model for old
+            // sessions, instead of the name that was in effect when each
+            // thread was originally created. The `model` column is only
+            // present in newer Codex schemas, so guard with TableHasColumn
+            // to keep legacy layouts working.
+            int modelRowsUpdated = 0;
+            if (!string.IsNullOrEmpty(targetModel) && await TableHasColumnAsync(connection, "threads", "model"))
+            {
+                await using SqliteCommand modelCommand = connection.CreateCommand();
+                modelCommand.CommandText = """
+                    UPDATE threads
+                    SET model = $model
+                    WHERE COALESCE(model, '') <> $model
+                    """;
+                modelCommand.Parameters.AddWithValue("$model", targetModel);
+                modelRowsUpdated = await modelCommand.ExecuteNonQueryAsync();
+            }
             int userEventRowsUpdated = 0;
             if (userEventThreadIds?.Count > 0 && await TableHasColumnAsync(connection, "threads", "has_user_event"))
             {
@@ -333,16 +354,16 @@ public sealed class SqliteStateService
                 }
             }
 
-            int updatedRows = providerRowsUpdated + userEventRowsUpdated + cwdRowsUpdated;
+            int updatedRows = providerRowsUpdated + modelRowsUpdated + userEventRowsUpdated + cwdRowsUpdated;
 
             if (afterUpdate is not null)
             {
-                await afterUpdate((updatedRows, providerRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true));
+                await afterUpdate((updatedRows, providerRowsUpdated, modelRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true));
             }
 
             await ExecuteNonQueryAsync(connection, "COMMIT");
             transactionOpen = false;
-            return (updatedRows, providerRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true);
+            return (updatedRows, providerRowsUpdated, modelRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true);
         }
         catch (Exception error)
         {

--- a/desktop/CodexProviderSync.Core/TextFormatter.cs
+++ b/desktop/CodexProviderSync.Core/TextFormatter.cs
@@ -101,6 +101,10 @@ public static class TextFormatter
         {
             lines.Add($"Updated SQLite user-event flags: {result.SqliteUserEventRowsUpdated}");
         }
+        if (result.SqliteModelRowsUpdated > 0)
+        {
+            lines.Add($"Updated SQLite per-thread models: {result.SqliteModelRowsUpdated}");
+        }
         if (result.SqliteCwdRowsUpdated > 0)
         {
             lines.Add($"Updated SQLite cwd paths: {result.SqliteCwdRowsUpdated}");

--- a/desktop/CodexProviderSync.Mac/MacDisplayFormatter.cs
+++ b/desktop/CodexProviderSync.Mac/MacDisplayFormatter.cs
@@ -110,6 +110,10 @@ internal static class MacDisplayFormatter
         {
             lines.Add($"已更新 SQLite user-event 标记: {result.SqliteUserEventRowsUpdated}");
         }
+        if (result.SqliteModelRowsUpdated > 0)
+        {
+            lines.Add($"已更新 SQLite 每线程 model: {result.SqliteModelRowsUpdated}");
+        }
         if (result.SqliteCwdRowsUpdated > 0)
         {
             lines.Add($"已更新 SQLite cwd 路径: {result.SqliteCwdRowsUpdated}");

--- a/src/backup.js
+++ b/src/backup.js
@@ -89,7 +89,7 @@ export async function createBackup({
   await backupGlobalStateFiles(codexHome, backupDir);
 
   const sessionManifest = {
-    version: 1,
+    version: 2,
     namespace: BACKUP_NAMESPACE,
     codexHome,
     targetProvider,
@@ -98,7 +98,16 @@ export async function createBackup({
       path: change.path,
       originalFirstLine: change.originalFirstLine,
       originalSeparator: change.originalSeparator,
-      originalMtimeMs: change.originalMtimeMs
+      originalMtimeMs: change.originalMtimeMs,
+      // Per-line record of the original turn_context.model values
+      // so a failed rollback can put the per-turn model back to
+      // what it was before the sync. Without this, a restore
+      // would only rewind the session_meta line and leave the
+      // per-turn `model` field pointing at the new value, which
+      // is exactly the "half-completed state" the owner review
+      // called out.
+      originalTurnContextModels: change.originalTurnContextModels ?? [],
+      modelOnlyChange: Boolean(change.modelOnlyChange)
     }))
   };
   await fs.writeFile(
@@ -134,11 +143,19 @@ export async function updateSessionBackupManifest(backupDir, sessionChanges) {
   const sessionManifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
   const metadata = JSON.parse(await fs.readFile(metadataPath, "utf8"));
 
+  // Promote older manifests to the v2 schema so restoreSessionChanges
+  // can rely on the per-line `originalTurnContextModels` field.
+  if (sessionManifest.version !== 2) {
+    sessionManifest.version = 2;
+  }
+
   sessionManifest.files = sessionChanges.map((change) => ({
     path: change.path,
     originalFirstLine: change.originalFirstLine,
     originalSeparator: change.originalSeparator,
-    originalMtimeMs: change.originalMtimeMs
+    originalMtimeMs: change.originalMtimeMs,
+    originalTurnContextModels: change.originalTurnContextModels ?? [],
+    modelOnlyChange: Boolean(change.modelOnlyChange)
   }));
   metadata.changedSessionFiles = sessionChanges.length;
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,10 +17,14 @@ function printHelp() {
 Usage:
   codex-provider status [--codex-home PATH]
   codex-provider sync [--provider ID] [--keep N] [--codex-home PATH]
-  codex-provider switch <provider-id> [--keep N] [--codex-home PATH]
+  codex-provider switch <provider-id> [--model NAME] [--keep-root-model] [--keep N] [--codex-home PATH]
   codex-provider prune-backups [--keep N] [--codex-home PATH]
   codex-provider restore <backup-dir> [--no-config] [--no-db] [--no-sessions] [--codex-home PATH]
   codex-provider install-windows-launcher [--dir PATH] [--codex-home PATH]
+
+switch flags:
+  --model NAME         override root-level model field with NAME (e.g. "MiniMax-M3")
+  --keep-root-model    do not touch the root-level model field; only switch model_provider
 `);
 }
 
@@ -208,10 +212,22 @@ async function main() {
     const result = await runSwitch({
       codexHome: flags["codex-home"],
       provider,
+      model: flags.model,
+      keepRootModel: Boolean(flags["keep-root-model"]),
       keepCount: parseKeepCount(flags.keep),
       onProgress: createSyncProgressReporter()
     });
     console.log(summarizeSync(result, "Switched to"));
+    if (result.modelSync) {
+      const { applied, source, model, warning } = result.modelSync;
+      if (applied) {
+        console.log(`Root-level model: ${model} (source: ${source})`);
+      } else if (warning) {
+        console.log(`Root-level model: unchanged (${warning})`);
+      } else {
+        console.log("Root-level model: unchanged (keep-root-model flag set)");
+      }
+    }
     return;
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -196,11 +196,29 @@ async function main() {
 
   if (command === "sync") {
     const { runSync } = await loadService();
+    const { defaultCodexHome } = await import("./constants.js");
+    const { readConfigText } = await import("./config-file.js");
+    const codexHome = path.resolve(
+      flags["codex-home"] ?? process.env.CODEX_HOME ?? defaultCodexHome()
+    );
+    const configPath = path.join(codexHome, "config.toml");
+    let rootModel = null;
+    try {
+      const cfg = await readConfigText(configPath);
+      const m = cfg.match(/^\s*model\s*=\s*"([^"]+)"\s*$/m);
+      if (m) {
+        rootModel = m[1];
+      }
+    } catch {
+      // config may be missing in degraded scenarios; carry on without a
+      // model rewrite so the rest of the sync still runs.
+    }
     const result = await runSync({
       codexHome: flags["codex-home"],
       provider: flags.provider,
       keepCount: parseKeepCount(flags.keep),
-      onProgress: createSyncProgressReporter()
+      onProgress: createSyncProgressReporter(),
+      model: rootModel
     });
     console.log(summarizeSync(result, "Synchronized"));
     return;

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,6 +18,7 @@ Usage:
   codex-provider status [--codex-home PATH]
   codex-provider sync [--provider ID] [--keep N] [--codex-home PATH]
   codex-provider switch <provider-id> [--model NAME] [--keep-root-model] [--keep N] [--codex-home PATH]
+  codex-provider watch [--codex-home PATH] [--debounce-ms N] [--once] [--no-state-db]
   codex-provider prune-backups [--keep N] [--codex-home PATH]
   codex-provider restore <backup-dir> [--no-config] [--no-db] [--no-sessions] [--codex-home PATH]
   codex-provider install-windows-launcher [--dir PATH] [--codex-home PATH]
@@ -25,6 +26,12 @@ Usage:
 switch flags:
   --model NAME         override root-level model field with NAME (e.g. "MiniMax-M3")
   --keep-root-model    do not touch the root-level model field; only switch model_provider
+
+watch flags:
+  --codex-home PATH    override CODEX_HOME (default: ~/.codex or $CODEX_HOME)
+  --debounce-ms N      wait N milliseconds after a change before syncing (default 750)
+  --once               exit after the first successful sync
+  --no-state-db        only watch config.toml, ignore SQLite state events
 `);
 }
 
@@ -197,7 +204,7 @@ async function main() {
   if (command === "sync") {
     const { runSync } = await loadService();
     const { defaultCodexHome } = await import("./constants.js");
-    const { readConfigText } = await import("./config-file.js");
+    const { readConfigText, readRootModelFromConfigText } = await import("./config-file.js");
     const codexHome = path.resolve(
       flags["codex-home"] ?? process.env.CODEX_HOME ?? defaultCodexHome()
     );
@@ -205,10 +212,7 @@ async function main() {
     let rootModel = null;
     try {
       const cfg = await readConfigText(configPath);
-      const m = cfg.match(/^\s*model\s*=\s*"([^"]+)"\s*$/m);
-      if (m) {
-        rootModel = m[1];
-      }
+      rootModel = readRootModelFromConfigText(cfg);
     } catch {
       // config may be missing in degraded scenarios; carry on without a
       // model rewrite so the rest of the sync still runs.
@@ -256,6 +260,48 @@ async function main() {
       keepCount: parseKeepCount(flags.keep, { allowZero: true })
     });
     console.log(summarizePrune(result));
+    return;
+  }
+
+  if (command === "watch") {
+    const { runWatch } = await import("./watch.js");
+    const debounceMs = flags["debounce-ms"] !== undefined
+      ? parseKeepCount(flags["debounce-ms"], { allowZero: true })
+      : undefined;
+    const handle = await runWatch({
+      codexHome: flags["codex-home"],
+      debounceMs,
+      includeStateDb: !flags["no-state-db"],
+      once: Boolean(flags.once)
+    });
+    // Race the watcher's own `done` promise (which resolves when
+    // `--once` completes or the consecutive-failure auto-shutdown
+    // fires) against the external SIGINT/SIGTERM handler. Whichever
+    // wins, we stop the watcher cleanly and let the process exit.
+    // Without this race, the CLI sits in the event loop forever
+    // after a `--once` run, because Node only exits on its own
+    // when there are no more pending handles.
+    await new Promise((resolve) => {
+      let settled = false;
+      const finish = async (source) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        try {
+          await handle.stop();
+        } catch {
+          // best effort: stop() may already be in flight
+        }
+        resolve(source);
+      };
+      handle.done.then(() => finish("done"), () => finish("done-rejected"));
+      if (handle.signalPromise) {
+        handle.signalPromise.then(() => finish("signal"), () => finish("signal-rejected"));
+      }
+      process.once("SIGINT", () => finish("SIGINT"));
+      process.once("SIGTERM", () => finish("SIGTERM"));
+    });
     return;
   }
 

--- a/src/config-file.js
+++ b/src/config-file.js
@@ -45,6 +45,51 @@ export function configDeclaresProvider(configText, provider) {
   return listConfiguredProviderIds(configText).includes(provider);
 }
 
+function locateProviderSection(configText, provider) {
+  const lines = splitLines(configText);
+  const startRegex = new RegExp(`^\\[model_providers\\.${provider.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}\\]\\s*$`);
+  let sectionStart = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (startRegex.test(lines[index].trim())) {
+      sectionStart = index;
+      break;
+    }
+  }
+  if (sectionStart === -1) {
+    return null;
+  }
+
+  const sectionLines = [];
+  for (let index = sectionStart + 1; index < lines.length; index += 1) {
+    const trimmed = lines[index].trim();
+    if (trimmed.startsWith("[")) {
+      break;
+    }
+    sectionLines.push({ index, line: lines[index], trimmed });
+  }
+  return { startIndex: sectionStart, lines: sectionLines };
+}
+
+export function readProviderModel(configText, provider) {
+  if (provider === DEFAULT_PROVIDER) {
+    // Built-in openai provider: there is no [model_providers.openai] section,
+    // so the model is whatever the root-level `model` already is. We have no
+    // canonical value to pull from — return null and let the caller decide.
+    return null;
+  }
+  const section = locateProviderSection(configText, provider);
+  if (!section) {
+    return null;
+  }
+  for (const { line } of section.lines) {
+    const match = line.match(/^\s*model\s*=\s*"([^"]+)"\s*$/);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
 export function setRootProviderInConfigText(configText, provider) {
   const lines = splitLines(configText);
   let insertIndex = lines.length;
@@ -67,6 +112,32 @@ export function setRootProviderInConfigText(configText, provider) {
   }
 
   lines.splice(insertIndex, 0, `model_provider = "${escapeTomlString(provider)}"`);
+  const nextText = lines.join("\n");
+  return configText.endsWith("\n") ? `${nextText}\n` : nextText;
+}
+
+export function setRootModelInConfigText(configText, model) {
+  const lines = splitLines(configText);
+  let insertIndex = lines.length;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const trimmed = lines[index].trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      insertIndex = index + 1;
+      continue;
+    }
+    if (trimmed.startsWith("[")) {
+      insertIndex = index;
+      break;
+    }
+    if (/^model\s*=/.test(trimmed)) {
+      lines[index] = `model = "${escapeTomlString(model)}"`;
+      return `${lines.join("\n")}${configText.endsWith("\n") ? "\n" : ""}`.replace(/\n\n$/, "\n");
+    }
+    insertIndex = index + 1;
+  }
+
+  lines.splice(insertIndex, 0, `model = "${escapeTomlString(model)}"`);
   const nextText = lines.join("\n");
   return configText.endsWith("\n") ? `${nextText}\n` : nextText;
 }

--- a/src/config-file.js
+++ b/src/config-file.js
@@ -32,6 +32,40 @@ export function readCurrentProviderFromConfigText(configText) {
   return { provider: DEFAULT_PROVIDER, implicit: true };
 }
 
+// Read the root-level `model = "..."` field from a Codex config.toml.
+// We deliberately only consider the first occurrence of `model = "..."`
+// before any `[section]` header. Without this guard, a config like
+//
+//   model_provider = "foo"
+//
+//   [model_providers.foo]
+//   model = "gpt-4o-mini"
+//
+// would return `"gpt-4o-mini"` here, and the per-rollout rewrite step
+// would propagate that provider-section model into every turn_context
+// line — which is wrong, because the user-set root model is the value
+// the Codex CLI/GUI actually use for the next turn.
+//
+// Returns `null` when no root-level `model` is set; callers should
+// treat that as "do not touch the per-turn model field".
+export function readRootModelFromConfigText(configText) {
+  const lines = splitLines(configText);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    if (trimmed.startsWith("[")) {
+      break;
+    }
+    const match = trimmed.match(/^model\s*=\s*"([^"]+)"\s*$/);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
 export function listConfiguredProviderIds(configText) {
   const providerIds = new Set([DEFAULT_PROVIDER]);
   const regex = /^\[model_providers\.([A-Za-z0-9_.-]+)]\s*$/gm;

--- a/src/service.js
+++ b/src/service.js
@@ -419,6 +419,10 @@ export async function runSwitch({
     throw new Error(`Provider "${provider}" is not available in config.toml. Configure it first or use one of: ${listConfiguredProviderIds(originalConfigText).join(", ")}`);
   }
 
+  if (model !== undefined && model !== null && keepRootModel) {
+    throw new Error("--model and --keep-root-model are mutually exclusive. Pick one.");
+  }
+
   let nextConfigText = setRootProviderInConfigText(originalConfigText, provider);
   let modelSync = { applied: false, source: "none", model: null, warning: null };
 

--- a/src/service.js
+++ b/src/service.js
@@ -207,7 +207,8 @@ export async function runSync({
   configBackupText,
   keepCount = DEFAULT_BACKUP_RETENTION_COUNT,
   sqliteBusyTimeoutMs,
-  onProgress
+  onProgress,
+  model = null
 } = {}) {
   if (!Number.isInteger(keepCount) || keepCount < 1) {
     throw new Error(`Invalid automatic keep count: ${keepCount}. Expected an integer greater than or equal to 1.`);
@@ -311,7 +312,7 @@ export async function runSync({
           workspaceRootResult = await syncWorkspaceRoots(codexHome, { cwdStats });
           globalStateRestoreNeeded = workspaceRootResult.updated;
         },
-        { busyTimeoutMs: sqliteBusyTimeoutMs, userEventThreadIds, threadCwdById }
+        { busyTimeoutMs: sqliteBusyTimeoutMs, userEventThreadIds, threadCwdById, targetModel: model }
       );
       emitProgress(onProgress, {
         stage: "rewrite_rollout_files",
@@ -460,12 +461,23 @@ export async function runSwitch({
   });
 
   try {
+    // After the config update, `nextConfigText` has the final root-level
+    // `model` value. We use that to drive the per-thread `model` column
+    // rewrite so old sessions pick up the same model that new ones will.
+    let modelForThreads = null;
+    if (modelSync.applied && modelSync.model) {
+      modelForThreads = modelSync.model;
+    } else {
+      const rootModelMatch = nextConfigText.match(/^\s*model\s*=\s*"([^"]+)"\s*$/m);
+      modelForThreads = rootModelMatch ? rootModelMatch[1] : null;
+    }
     const syncResult = await runSync({
       codexHome,
       provider,
       configBackupText: originalConfigText,
       keepCount,
-      onProgress
+      onProgress,
+      model: modelForThreads
     });
     return {
       ...syncResult,

--- a/src/service.js
+++ b/src/service.js
@@ -303,7 +303,7 @@ export async function runSync({
         targetProvider,
         async () => {
           if (writableChanges.length > 0) {
-            applyResult = await applySessionChanges(writableChanges);
+            applyResult = await applySessionChanges(writableChanges, { targetModel: model });
             const appliedPathSet = new Set(applyResult.appliedPaths ?? []);
             appliedSessionChanges = writableChanges.filter((change) => appliedPathSet.has(change.path));
             sessionRestoreNeeded = appliedSessionChanges.length > 0;

--- a/src/service.js
+++ b/src/service.js
@@ -12,6 +12,8 @@ import {
   listConfiguredProviderIds,
   readConfigText,
   readCurrentProviderFromConfigText,
+  readProviderModel,
+  setRootModelInConfigText,
   setRootProviderInConfigText,
   writeConfigText
 } from "./config-file.js";
@@ -400,6 +402,8 @@ export async function runSync({
 export async function runSwitch({
   codexHome: explicitCodexHome,
   provider,
+  model,
+  keepRootModel = false,
   keepCount = DEFAULT_BACKUP_RETENTION_COUNT,
   onProgress
 }) {
@@ -415,7 +419,30 @@ export async function runSwitch({
     throw new Error(`Provider "${provider}" is not available in config.toml. Configure it first or use one of: ${listConfiguredProviderIds(originalConfigText).join(", ")}`);
   }
 
-  const nextConfigText = setRootProviderInConfigText(originalConfigText, provider);
+  let nextConfigText = setRootProviderInConfigText(originalConfigText, provider);
+  let modelSync = { applied: false, source: "none", model: null, warning: null };
+
+  if (model !== undefined && model !== null) {
+    if (typeof model !== "string" || model.length === 0) {
+      throw new Error(`Invalid --model value: ${model}. Expected a non-empty string.`);
+    }
+    nextConfigText = setRootModelInConfigText(nextConfigText, model);
+    modelSync = { applied: true, source: "explicit", model, warning: null };
+  } else if (!keepRootModel) {
+    const providerModel = readProviderModel(originalConfigText, provider);
+    if (providerModel) {
+      nextConfigText = setRootModelInConfigText(nextConfigText, providerModel);
+      modelSync = { applied: true, source: "provider-section", model: providerModel, warning: null };
+    } else if (provider !== DEFAULT_PROVIDER) {
+      modelSync = {
+        applied: false,
+        source: "none",
+        model: null,
+        warning: `Provider "${provider}" has no model field in [model_providers.${provider}]; root-level model left unchanged. Use --model <name> to set it explicitly, or --keep-root-model to suppress this warning.`
+      };
+    }
+  }
+
   emitProgress(onProgress, {
     stage: "update_config",
     status: "start",
@@ -438,7 +465,8 @@ export async function runSwitch({
     });
     return {
       ...syncResult,
-      configUpdated: true
+      configUpdated: true,
+      modelSync
     };
   } catch (error) {
     await writeConfigText(configPath, originalConfigText);

--- a/src/service.js
+++ b/src/service.js
@@ -233,7 +233,7 @@ export async function runSync({
       encryptedContentCounts,
       userEventThreadIds,
       threadCwdById
-    } = await collectSessionChanges(codexHome, targetProvider, { skipLockedReads: true });
+    } = await collectSessionChanges(codexHome, targetProvider, { skipLockedReads: true, targetModel: model });
     const cwdStats = await readThreadCwdStats(codexHome);
     const encryptedContentWarning = buildEncryptedContentWarning(encryptedContentCounts, targetProvider);
     emitProgress(onProgress, {

--- a/src/service.js
+++ b/src/service.js
@@ -13,6 +13,7 @@ import {
   readConfigText,
   readCurrentProviderFromConfigText,
   readProviderModel,
+  readRootModelFromConfigText,
   setRootModelInConfigText,
   setRootProviderInConfigText,
   writeConfigText
@@ -468,8 +469,7 @@ export async function runSwitch({
     if (modelSync.applied && modelSync.model) {
       modelForThreads = modelSync.model;
     } else {
-      const rootModelMatch = nextConfigText.match(/^\s*model\s*=\s*"([^"]+)"\s*$/m);
-      modelForThreads = rootModelMatch ? rootModelMatch[1] : null;
+      modelForThreads = readRootModelFromConfigText(nextConfigText);
     }
     const syncResult = await runSync({
       codexHome,

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -264,6 +264,77 @@ function parseSessionMetaRecord(firstLine) {
   }
 }
 
+// Scan the start of a rollout file looking for the first `turn_context`
+// event and return its `payload.model` field. This is the field that the
+// Codex GUI bottom-right uses to label old conversations, so we have to
+// rewrite it (along with `payload.collaboration_mode.settings.model`) on
+// every sync in addition to the per-thread SQLite `model` column.
+//
+// We only need to peek at the first few KB of the file: the very first
+// `turn_context` event after the leading `session_meta` line is enough
+// to know what model the rest of the file uses. We deliberately stop as
+// soon as we find one, so the scan is O(1) for the common case and does
+// not load multi-MB rollouts into memory just to read a header.
+async function readFirstTurnContextModel(rolloutPath, { firstLineOffset, firstLineLength } = {}) {
+  let handle;
+  try {
+    handle = await fsp.open(rolloutPath, "r");
+    const headerSkip = firstLineOffset ?? 0;
+    const headerLength = firstLineLength ?? 0;
+    const scanLimit = 64 * 1024; // first 64 KB is plenty for one turn_context
+    const chunk = Buffer.alloc(scanLimit);
+    const start = headerSkip + headerLength;
+    const { bytesRead } = await handle.read(chunk, 0, chunk.length, start);
+    if (bytesRead === 0) {
+      return null;
+    }
+
+    const text = chunk.subarray(0, bytesRead).toString("utf8");
+    // Each line in a rollout is a single JSON object. We split on
+    // newlines and look for the first line whose top-level `type`
+    // is `turn_context`, then parse it. A regex that tries to
+    // match the surrounding `{}` of a deeply nested payload will
+    // stop at the first inner `}` and miss the real outer one, so
+    // per-line scanning is much more robust here.
+    for (const line of text.split(/\r?\n/)) {
+      if (!line.includes('"turn_context"')) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed?.type === "turn_context"
+            && typeof parsed?.payload?.model === "string"
+            && parsed.payload.model.length > 0) {
+          return parsed.payload.model;
+        }
+      } catch {
+        // Skip lines that look like turn_context but fail to parse.
+      }
+    }
+    return null;
+  } catch (error) {
+    throw wrapRolloutFileBusyError(error, rolloutPath, "read");
+  } finally {
+    await handle?.close();
+  }
+}
+
+// Replace `"model":"oldModel"` with `"model":"newModel"` in lines that
+// represent a `turn_context` event. We intentionally do a per-line
+// regex rewrite (rather than re-serializing the full JSON tree) because
+// rollout files can be tens of megabytes, and Codex writes a lot of
+// opaque payload (e.g. `developer_instructions`) that round-tripping
+// through `JSON.parse`+`JSON.stringify` would silently mangle.
+function rewriteTurnContextModelInLine(line, oldModel, newModel) {
+  if (!line || !line.includes('"turn_context"')) {
+    return line;
+  }
+  const escapedOld = oldModel.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+  const escapedNew = newModel.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+  const pattern = new RegExp(`"model"\\s*:\\s*"${escapedOld}"`, "g");
+  return line.replace(pattern, `"model":"${escapedNew}"`);
+}
+
 function isValidWindowsRewriteResult(result) {
   return result === "APPLIED" || result === "SKIP_BUSY" || result === "SKIP_CHANGED";
 }
@@ -580,6 +651,93 @@ async function tryRewriteCollectedFirstLine(change) {
   }
 }
 
+// Rewrite the per-turn `model` field in every `turn_context` event of
+// the rollout. This is what the Codex GUI bottom-right of an old
+// conversation reads, so we have to keep it in sync with the
+// root-level `model` from config.toml on every sync, not just the
+// per-thread SQLite `model` column. We do this as a separate
+// line-by-line pass (rather than re-serializing the whole JSON tree)
+// to avoid round-tripping the multi-MB `developer_instructions` blob
+// Codex writes into every `turn_context`, which can lose embedded
+// backslashes or escape sequences when run through `JSON.stringify`.
+async function rewriteRolloutModelField(change, targetModel) {
+  if (!change || typeof change.originalModel !== "string" || change.originalModel.length === 0) {
+    return false;
+  }
+  if (typeof targetModel !== "string" || targetModel.length === 0) {
+    return false;
+  }
+  if (change.originalModel === targetModel) {
+    return false;
+  }
+
+  const filePath = change.path;
+  // Snapshot the file as it stands after the first-line rewrite so
+  // we can detect concurrent appends by Codex while we read+rewrite.
+  // The original `change` snapshot no longer matches because the
+  // first-line rewrite already mutated size and mtime, so we
+  // intentionally don't compare to `change.originalSize` here.
+  const beforeStat = await fsp.stat(filePath);
+  const beforeSnapshot = {
+    size: beforeStat.size,
+    mtimeMs: beforeStat.mtimeMs
+  };
+
+  let handle;
+  try {
+    handle = await fsp.open(filePath, "r+");
+    const stream = handle.createReadStream({ encoding: "utf8" });
+    const reader = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    const tmpPath = `${filePath}.provider-sync-model.${process.pid}.${Date.now()}.tmp`;
+    const writer = fs.createWriteStream(tmpPath, { encoding: "utf8" });
+    let firstLine = true;
+    let replacements = 0;
+
+    await new Promise((resolve, reject) => {
+      reader.on("error", reject);
+      writer.on("error", reject);
+      reader.on("line", (line) => {
+        const next = firstLine
+          ? line
+          : rewriteTurnContextModelInLine(line, change.originalModel, targetModel);
+        if (next !== line) {
+          replacements += 1;
+        }
+        if (!firstLine) {
+          writer.write("\n");
+        }
+        firstLine = false;
+        writer.write(next);
+      });
+      reader.on("close", () => {
+        writer.end();
+      });
+      writer.on("finish", resolve);
+    });
+
+    if (replacements === 0) {
+      await fsp.rm(tmpPath, { force: true });
+      return false;
+    }
+
+    // Refuse to swap in the new file if Codex appended anything
+    // between our snapshot and the rename — otherwise we would
+    // silently drop those trailing events.
+    const afterStat = await fsp.stat(filePath);
+    if (afterStat.size !== beforeSnapshot.size || afterStat.mtimeMs !== beforeSnapshot.mtimeMs) {
+      await fsp.rm(tmpPath, { force: true });
+      return false;
+    }
+
+    await fsp.rename(tmpPath, filePath);
+    return true;
+  } catch (error) {
+    throw wrapRolloutFileBusyError(error, filePath, "rewrite model field");
+  } finally {
+    await handle?.close();
+  }
+}
+
 async function findLockedFilesOnWindows(filePaths) {
   if (!filePaths.length) {
     return [];
@@ -685,6 +843,15 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
       if (targetProvider !== "__status_only__" && parsed.payload.model_provider !== targetProvider) {
         const snapshot = await getFileSnapshot(rolloutPath);
         parsed.payload.model_provider = targetProvider;
+        // Peek at the first `turn_context` event to capture the
+        // per-turn model that the Codex GUI bottom-right reads. We
+        // keep this on the summary so the rewrite step knows what
+        // value to swap out, without making collectSessionChanges
+        // require a target model.
+        const originalModel = await readFirstTurnContextModel(rolloutPath, {
+          firstLineOffset: 0,
+          firstLineLength: record.offset
+        });
         summaries.push({
           path: rolloutPath,
           threadId: parsed.payload.id ?? null,
@@ -695,6 +862,7 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
           originalSize: snapshot.size,
           originalMtimeMs: snapshot.mtimeMs,
           originalProvider: currentProvider,
+          originalModel,
           updatedFirstLine: JSON.stringify(parsed)
         });
       }
@@ -704,8 +872,9 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
   return { changes: summaries, lockedPaths, providerCounts, encryptedContentCounts, userEventThreadIds, threadCwdById };
 }
 
-export async function applySessionChanges(changes) {
+export async function applySessionChanges(changes, options = {}) {
   const normalizedChanges = changes ?? [];
+  const { targetModel = null } = options ?? {};
   const skippedPaths = [];
   const appliedPaths = [];
   let appliedChanges = 0;
@@ -717,6 +886,10 @@ export async function applySessionChanges(changes) {
         appliedChanges += 1;
         appliedPaths.push(normalizedChanges[index].path);
         await restoreOriginalMtime(normalizedChanges[index].path, normalizedChanges[index].originalMtimeMs);
+        // After the first-line rewrite, do a second pass that
+        // updates the per-turn `model` field. This is what the
+        // Codex GUI bottom-right of an old conversation reads.
+        await rewriteRolloutModelField(normalizedChanges[index], targetModel);
       } else {
         skippedPaths.push(normalizedChanges[index].path);
       }
@@ -727,6 +900,7 @@ export async function applySessionChanges(changes) {
         appliedChanges += 1;
         appliedPaths.push(change.path);
         await restoreOriginalMtime(change.path, change.originalMtimeMs);
+        await rewriteRolloutModelField(change, targetModel);
       } else {
         skippedPaths.push(change.path);
       }

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -358,7 +358,15 @@ async function readFirstTurnContextModel(rolloutPath, { firstLineOffset, firstLi
 // stay in sync. The `originalModel` we report back is the
 // top-level one — it is what the restore path uses to put the
 // line back to its original state on a failed rollback.
-const TURN_CONTEXT_MODEL_FIELD_RE = /"model"\s*:\s*"((?:[^"\\]|\\.)*)"/g;
+//
+// `g`-flagged RegExps are stateful: `String.prototype.match` and
+// `RegExp.prototype.test` both advance `lastIndex` between calls,
+// which is a footgun we explicitly do not want to inherit. We
+// rebuild the regex on every call site instead, which is cheap
+// (V8 caches the compiled pattern) and keeps each function pure.
+function buildTurnContextModelFieldRegex() {
+  return /"model"\s*:\s*"((?:[^"\\]|\\.)*)"/g;
+}
 
 function decodeJsonStringLiteral(literal) {
   // Treat the captured value as the inside of a JSON string literal
@@ -381,10 +389,10 @@ function rewriteTurnContextModelInLine(line, newModel) {
   if (!line || !line.includes('"turn_context"')) {
     return { line, replaced: false, originalModel: null };
   }
-  // Reset the regex's lastIndex because `g`-flag regexes are
-  // stateful when used with `match`/`exec`. We use `matchAll` to
-  // find every `model` field in the line in one pass.
-  const occurrences = [...line.matchAll(TURN_CONTEXT_MODEL_FIELD_RE)];
+  const regex = buildTurnContextModelFieldRegex();
+  // `matchAll` is non-mutating and returns a fresh iterator on
+  // every call, so we can safely use a stateful regex here.
+  const occurrences = [...line.matchAll(regex)];
   if (occurrences.length === 0) {
     return { line, replaced: false, originalModel: null };
   }
@@ -418,9 +426,8 @@ function rewriteTurnContextModelInLine(line, newModel) {
   if (alreadyMatches) {
     return { line, replaced: false, originalModel };
   }
-  // Reset the regex for the replacement pass.
-  TURN_CONTEXT_MODEL_FIELD_RE.lastIndex = 0;
-  const newLine = line.replace(TURN_CONTEXT_MODEL_FIELD_RE, `"model":${encodeJsonStringLiteral(newModel)}`);
+  const replacementRegex = buildTurnContextModelFieldRegex();
+  const newLine = line.replace(replacementRegex, `"model":${encodeJsonStringLiteral(newModel)}`);
   return { line: newLine, replaced: true, originalModel };
 }
 
@@ -1058,6 +1065,10 @@ export async function applySessionChanges(changes, options = {}) {
         const modelResult = await rewriteRolloutModelField(firstLineChanges[index], targetModel);
         firstLineChanges[index].originalTurnContextModels = modelResult.originalTurnContextModels;
         firstLineChanges[index].appliedTurnContextRewrites = modelResult.replacedLines;
+        // The per-turn rewrite is a tmp + rename that resets the
+        // mtime; pin it back to the original so the file's
+        // mtime is preserved end-to-end.
+        await restoreOriginalMtime(firstLineChanges[index].path, firstLineChanges[index].originalMtimeMs);
       } else {
         skippedPaths.push(firstLineChanges[index].path);
       }
@@ -1071,6 +1082,9 @@ export async function applySessionChanges(changes, options = {}) {
         const modelResult = await rewriteRolloutModelField(change, targetModel);
         change.originalTurnContextModels = modelResult.originalTurnContextModels;
         change.appliedTurnContextRewrites = modelResult.replacedLines;
+        // Pin the mtime back after the per-turn rewrite's
+        // tmp+rename, which would otherwise advance it to "now".
+        await restoreOriginalMtime(change.path, change.originalMtimeMs);
       } else {
         skippedPaths.push(change.path);
       }
@@ -1314,20 +1328,27 @@ function restoreTurnContextModelInLine(line, originalModel) {
   if (!line || !line.includes('"turn_context"')) {
     return line;
   }
-  const match = line.match(TURN_CONTEXT_MODEL_FIELD_RE);
-  if (!match) {
+  // `matchAll` is the only safe way to inspect a `g`-flagged
+  // regex's matches without poisoning `lastIndex` for the
+  // subsequent `replace` call.
+  const regex = buildTurnContextModelFieldRegex();
+  const occurrences = [...line.matchAll(regex)];
+  if (occurrences.length === 0) {
     return line;
   }
+  // Check the first occurrence's current value. If it already
+  // matches `originalModel` there is no work to do.
   let currentModel = null;
   try {
-    currentModel = decodeJsonStringLiteral(match[1]);
+    currentModel = decodeJsonStringLiteral(occurrences[0][1]);
   } catch {
     return line;
   }
   if (currentModel === originalModel) {
     return line;
   }
-  return line.replace(TURN_CONTEXT_MODEL_FIELD_RE, `"model":${encodeJsonStringLiteral(originalModel)}`);
+  const replacementRegex = buildTurnContextModelFieldRegex();
+  return line.replace(replacementRegex, `"model":${encodeJsonStringLiteral(originalModel)}`);
 }
 
 export function summarizeProviderCounts(providerCounts) {

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -270,42 +270,54 @@ function parseSessionMetaRecord(firstLine) {
 // rewrite it (along with `payload.collaboration_mode.settings.model`) on
 // every sync in addition to the per-thread SQLite `model` column.
 //
-// We only need to peek at the first few KB of the file: the very first
-// `turn_context` event after the leading `session_meta` line is enough
-// to know what model the rest of the file uses. We deliberately stop as
-// soon as we find one, so the scan is O(1) for the common case and does
-// not load multi-MB rollouts into memory just to read a header.
-async function readFirstTurnContextModel(rolloutPath, { firstLineOffset, firstLineLength } = {}) {
-  let handle;
-  try {
-    handle = await fsp.open(rolloutPath, "r");
-    const headerSkip = firstLineOffset ?? 0;
-    const headerLength = firstLineLength ?? 0;
-    const scanLimit = 64 * 1024; // first 64 KB is plenty for one turn_context
-    const chunk = Buffer.alloc(scanLimit);
-    const start = headerSkip + headerLength;
-    const { bytesRead } = await handle.read(chunk, 0, chunk.length, start);
-    if (bytesRead === 0) {
-      return null;
-    }
+// We stream line-by-line because individual `turn_context` lines can
+// easily exceed 64 KB once Codex includes the `developer_instructions`
+// blob — the previous code that capped the read at 64 KB silently
+// missed those, which made the rollout model rewrite a no-op for
+// sessions whose first turn was a long planning step. We stop as
+// soon as we find a `turn_context` line, so the scan is O(1) for the
+// common case and we never load multi-MB rollouts into memory just
+// to read a header.
+//
+// For each line we find, we do a regex on the raw text instead of
+// `JSON.parse`-ing the entire payload: Codex writes opaque multi-KB
+// strings (`developer_instructions`, raw tool output, …) into the
+// payload, and round-tripping those through `JSON.parse` -> `JSON.stringify`
+// would silently mangle embedded escape sequences. Anchoring on
+// `"type":"turn_context"` and grabbing the first `"model":"<value>"`
+// that follows is enough for the first `turn_context` of the file,
+// because rollout lines are single JSON objects.
+const ROLLOUT_TURNCONTEXT_MODEL_RE = /"type"\s*:\s*"turn_context"[\s\S]*?"model"\s*:\s*"((?:[^"\\]|\\.)*)"/;
 
-    const text = chunk.subarray(0, bytesRead).toString("utf8");
-    // Each line in a rollout is a single JSON object. We split on
-    // newlines and look for the first line whose top-level `type`
-    // is `turn_context`, then parse it. A regex that tries to
-    // match the surrounding `{}` of a deeply nested payload will
-    // stop at the first inner `}` and miss the real outer one, so
-    // per-line scanning is much more robust here.
-    for (const line of text.split(/\r?\n/)) {
+async function readFirstTurnContextModel(rolloutPath, { firstLineOffset, firstLineLength } = {}) {
+  const headerSkip = Math.max(0, firstLineOffset ?? 0);
+  const headerLength = Math.max(0, firstLineLength ?? 0);
+
+  const stream = fs.createReadStream(rolloutPath, {
+    encoding: "utf8",
+    start: headerSkip + headerLength,
+    highWaterMark: ROLLOUT_SCAN_CHUNK_BYTES
+  });
+  const lines = readline.createInterface({
+    input: stream,
+    crlfDelay: Infinity
+  });
+
+  try {
+    for await (const line of lines) {
       if (!line.includes('"turn_context"')) {
         continue;
       }
+      const match = line.match(ROLLOUT_TURNCONTEXT_MODEL_RE);
+      if (!match) {
+        continue;
+      }
       try {
-        const parsed = JSON.parse(line);
-        if (parsed?.type === "turn_context"
-            && typeof parsed?.payload?.model === "string"
-            && parsed.payload.model.length > 0) {
-          return parsed.payload.model;
+        // The captured value is JSON-escaped (e.g. `\\`, `\"`). Decode
+        // it the same way `JSON.parse` would for a string literal.
+        const value = JSON.parse(`"${match[1]}"`);
+        if (typeof value === "string" && value.length > 0) {
+          return value;
         }
       } catch {
         // Skip lines that look like turn_context but fail to parse.
@@ -315,7 +327,8 @@ async function readFirstTurnContextModel(rolloutPath, { firstLineOffset, firstLi
   } catch (error) {
     throw wrapRolloutFileBusyError(error, rolloutPath, "read");
   } finally {
-    await handle?.close();
+    lines.close();
+    stream.destroy();
   }
 }
 
@@ -325,14 +338,30 @@ async function readFirstTurnContextModel(rolloutPath, { firstLineOffset, firstLi
 // rollout files can be tens of megabytes, and Codex writes a lot of
 // opaque payload (e.g. `developer_instructions`) that round-tripping
 // through `JSON.parse`+`JSON.stringify` would silently mangle.
+function jsonEscape(value) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+}
+
+function regexEscape(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function rewriteTurnContextModelInLine(line, oldModel, newModel) {
   if (!line || !line.includes('"turn_context"')) {
     return line;
   }
-  const escapedOld = oldModel.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
-  const escapedNew = newModel.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
-  const pattern = new RegExp(`"model"\\s*:\\s*"${escapedOld}"`, "g");
-  return line.replace(pattern, `"model":"${escapedNew}"`);
+  // The old model is embedded in two layers: regex syntax for the
+  // pattern, then JSON string syntax for the payload. We
+  // JSON-escape first (so a literal `\` in the model becomes `\\`
+  // and a `"` becomes `\"`), then regex-escape the resulting string
+  // so those new backslashes — and any other regex metacharacters
+  // in the original model name, like `.`, `+`, `*`, `?` — match
+  // literally instead of being treated as regex specials. Reversing
+  // the order would either fail to compile (an unescaped `{` in the
+  // original) or double-escape the regex metacharacters (the regex
+  // escape of a backslash we just inserted).
+  const pattern = new RegExp(`"model"\\s*:\\s*"${regexEscape(jsonEscape(oldModel))}"`, "g");
+  return line.replace(pattern, `"model":"${jsonEscape(newModel)}"`);
 }
 
 function isValidWindowsRewriteResult(result) {

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -332,36 +332,96 @@ async function readFirstTurnContextModel(rolloutPath, { firstLineOffset, firstLi
   }
 }
 
-// Replace `"model":"oldModel"` with `"model":"newModel"` in lines that
-// represent a `turn_context` event. We intentionally do a per-line
-// regex rewrite (rather than re-serializing the full JSON tree) because
-// rollout files can be tens of megabytes, and Codex writes a lot of
-// opaque payload (e.g. `developer_instructions`) that round-tripping
-// through `JSON.parse`+`JSON.stringify` would silently mangle.
-function jsonEscape(value) {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+// Replace the per-turn `model` field in a single rollout line, on the
+// assumption that the line represents a `turn_context` event. We
+// intentionally do a per-line regex rewrite (rather than
+// re-serializing the full JSON tree) because rollout files can be
+// tens of megabytes, and Codex writes a lot of opaque payload (e.g.
+// `developer_instructions`) that round-tripping through
+// `JSON.parse`+`JSON.stringify` would silently mangle.
+//
+// Unlike the previous implementation, this version does NOT take an
+// `oldModel` parameter: it captures whatever model is currently in
+// the line and replaces it with `newModel`. That makes it correct
+// for sessions where the user has changed models mid-conversation
+// (a real Codex workflow — switching from "gpt-5" to "gpt-4o-mini"
+// for one follow-up turn, for example): the per-turn model must be
+// normalised to the new root-level value regardless of what the
+// previous per-turn value was. The captured `originalModel` is
+// returned so the caller can hand it to the backup manifest and
+// later restore it on a failed rollback.
+//
+// A `turn_context` line can carry more than one `model` field: the
+// top-level `payload.model` and a nested
+// `payload.collaboration_mode.settings.model`. We rewrite every
+// occurrence in the line (the regex uses the `g` flag) so both
+// stay in sync. The `originalModel` we report back is the
+// top-level one — it is what the restore path uses to put the
+// line back to its original state on a failed rollback.
+const TURN_CONTEXT_MODEL_FIELD_RE = /"model"\s*:\s*"((?:[^"\\]|\\.)*)"/g;
+
+function decodeJsonStringLiteral(literal) {
+  // Treat the captured value as the inside of a JSON string literal
+  // and run it through `JSON.parse` so escape sequences such as
+  // `\\`, `\"`, `\n`, `\u00e9` round-trip the same way the rest of
+  // the JSON parser would. We bracket the captured value in quotes
+  // and feed the result back to `JSON.parse`.
+  return JSON.parse(`"${literal}"`);
 }
 
-function regexEscape(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function encodeJsonStringLiteral(value) {
+  // `JSON.stringify` produces a JSON string literal — including the
+  // surrounding double quotes and the right escape sequences for
+  // the value. That is exactly what we need to splice back into the
+  // raw line as the new value of the `model` field.
+  return JSON.stringify(value);
 }
 
-function rewriteTurnContextModelInLine(line, oldModel, newModel) {
+function rewriteTurnContextModelInLine(line, newModel) {
   if (!line || !line.includes('"turn_context"')) {
-    return line;
+    return { line, replaced: false, originalModel: null };
   }
-  // The old model is embedded in two layers: regex syntax for the
-  // pattern, then JSON string syntax for the payload. We
-  // JSON-escape first (so a literal `\` in the model becomes `\\`
-  // and a `"` becomes `\"`), then regex-escape the resulting string
-  // so those new backslashes — and any other regex metacharacters
-  // in the original model name, like `.`, `+`, `*`, `?` — match
-  // literally instead of being treated as regex specials. Reversing
-  // the order would either fail to compile (an unescaped `{` in the
-  // original) or double-escape the regex metacharacters (the regex
-  // escape of a backslash we just inserted).
-  const pattern = new RegExp(`"model"\\s*:\\s*"${regexEscape(jsonEscape(oldModel))}"`, "g");
-  return line.replace(pattern, `"model":"${jsonEscape(newModel)}"`);
+  // Reset the regex's lastIndex because `g`-flag regexes are
+  // stateful when used with `match`/`exec`. We use `matchAll` to
+  // find every `model` field in the line in one pass.
+  const occurrences = [...line.matchAll(TURN_CONTEXT_MODEL_FIELD_RE)];
+  if (occurrences.length === 0) {
+    return { line, replaced: false, originalModel: null };
+  }
+  let originalModel = null;
+  try {
+    originalModel = decodeJsonStringLiteral(occurrences[0][1]);
+  } catch {
+    // The line looks like a turn_context but its `model` value is
+    // not a clean JSON string literal. Refuse to touch it rather
+    // than guess — the roll-out stays byte-identical.
+    return { line, replaced: false, originalModel: null };
+  }
+  if (typeof originalModel !== "string") {
+    return { line, replaced: false, originalModel: null };
+  }
+  // If every `model` field in the line already equals newModel,
+  // there is nothing to rewrite. The line stays byte-identical.
+  let alreadyMatches = true;
+  for (const occurrence of occurrences) {
+    let current;
+    try {
+      current = decodeJsonStringLiteral(occurrence[1]);
+    } catch {
+      current = null;
+    }
+    if (current !== newModel) {
+      alreadyMatches = false;
+      break;
+    }
+  }
+  if (alreadyMatches) {
+    return { line, replaced: false, originalModel };
+  }
+  // Reset the regex for the replacement pass.
+  TURN_CONTEXT_MODEL_FIELD_RE.lastIndex = 0;
+  const newLine = line.replace(TURN_CONTEXT_MODEL_FIELD_RE, `"model":${encodeJsonStringLiteral(newModel)}`);
+  return { line: newLine, replaced: true, originalModel };
 }
 
 function isValidWindowsRewriteResult(result) {
@@ -689,15 +749,25 @@ async function tryRewriteCollectedFirstLine(change) {
 // to avoid round-tripping the multi-MB `developer_instructions` blob
 // Codex writes into every `turn_context`, which can lose embedded
 // backslashes or escape sequences when run through `JSON.stringify`.
+//
+// We pre-scan the file to detect the original line separator (LF vs
+// CRLF) and whether the file had a trailing newline. We then write
+// the rewritten content into a tmp file using the same separator and
+// re-add the trailing newline if it was present. This is the
+// behaviour the owner review asked for: "重写 rollout 时需要保留末尾
+// 换行、换行格式和原始 mtime".
+//
+// Returns `{ replacedLines, originalTurnContextModels }`. The latter
+// is an array of `{ lineIndex, originalModel }` entries (one per
+// rewritten turn_context line) that the backup manifest stores so
+// `restoreSessionChanges` can put the per-turn `model` field back to
+// its original value on a failed rollback.
 async function rewriteRolloutModelField(change, targetModel) {
-  if (!change || typeof change.originalModel !== "string" || change.originalModel.length === 0) {
-    return false;
+  if (!change || typeof change.path !== "string") {
+    return { replacedLines: 0, originalTurnContextModels: [] };
   }
   if (typeof targetModel !== "string" || targetModel.length === 0) {
-    return false;
-  }
-  if (change.originalModel === targetModel) {
-    return false;
+    return { replacedLines: 0, originalTurnContextModels: [] };
   }
 
   const filePath = change.path;
@@ -712,6 +782,18 @@ async function rewriteRolloutModelField(change, targetModel) {
     mtimeMs: beforeStat.mtimeMs
   };
 
+  // Detect the original line separator and trailing-newline state
+  // by reading the file once. Any 0x0d immediately preceding a 0x0a
+  // means CRLF; if we never see 0x0d we treat the file as LF. The
+  // "trailing newline" check covers the three cases we care about:
+  // no terminator, single LF, or CRLF.
+  const rawBuffer = await fsp.readFile(filePath);
+  const lineSeparator = rawBuffer.includes(0x0d) ? "\r\n" : "\n";
+  const lastByte = rawBuffer.length > 0 ? rawBuffer[rawBuffer.length - 1] : null;
+  const secondLastByte = rawBuffer.length > 1 ? rawBuffer[rawBuffer.length - 2] : null;
+  const hasTrailingNewline = lastByte === 0x0a
+    || (lineSeparator === "\r\n" && lastByte === 0x0a && secondLastByte === 0x0d);
+
   let handle;
   try {
     handle = await fsp.open(filePath, "r+");
@@ -721,22 +803,32 @@ async function rewriteRolloutModelField(change, targetModel) {
     const writer = fs.createWriteStream(tmpPath, { encoding: "utf8" });
     let firstLine = true;
     let replacements = 0;
+    let lineIndex = -1;
+    const originalTurnContextModels = [];
 
     await new Promise((resolve, reject) => {
       reader.on("error", reject);
       writer.on("error", reject);
       reader.on("line", (line) => {
-        const next = firstLine
-          ? line
-          : rewriteTurnContextModelInLine(line, change.originalModel, targetModel);
-        if (next !== line) {
+        if (firstLine) {
+          // The first line is the session_meta; it has no
+          // per-turn model field. Write it through verbatim.
+          writer.write(line);
+          firstLine = false;
+          lineIndex = 0;
+          return;
+        }
+        lineIndex += 1;
+        const result = rewriteTurnContextModelInLine(line, targetModel);
+        if (result.replaced) {
           replacements += 1;
+          originalTurnContextModels.push({
+            lineIndex,
+            originalModel: result.originalModel
+          });
         }
-        if (!firstLine) {
-          writer.write("\n");
-        }
-        firstLine = false;
-        writer.write(next);
+        writer.write(lineSeparator);
+        writer.write(result.line);
       });
       reader.on("close", () => {
         writer.end();
@@ -746,7 +838,14 @@ async function rewriteRolloutModelField(change, targetModel) {
 
     if (replacements === 0) {
       await fsp.rm(tmpPath, { force: true });
-      return false;
+      return { replacedLines: 0, originalTurnContextModels: [] };
+    }
+
+    // Preserve the original trailing newline state. If the file
+    // had no terminator we leave it that way; if it had one
+    // (LF or CRLF) we re-add it to the tmp file.
+    if (hasTrailingNewline) {
+      await fsp.appendFile(tmpPath, lineSeparator, "utf8");
     }
 
     // Refuse to swap in the new file if Codex appended anything
@@ -755,11 +854,11 @@ async function rewriteRolloutModelField(change, targetModel) {
     const afterStat = await fsp.stat(filePath);
     if (afterStat.size !== beforeSnapshot.size || afterStat.mtimeMs !== beforeSnapshot.mtimeMs) {
       await fsp.rm(tmpPath, { force: true });
-      return false;
+      return { replacedLines: 0, originalTurnContextModels: [] };
     }
 
     await fsp.rename(tmpPath, filePath);
-    return true;
+    return { replacedLines: replacements, originalTurnContextModels };
   } catch (error) {
     throw wrapRolloutFileBusyError(error, filePath, "rewrite model field");
   } finally {
@@ -811,7 +910,8 @@ async function findLockedFilesOnWindows(filePaths) {
 
 export async function collectSessionChanges(codexHome, targetProvider, options = {}) {
   const {
-    skipLockedReads = false
+    skipLockedReads = false,
+    targetModel = null
   } = options;
   const summaries = [];
   const lockedPaths = [];
@@ -869,18 +969,35 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
         throw error;
       }
 
-      if (targetProvider !== "__status_only__" && parsed.payload.model_provider !== targetProvider) {
+      // Peek at the first `turn_context` event to capture the
+      // per-turn model that the Codex GUI bottom-right reads. We
+      // keep this on the summary so the rewrite step knows what
+      // value to swap out, without making collectSessionChanges
+      // require a target model.
+      const originalModel = await readFirstTurnContextModel(rolloutPath, {
+        firstLineOffset: 0,
+        firstLineLength: record.offset
+      });
+
+      // A file is rewritten when EITHER the provider needs to
+      // change OR the per-turn model needs to change. The
+      // provider-unchanged-but-model-changed case was missing
+      // before the owner review: when the user edited the
+      // root-level `model = "..."` in config.toml but kept the
+      // same provider, the rollout's turn_context.model was not
+      // updated and the GUI would still show the old model.
+      const providerChanged = targetProvider !== "__status_only__" && parsed.payload.model_provider !== targetProvider;
+      const modelChanged = typeof targetModel === "string"
+        && targetModel.length > 0
+        && typeof originalModel === "string"
+        && originalModel.length > 0
+        && originalModel !== targetModel;
+
+      if (providerChanged || modelChanged) {
         const snapshot = await getFileSnapshot(rolloutPath);
-        parsed.payload.model_provider = targetProvider;
-        // Peek at the first `turn_context` event to capture the
-        // per-turn model that the Codex GUI bottom-right reads. We
-        // keep this on the summary so the rewrite step knows what
-        // value to swap out, without making collectSessionChanges
-        // require a target model.
-        const originalModel = await readFirstTurnContextModel(rolloutPath, {
-          firstLineOffset: 0,
-          firstLineLength: record.offset
-        });
+        if (providerChanged) {
+          parsed.payload.model_provider = targetProvider;
+        }
         summaries.push({
           path: rolloutPath,
           threadId: parsed.payload.id ?? null,
@@ -892,7 +1009,12 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
           originalMtimeMs: snapshot.mtimeMs,
           originalProvider: currentProvider,
           originalModel,
-          updatedFirstLine: JSON.stringify(parsed)
+          // Mark this change as a "model-only" change when the
+          // provider is already correct. The first-line rewrite
+        // path uses this to skip touching the first line at
+        // all — only the per-turn `model` field needs to move.
+          modelOnlyChange: !providerChanged && modelChanged,
+          updatedFirstLine: providerChanged ? JSON.stringify(parsed) : record.firstLine
         });
       }
     }
@@ -908,31 +1030,76 @@ export async function applySessionChanges(changes, options = {}) {
   const appliedPaths = [];
   let appliedChanges = 0;
 
+  // A "model-only" change carries no first-line rewrite. The
+  // provider is already correct on disk, so the only thing to
+  // update is the per-turn `model` field on each turn_context
+  // line. We still need the manifest entry so a failed
+  // rollback can put the per-turn `model` values back, so we
+  // synthesise an entry that records the no-op first-line
+  // rewrite explicitly.
+  const modelOnlyChanges = normalizedChanges.filter((change) => change?.modelOnlyChange);
+  const firstLineChanges = normalizedChanges.filter((change) => !change?.modelOnlyChange);
+
   if (process.platform === "win32") {
-    const results = await invokeWindowsExclusiveRewriteBatch(normalizedChanges, { requireOriginalMatch: true });
-    for (let index = 0; index < normalizedChanges.length; index += 1) {
+    const results = firstLineChanges.length > 0
+      ? await invokeWindowsExclusiveRewriteBatch(firstLineChanges, { requireOriginalMatch: true })
+      : [];
+    for (let index = 0; index < firstLineChanges.length; index += 1) {
       if (results[index] === "APPLIED") {
         appliedChanges += 1;
-        appliedPaths.push(normalizedChanges[index].path);
-        await restoreOriginalMtime(normalizedChanges[index].path, normalizedChanges[index].originalMtimeMs);
+        appliedPaths.push(firstLineChanges[index].path);
+        await restoreOriginalMtime(firstLineChanges[index].path, firstLineChanges[index].originalMtimeMs);
         // After the first-line rewrite, do a second pass that
         // updates the per-turn `model` field. This is what the
         // Codex GUI bottom-right of an old conversation reads.
-        await rewriteRolloutModelField(normalizedChanges[index], targetModel);
+        // We also attach the per-line original model list to the
+        // change so the backup manifest can record it for the
+        // restore path.
+        const modelResult = await rewriteRolloutModelField(firstLineChanges[index], targetModel);
+        firstLineChanges[index].originalTurnContextModels = modelResult.originalTurnContextModels;
+        firstLineChanges[index].appliedTurnContextRewrites = modelResult.replacedLines;
       } else {
-        skippedPaths.push(normalizedChanges[index].path);
+        skippedPaths.push(firstLineChanges[index].path);
       }
     }
   } else {
-    for (const change of normalizedChanges) {
+    for (const change of firstLineChanges) {
       if (await tryRewriteCollectedFirstLine(change)) {
         appliedChanges += 1;
         appliedPaths.push(change.path);
         await restoreOriginalMtime(change.path, change.originalMtimeMs);
-        await rewriteRolloutModelField(change, targetModel);
+        const modelResult = await rewriteRolloutModelField(change, targetModel);
+        change.originalTurnContextModels = modelResult.originalTurnContextModels;
+        change.appliedTurnContextRewrites = modelResult.replacedLines;
       } else {
         skippedPaths.push(change.path);
       }
+    }
+  }
+
+  // For model-only changes, skip the first-line rewrite entirely
+  // and go straight to the per-turn model field pass. We only
+  // count the change as "applied" when the per-turn pass actually
+  // rewrote at least one line, so the manifest does not get a
+  // half-applied entry. We also restore the original mtime so
+  // the file's timestamp is preserved exactly the way the user
+  // set it.
+  for (const change of modelOnlyChanges) {
+    let modelResult;
+    try {
+      modelResult = await rewriteRolloutModelField(change, targetModel);
+    } catch (error) {
+      skippedPaths.push(change.path);
+      throw error;
+    }
+    if (modelResult.replacedLines > 0) {
+      await restoreOriginalMtime(change.path, change.originalMtimeMs);
+      appliedChanges += 1;
+      appliedPaths.push(change.path);
+      change.originalTurnContextModels = modelResult.originalTurnContextModels;
+      change.appliedTurnContextRewrites = modelResult.replacedLines;
+    } else {
+      skippedPaths.push(change.path);
     }
   }
 
@@ -1018,13 +1185,149 @@ export async function restoreSessionChanges(manifestEntries) {
     for (const change of changes) {
       await restoreOriginalMtime(change.path, change.originalMtimeMs);
     }
+    for (const entry of manifestEntries) {
+      if (entry.originalTurnContextModels?.length) {
+        await restoreTurnContextModelsInFile(entry.path, entry.originalTurnContextModels);
+      }
+    }
     return;
   }
 
   for (const entry of manifestEntries) {
     await rewriteFirstLine(entry.path, entry.originalFirstLine, entry.originalSeparator ?? "\n");
     await restoreOriginalMtime(entry.path, entry.originalMtimeMs);
+    if (entry.originalTurnContextModels?.length) {
+      await restoreTurnContextModelsInFile(entry.path, entry.originalTurnContextModels);
+    }
   }
+}
+
+// Walk a rollout file and restore the per-turn `model` field for
+// every line that the backup manifest recorded. The manifest stores
+// `lineIndex` values that are stable relative to the session_meta
+// first line: index 0 is the first non-meta line, 1 is the second,
+// and so on. Codex may have appended new events after the backup;
+// those events are at indices beyond the manifest's range and are
+// left alone.
+//
+// The rewrite path is line-by-line, identical in shape to
+// `rewriteRolloutModelField`, and preserves the original line
+// separator + trailing-newline state of the file.
+async function restoreTurnContextModelsInFile(filePath, originalTurnContextModels) {
+  if (!filePath || !Array.isArray(originalTurnContextModels) || originalTurnContextModels.length === 0) {
+    return;
+  }
+  // Build a quick lookup by index.
+  const byIndex = new Map();
+  for (const entry of originalTurnContextModels) {
+    if (entry && typeof entry.lineIndex === "number" && typeof entry.originalModel === "string") {
+      byIndex.set(entry.lineIndex, entry.originalModel);
+    }
+  }
+  if (byIndex.size === 0) {
+    return;
+  }
+
+  const beforeStat = await fsp.stat(filePath);
+  const beforeSnapshot = { size: beforeStat.size, mtimeMs: beforeStat.mtimeMs };
+
+  const rawBuffer = await fsp.readFile(filePath);
+  const lineSeparator = rawBuffer.includes(0x0d) ? "\r\n" : "\n";
+  const lastByte = rawBuffer.length > 0 ? rawBuffer[rawBuffer.length - 1] : null;
+  const secondLastByte = rawBuffer.length > 1 ? rawBuffer[rawBuffer.length - 2] : null;
+  const hasTrailingNewline = lastByte === 0x0a
+    || (lineSeparator === "\r\n" && lastByte === 0x0a && secondLastByte === 0x0d);
+
+  let handle;
+  try {
+    handle = await fsp.open(filePath, "r+");
+    const stream = handle.createReadStream({ encoding: "utf8" });
+    const reader = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    const tmpPath = `${filePath}.provider-sync-restore.${process.pid}.${Date.now()}.tmp`;
+    const writer = fs.createWriteStream(tmpPath, { encoding: "utf8" });
+
+    let firstLine = true;
+    let lineIndex = -1;
+    let replacements = 0;
+
+    await new Promise((resolve, reject) => {
+      reader.on("error", reject);
+      writer.on("error", reject);
+      reader.on("line", (line) => {
+        if (firstLine) {
+          writer.write(line);
+          firstLine = false;
+          lineIndex = 0;
+          return;
+        }
+        lineIndex += 1;
+        const restoreTo = byIndex.get(lineIndex);
+        if (restoreTo !== undefined && line.includes('"turn_context"')) {
+          // The current line is a turn_context line whose
+          // per-turn `model` field we need to put back. We only
+          // touch it if it currently holds some other value
+          // (i.e. the value is not the original — if it is
+          // already correct, skip the rewrite so the file stays
+          // byte-identical and we don't burn IOPS on no-op
+          // edits).
+          const newLine = restoreTurnContextModelInLine(line, restoreTo);
+          if (newLine !== line) {
+            replacements += 1;
+            writer.write(lineSeparator);
+            writer.write(newLine);
+            return;
+          }
+        }
+        writer.write(lineSeparator);
+        writer.write(line);
+      });
+      reader.on("close", () => {
+        writer.end();
+      });
+      writer.on("finish", resolve);
+    });
+
+    if (replacements === 0) {
+      await fsp.rm(tmpPath, { force: true });
+      return;
+    }
+
+    if (hasTrailingNewline) {
+      await fsp.appendFile(tmpPath, lineSeparator, "utf8");
+    }
+
+    const afterStat = await fsp.stat(filePath);
+    if (afterStat.size !== beforeSnapshot.size || afterStat.mtimeMs !== beforeSnapshot.mtimeMs) {
+      await fsp.rm(tmpPath, { force: true });
+      return;
+    }
+
+    await fsp.rename(tmpPath, filePath);
+  } catch (error) {
+    throw wrapRolloutFileBusyError(error, filePath, "restore turn_context model");
+  } finally {
+    await handle?.close();
+  }
+}
+
+function restoreTurnContextModelInLine(line, originalModel) {
+  if (!line || !line.includes('"turn_context"')) {
+    return line;
+  }
+  const match = line.match(TURN_CONTEXT_MODEL_FIELD_RE);
+  if (!match) {
+    return line;
+  }
+  let currentModel = null;
+  try {
+    currentModel = decodeJsonStringLiteral(match[1]);
+  } catch {
+    return line;
+  }
+  if (currentModel === originalModel) {
+    return line;
+  }
+  return line.replace(TURN_CONTEXT_MODEL_FIELD_RE, `"model":${encodeJsonStringLiteral(originalModel)}`);
 }
 
 export function summarizeProviderCounts(providerCounts) {

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -287,11 +287,12 @@ function parseSessionMetaRecord(firstLine) {
 // `"type":"turn_context"` and grabbing the first `"model":"<value>"`
 // that follows is enough for the first `turn_context` of the file,
 // because rollout lines are single JSON objects.
-const ROLLOUT_TURNCONTEXT_MODEL_RE = /"type"\s*:\s*"turn_context"[\s\S]*?"model"\s*:\s*"((?:[^"\\]|\\.)*)"/;
+const ROLLOUT_TURNCONTEXT_TYPE_RE = /"type"\s*:\s*"turn_context"/;
 
-async function readFirstTurnContextModel(rolloutPath, { firstLineOffset, firstLineLength } = {}) {
+async function readTurnContextModels(rolloutPath, { firstLineOffset, firstLineLength } = {}) {
   const headerSkip = Math.max(0, firstLineOffset ?? 0);
   const headerLength = Math.max(0, firstLineLength ?? 0);
+  const models = [];
 
   const stream = fs.createReadStream(rolloutPath, {
     encoding: "utf8",
@@ -308,22 +309,21 @@ async function readFirstTurnContextModel(rolloutPath, { firstLineOffset, firstLi
       if (!line.includes('"turn_context"')) {
         continue;
       }
-      const match = line.match(ROLLOUT_TURNCONTEXT_MODEL_RE);
-      if (!match) {
+      if (!ROLLOUT_TURNCONTEXT_TYPE_RE.test(line)) {
         continue;
       }
-      try {
-        // The captured value is JSON-escaped (e.g. `\\`, `\"`). Decode
-        // it the same way `JSON.parse` would for a string literal.
-        const value = JSON.parse(`"${match[1]}"`);
-        if (typeof value === "string" && value.length > 0) {
-          return value;
+      for (const match of line.matchAll(buildTurnContextModelFieldRegex())) {
+        try {
+          const value = decodeJsonStringLiteral(match[1]);
+          if (typeof value === "string" && value.length > 0) {
+            models.push(value);
+          }
+        } catch {
+          // Leave malformed model literals untouched.
         }
-      } catch {
-        // Skip lines that look like turn_context but fail to parse.
       }
     }
-    return null;
+    return models;
   } catch (error) {
     throw wrapRolloutFileBusyError(error, rolloutPath, "read");
   } finally {
@@ -396,39 +396,40 @@ function rewriteTurnContextModelInLine(line, newModel) {
   if (occurrences.length === 0) {
     return { line, replaced: false, originalModel: null };
   }
-  let originalModel = null;
+  const originalModels = [];
   try {
-    originalModel = decodeJsonStringLiteral(occurrences[0][1]);
+    for (const occurrence of occurrences) {
+      originalModels.push(decodeJsonStringLiteral(occurrence[1]));
+    }
   } catch {
     // The line looks like a turn_context but its `model` value is
     // not a clean JSON string literal. Refuse to touch it rather
     // than guess — the roll-out stays byte-identical.
     return { line, replaced: false, originalModel: null };
   }
-  if (typeof originalModel !== "string") {
+  if (originalModels.some((model) => typeof model !== "string")) {
     return { line, replaced: false, originalModel: null };
   }
   // If every `model` field in the line already equals newModel,
   // there is nothing to rewrite. The line stays byte-identical.
   let alreadyMatches = true;
-  for (const occurrence of occurrences) {
-    let current;
-    try {
-      current = decodeJsonStringLiteral(occurrence[1]);
-    } catch {
-      current = null;
-    }
+  for (const current of originalModels) {
     if (current !== newModel) {
       alreadyMatches = false;
       break;
     }
   }
   if (alreadyMatches) {
-    return { line, replaced: false, originalModel };
+    return { line, replaced: false, originalModel: originalModels[0], originalModels };
   }
   const replacementRegex = buildTurnContextModelFieldRegex();
   const newLine = line.replace(replacementRegex, `"model":${encodeJsonStringLiteral(newModel)}`);
-  return { line: newLine, replaced: true, originalModel };
+  return {
+    line: newLine,
+    replaced: true,
+    originalModel: originalModels[0],
+    originalModels
+  };
 }
 
 function isValidWindowsRewriteResult(result) {
@@ -789,21 +790,20 @@ async function rewriteRolloutModelField(change, targetModel) {
     mtimeMs: beforeStat.mtimeMs
   };
 
-  // Detect the original line separator and trailing-newline state
-  // by reading the file once. Any 0x0d immediately preceding a 0x0a
-  // means CRLF; if we never see 0x0d we treat the file as LF. The
-  // "trailing newline" check covers the three cases we care about:
-  // no terminator, single LF, or CRLF.
-  const rawBuffer = await fsp.readFile(filePath);
-  const lineSeparator = rawBuffer.includes(0x0d) ? "\r\n" : "\n";
-  const lastByte = rawBuffer.length > 0 ? rawBuffer[rawBuffer.length - 1] : null;
-  const secondLastByte = rawBuffer.length > 1 ? rawBuffer[rawBuffer.length - 2] : null;
-  const hasTrailingNewline = lastByte === 0x0a
-    || (lineSeparator === "\r\n" && lastByte === 0x0a && secondLastByte === 0x0d);
+  const lineSeparator = change.originalSeparator === "\r\n" ? "\r\n" : "\n";
 
   let handle;
   try {
     handle = await fsp.open(filePath, "r+");
+    const openedStat = await handle.stat();
+    if (openedStat.size !== beforeSnapshot.size || openedStat.mtimeMs !== beforeSnapshot.mtimeMs) {
+      return { replacedLines: 0, originalTurnContextModels: [] };
+    }
+    const tail = Buffer.alloc(Math.min(2, openedStat.size));
+    if (tail.length > 0) {
+      await handle.read(tail, 0, tail.length, openedStat.size - tail.length);
+    }
+    const hasTrailingNewline = tail.length > 0 && tail[tail.length - 1] === 0x0a;
     const stream = handle.createReadStream({ encoding: "utf8" });
     const reader = readline.createInterface({ input: stream, crlfDelay: Infinity });
     const tmpPath = `${filePath}.provider-sync-model.${process.pid}.${Date.now()}.tmp`;
@@ -831,7 +831,8 @@ async function rewriteRolloutModelField(change, targetModel) {
           replacements += 1;
           originalTurnContextModels.push({
             lineIndex,
-            originalModel: result.originalModel
+            originalModel: result.originalModel,
+            originalModels: result.originalModels
           });
         }
         writer.write(lineSeparator);
@@ -981,10 +982,11 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
       // keep this on the summary so the rewrite step knows what
       // value to swap out, without making collectSessionChanges
       // require a target model.
-      const originalModel = await readFirstTurnContextModel(rolloutPath, {
+      const currentModels = await readTurnContextModels(rolloutPath, {
         firstLineOffset: 0,
         firstLineLength: record.offset
       });
+      const originalModel = currentModels[0] ?? null;
 
       // A file is rewritten when EITHER the provider needs to
       // change OR the per-turn model needs to change. The
@@ -996,9 +998,7 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
       const providerChanged = targetProvider !== "__status_only__" && parsed.payload.model_provider !== targetProvider;
       const modelChanged = typeof targetModel === "string"
         && targetModel.length > 0
-        && typeof originalModel === "string"
-        && originalModel.length > 0
-        && originalModel !== targetModel;
+        && currentModels.some((currentModel) => currentModel !== targetModel);
 
       if (providerChanged || modelChanged) {
         const snapshot = await getFileSnapshot(rolloutPath);
@@ -1182,7 +1182,8 @@ export async function restoreSessionChanges(manifestEntries) {
   }
 
   if (process.platform === "win32") {
-    const changes = manifestEntries.map((entry) => ({
+    const firstLineEntries = manifestEntries.filter((entry) => !entry.modelOnlyChange);
+    const changes = firstLineEntries.map((entry) => ({
       path: entry.path,
       separator: entry.originalSeparator ?? "\n",
       updatedFirstLine: entry.originalFirstLine,
@@ -1196,23 +1197,23 @@ export async function restoreSessionChanges(manifestEntries) {
         `Unable to rewrite rollout file because it is currently in use. Close Codex and the Codex app, then retry. Locked file: ${filePath}`
       );
     }
-    for (const change of changes) {
-      await restoreOriginalMtime(change.path, change.originalMtimeMs);
-    }
     for (const entry of manifestEntries) {
       if (entry.originalTurnContextModels?.length) {
-        await restoreTurnContextModelsInFile(entry.path, entry.originalTurnContextModels);
+        await restoreTurnContextModelsInFile(entry.path, entry.originalTurnContextModels, entry.originalSeparator);
       }
+      await restoreOriginalMtime(entry.path, entry.originalMtimeMs);
     }
     return;
   }
 
   for (const entry of manifestEntries) {
-    await rewriteFirstLine(entry.path, entry.originalFirstLine, entry.originalSeparator ?? "\n");
-    await restoreOriginalMtime(entry.path, entry.originalMtimeMs);
-    if (entry.originalTurnContextModels?.length) {
-      await restoreTurnContextModelsInFile(entry.path, entry.originalTurnContextModels);
+    if (!entry.modelOnlyChange) {
+      await rewriteFirstLine(entry.path, entry.originalFirstLine, entry.originalSeparator ?? "\n");
     }
+    if (entry.originalTurnContextModels?.length) {
+      await restoreTurnContextModelsInFile(entry.path, entry.originalTurnContextModels, entry.originalSeparator);
+    }
+    await restoreOriginalMtime(entry.path, entry.originalMtimeMs);
   }
 }
 
@@ -1227,7 +1228,7 @@ export async function restoreSessionChanges(manifestEntries) {
 // The rewrite path is line-by-line, identical in shape to
 // `rewriteRolloutModelField`, and preserves the original line
 // separator + trailing-newline state of the file.
-async function restoreTurnContextModelsInFile(filePath, originalTurnContextModels) {
+async function restoreTurnContextModelsInFile(filePath, originalTurnContextModels, originalSeparator) {
   if (!filePath || !Array.isArray(originalTurnContextModels) || originalTurnContextModels.length === 0) {
     return;
   }
@@ -1235,7 +1236,7 @@ async function restoreTurnContextModelsInFile(filePath, originalTurnContextModel
   const byIndex = new Map();
   for (const entry of originalTurnContextModels) {
     if (entry && typeof entry.lineIndex === "number" && typeof entry.originalModel === "string") {
-      byIndex.set(entry.lineIndex, entry.originalModel);
+      byIndex.set(entry.lineIndex, entry);
     }
   }
   if (byIndex.size === 0) {
@@ -1245,16 +1246,20 @@ async function restoreTurnContextModelsInFile(filePath, originalTurnContextModel
   const beforeStat = await fsp.stat(filePath);
   const beforeSnapshot = { size: beforeStat.size, mtimeMs: beforeStat.mtimeMs };
 
-  const rawBuffer = await fsp.readFile(filePath);
-  const lineSeparator = rawBuffer.includes(0x0d) ? "\r\n" : "\n";
-  const lastByte = rawBuffer.length > 0 ? rawBuffer[rawBuffer.length - 1] : null;
-  const secondLastByte = rawBuffer.length > 1 ? rawBuffer[rawBuffer.length - 2] : null;
-  const hasTrailingNewline = lastByte === 0x0a
-    || (lineSeparator === "\r\n" && lastByte === 0x0a && secondLastByte === 0x0d);
+  const lineSeparator = originalSeparator === "\r\n" ? "\r\n" : "\n";
 
   let handle;
   try {
     handle = await fsp.open(filePath, "r+");
+    const openedStat = await handle.stat();
+    if (openedStat.size !== beforeSnapshot.size || openedStat.mtimeMs !== beforeSnapshot.mtimeMs) {
+      return;
+    }
+    const tail = Buffer.alloc(Math.min(2, openedStat.size));
+    if (tail.length > 0) {
+      await handle.read(tail, 0, tail.length, openedStat.size - tail.length);
+    }
+    const hasTrailingNewline = tail.length > 0 && tail[tail.length - 1] === 0x0a;
     const stream = handle.createReadStream({ encoding: "utf8" });
     const reader = readline.createInterface({ input: stream, crlfDelay: Infinity });
     const tmpPath = `${filePath}.provider-sync-restore.${process.pid}.${Date.now()}.tmp`;
@@ -1275,8 +1280,8 @@ async function restoreTurnContextModelsInFile(filePath, originalTurnContextModel
           return;
         }
         lineIndex += 1;
-        const restoreTo = byIndex.get(lineIndex);
-        if (restoreTo !== undefined && line.includes('"turn_context"')) {
+        const restoreEntry = byIndex.get(lineIndex);
+        if (restoreEntry !== undefined && line.includes('"turn_context"')) {
           // The current line is a turn_context line whose
           // per-turn `model` field we need to put back. We only
           // touch it if it currently holds some other value
@@ -1284,7 +1289,7 @@ async function restoreTurnContextModelsInFile(filePath, originalTurnContextModel
           // already correct, skip the rewrite so the file stays
           // byte-identical and we don't burn IOPS on no-op
           // edits).
-          const newLine = restoreTurnContextModelInLine(line, restoreTo);
+          const newLine = restoreTurnContextModelInLine(line, restoreEntry);
           if (newLine !== line) {
             replacements += 1;
             writer.write(lineSeparator);
@@ -1324,7 +1329,7 @@ async function restoreTurnContextModelsInFile(filePath, originalTurnContextModel
   }
 }
 
-function restoreTurnContextModelInLine(line, originalModel) {
+function restoreTurnContextModelInLine(line, backup) {
   if (!line || !line.includes('"turn_context"')) {
     return line;
   }
@@ -1336,19 +1341,27 @@ function restoreTurnContextModelInLine(line, originalModel) {
   if (occurrences.length === 0) {
     return line;
   }
-  // Check the first occurrence's current value. If it already
-  // matches `originalModel` there is no work to do.
-  let currentModel = null;
+  const originalModels = Array.isArray(backup.originalModels)
+    && backup.originalModels.length === occurrences.length
+    ? backup.originalModels
+    : Array.from({ length: occurrences.length }, () => backup.originalModel);
+  const currentModels = [];
   try {
-    currentModel = decodeJsonStringLiteral(occurrences[0][1]);
+    for (const occurrence of occurrences) {
+      currentModels.push(decodeJsonStringLiteral(occurrence[1]));
+    }
   } catch {
     return line;
   }
-  if (currentModel === originalModel) {
+  if (currentModels.every((model, index) => model === originalModels[index])) {
     return line;
   }
   const replacementRegex = buildTurnContextModelFieldRegex();
-  return line.replace(replacementRegex, `"model":${encodeJsonStringLiteral(originalModel)}`);
+  let index = 0;
+  return line.replace(
+    replacementRegex,
+    () => `"model":${encodeJsonStringLiteral(originalModels[index++])}`
+  );
 }
 
 export function summarizeProviderCounts(providerCounts) {

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -335,6 +335,11 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
   const options = typeof afterUpdateOrOptions === "function"
     ? (maybeOptions ?? {})
     : (afterUpdateOrOptions ?? {});
+  // When provided, the per-thread `model` column is rewritten alongside
+  // `model_provider` so old sessions pick up the new active model in
+  // the Codex UI's bottom-right label. Pass null to leave the column
+  // untouched (legacy behaviour for callers that do not track model).
+  const targetModel = options.targetModel ?? null;
 
   const dbPath = await existingStateDbPath(codexHome);
   if (!dbPath) {
@@ -363,12 +368,24 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
     setBusyTimeout(db, options.busyTimeoutMs);
     db.exec("BEGIN IMMEDIATE");
     transactionOpen = true;
-    const stmt = db.prepare(`
-      UPDATE threads
-      SET model_provider = ?
-      WHERE COALESCE(model_provider, '') <> ?
-    `);
-    const result = stmt.run(targetProvider, targetProvider);
+    // When a target model is provided, align every thread's `model` column
+    // with it alongside `model_provider`. This is what makes the bottom-right
+    // of the Codex UI show the active model for old sessions, instead of the
+    // name that was in effect when each thread was originally created.
+    // The `model` column is only present in newer Codex schemas, so guard
+    // with tableHasColumn to keep legacy layouts working.
+    const wantsModel = targetModel != null && targetModel.length > 0
+      && tableHasColumn(db, "threads", "model");
+    const stmt = db.prepare(wantsModel
+      ? `UPDATE threads
+         SET model_provider = ?, model = ?
+         WHERE COALESCE(model_provider, '') <> ? OR COALESCE(model, '') <> ?`
+      : `UPDATE threads
+         SET model_provider = ?
+         WHERE COALESCE(model_provider, '') <> ?`);
+    const result = wantsModel
+      ? stmt.run(targetProvider, targetModel, targetProvider, targetModel)
+      : stmt.run(targetProvider, targetProvider);
     let userEventUpdatedRows = 0;
     if (tableHasColumn(db, "threads", "has_user_event") && options.userEventThreadIds?.size) {
       const userEventStmt = db.prepare(`

--- a/src/watch.js
+++ b/src/watch.js
@@ -1,0 +1,382 @@
+// Watch daemon: monitor ~/.codex/config.toml and the Codex state database
+// (including its WAL sidecar) for external changes and run a sync whenever
+// the active provider goes out of sync. This is the "auto resync" companion
+// to `codex-provider sync`.
+//
+// Usage:
+//   codex-provider watch [--codex-home PATH] [--debounce-ms N] [--once] [--no-state-db]
+//
+// --once    : exit after the first successful sync (or after debounce settles).
+//             Useful for one-shot automation without keeping a process around.
+// --no-state-db : only watch config.toml, ignore SQLite state events.
+
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import { defaultCodexHome } from "./constants.js";
+import { detectStateDb } from "./sqlite-state.js";
+import { readConfigText, readRootModelFromConfigText } from "./config-file.js";
+
+function normalizeCodexHome(explicitCodexHome) {
+  return path.resolve(explicitCodexHome ?? process.env.CODEX_HOME ?? defaultCodexHome());
+}
+
+function defaultDebounceMs() {
+  return 750;
+}
+
+function describeEvent(eventType, filename) {
+  return `${eventType ?? "change"}${filename ? `:${filename}` : ""}`;
+}
+
+function makeDebouncer(delayMs, run) {
+  let timer = null;
+  let pending = null;
+
+  const fire = () => {
+    timer = null;
+    const args = pending;
+    pending = null;
+    run(...args);
+  };
+
+  return function schedule(...args) {
+    pending = args;
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(fire, delayMs);
+  };
+}
+
+async function pathExists(target) {
+  try {
+    await fsp.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function runWatch({
+  codexHome: explicitCodexHome,
+  debounceMs = defaultDebounceMs(),
+  includeStateDb = true,
+  once = false,
+  onSync,
+  onLog,
+  onShutdown,
+  runSyncImpl,
+  signal,
+  sleepImpl
+} = {}) {
+  if (!Number.isInteger(debounceMs) || debounceMs < 0) {
+    throw new Error(`Invalid --debounce-ms value: ${debounceMs}. Expected a non-negative integer.`);
+  }
+
+  const codexHome = normalizeCodexHome(explicitCodexHome);
+  const configPath = path.join(codexHome, "config.toml");
+  await fsp.access(codexHome).catch(() => {
+    throw new Error(`Codex home not found at ${codexHome}`);
+  });
+  await fsp.access(configPath).catch(() => {
+    throw new Error(`config.toml not found at ${configPath}`);
+  });
+
+  const log = (message) => {
+    if (typeof onLog === "function") {
+      onLog(message);
+    } else {
+      console.log(message);
+    }
+  };
+
+  const invokeSync = async (reason) => {
+    // Read the current root-level model on every fire so the per-thread
+    // model rewrite picks up the latest value the user has in config.toml.
+    // We only consider the top-level (root) `model = "..."` line — anything
+    // inside a `[model_providers.*]` section must be ignored, otherwise a
+    // user who has a `model = "..."` entry in a provider section will see
+    // the wrong model propagated to every rollout file.
+    let rootModel = null;
+    try {
+      const cfg = await readConfigText(path.join(codexHome, "config.toml"));
+      rootModel = readRootModelFromConfigText(cfg);
+    } catch {
+      // Missing/unreadable config; carry on with a null model.
+    }
+    if (typeof onSync === "function") {
+      return onSync({ reason, codexHome, model: rootModel });
+    }
+    if (typeof runSyncImpl === "function") {
+      return runSyncImpl({ codexHome, reason, model: rootModel });
+    }
+    // Lazy import to avoid pulling in the full service module until needed.
+    const { runSync } = await import("./service.js");
+    return runSync({
+      codexHome,
+      model: rootModel,
+      onProgress: (event) => {
+        if (event?.stage && event.status === "start") {
+          log(`  · ${event.stage}`);
+        }
+      }
+    });
+  };
+
+  let stopped = false;
+  let watchers = [];
+  let stateDbInfo = null;
+  // Track the currently-running sync (if any) so that stop()/SIGINT can
+  // wait for it to drain instead of yanking the watcher out from under
+  // a half-written SQLite transaction.
+  let inFlight = null;
+  // Counter of consecutive non-busy sync failures. A "busy" SQLite
+  // error is normal transient behaviour (Codex has the DB open);
+  // anything else (config corruption, codex home moved, disk
+  // full, permission denied, ...) would otherwise fire on every
+  // config/state event forever. We shut the watcher down after a
+  // small threshold so the user gets a clean exit signal instead
+  // of a log-spamming daemon.
+  let consecutiveNonBusyFailures = 0;
+  const MAX_CONSECUTIVE_NON_BUSY_FAILURES = 5;
+
+  // A promise that resolves when the watcher has finished its
+  // internal shutdown. The CLI uses this to await exit so the
+  // process terminates cleanly after `--once` completes or after
+  // the consecutive-failure auto-shutdown, instead of sitting in
+  // the event loop waiting for SIGINT/SIGTERM that will never
+  // arrive. External callers (e.g. tests) can also `await` it.
+  let donePromise;
+  let resolveDone;
+  donePromise = new Promise((resolve) => {
+    resolveDone = resolve;
+  });
+
+  const debouncedSync = makeDebouncer(debounceMs, (reason) => {
+    if (stopped) {
+      return;
+    }
+    log(`[${new Date().toISOString()}] Detected change (${reason}); running sync...`);
+    const task = (async () => {
+      try {
+        const result = await invokeSync(reason);
+        log(`[${new Date().toISOString()}] Sync complete: provider=${result.targetProvider}, rollout_files=${result.changedSessionFiles}, sqlite_rows=${result.sqliteRowsUpdated}${result.skippedLockedRolloutFiles?.length ? `, skipped_locked=${result.skippedLockedRolloutFiles.length}` : ""}`);
+        // A successful sync resets the consecutive-failure counter
+        // so a transient error followed by recovery does not
+        // poison subsequent invocations.
+        consecutiveNonBusyFailures = 0;
+        if (once) {
+          await shutdown("once-mode-complete", task);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // SQLite being in use is a normal transient condition while Codex
+        // is actively writing. Don't crash; just retry on the next event.
+        if (/state_5\.sqlite is currently in use/i.test(message)) {
+          log(`[${new Date().toISOString()}] Sync skipped: ${message} (will retry on next change)`);
+          // Busy is normal — reset the consecutive-failure counter
+          // so a long-running Codex session that keeps the DB open
+          // for many seconds does not push us toward the auto-shutdown
+          // threshold once Codex finally releases the lock.
+          consecutiveNonBusyFailures = 0;
+        } else {
+          log(`[${new Date().toISOString()}] Sync failed: ${message}`);
+          // Other errors (config corruption, disk full, codex home
+          // moved, permission denied, ...) would otherwise fire on
+          // every config/state event forever, hammering the failure
+          // surface without ever recovering. Track consecutive
+          // non-busy failures and shut the watcher down once we
+          // exceed the threshold so the user notices via the
+          // `codex-provider watch` exit instead of finding the log
+          // spammed at 3am.
+          consecutiveNonBusyFailures += 1;
+          if (consecutiveNonBusyFailures >= MAX_CONSECUTIVE_NON_BUSY_FAILURES) {
+            log(`[${new Date().toISOString()}] Watcher giving up after ${consecutiveNonBusyFailures} consecutive non-busy failures; shutting down. Rerun "codex-provider watch" once the underlying issue is fixed.`);
+            await shutdown("consecutive-failures", task);
+            return;
+          }
+        }
+      } finally {
+        if (inFlight === task) {
+          inFlight = null;
+        }
+      }
+    })();
+    inFlight = task;
+  });
+
+  const configWatcher = fs.watch(configPath, { persistent: true }, (eventType, filename) => {
+    if (stopped) {
+      return;
+    }
+    log(`[${new Date().toISOString()}] config.toml ${describeEvent(eventType, filename)}`);
+    debouncedSync("config.toml");
+  });
+  watchers.push(configWatcher);
+
+  if (includeStateDb) {
+    try {
+      stateDbInfo = await detectStateDb(codexHome);
+    } catch (error) {
+      log(`[${new Date().toISOString()}] Could not locate state database: ${error.message}`);
+    }
+    if (stateDbInfo?.path) {
+      // Watch the active database *and* its WAL sidecar. SQLite by
+      // default runs in WAL journal mode: new transactions are
+      // appended to `state_5.sqlite-wal` and only checkpointed back
+      // to the main file on a checkpoint, so watching the main
+      // file alone would miss every write Codex makes between
+      // checkpoints. We watch both, plus the -shm shared-memory
+      // file so a checkpoint still fires the change event for
+      // long-running sessions.
+      const stateDbFile = stateDbInfo.path;
+      const walFile = `${stateDbFile}-wal`;
+      const shmFile = `${stateDbFile}-shm`;
+      for (const target of [stateDbFile, walFile, shmFile]) {
+        if (!(await pathExists(target))) {
+          continue;
+        }
+        // Watch each file directly instead of its parent
+        // directory. Watching a directory on Windows enters a
+        // libuv path that asserts in src/win/fs-event.c around
+        // line 72 when any sibling under the directory is renamed
+        // during startup (a race condition Node 22 and 24 started
+        // hitting reliably on Windows runners). Watching a single
+        // file bypasses that path entirely. The downside is that
+        // SQLite's atomic-rename of the database (or its WAL)
+        // can leave us listening on a stale handle; we re-attach
+        // the watcher on any `rename` event so the next write
+        // burst still reaches us.
+        attachStateWatcher(target, target === stateDbFile ? "state_db" : "state_db-wal");
+      }
+    } else {
+      log(`[${new Date().toISOString()}] No state database found in ${codexHome}; skipping watcher`);
+    }
+  }
+
+  log(`[${new Date().toISOString()}] Watching ${configPath}${includeStateDb && stateDbInfo?.path ? `, ${stateDbInfo.path}, ${stateDbInfo.path}-wal, ${stateDbInfo.path}-shm` : ""} (debounce ${debounceMs}ms${once ? ", once" : ""})`);
+
+  const shutdown = async (reason, currentTask = null) => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    for (const watcher of watchers) {
+      try {
+        watcher.close();
+      } catch {
+        // best-effort
+      }
+    }
+    // Drain any sync that is still in flight so we do not yank the watcher
+    // out from under a half-written SQLite transaction or backup. Skip
+    // the caller's own task to avoid self-deadlock when shutdown is
+    // invoked from inside the task's catch block (e.g. the
+    // consecutive-failure path).
+    if (inFlight && inFlight !== currentTask) {
+      try {
+        await inFlight;
+      } catch {
+        // errors are already logged by the debouncedSync handler
+      }
+    }
+    log(`[${new Date().toISOString()}] Watcher stopped (${reason})`);
+    if (typeof onShutdown === "function") {
+      try {
+        await onShutdown(reason);
+      } catch {
+        // shutdown callbacks must not block the daemon from exiting
+      }
+    }
+    if (resolveDone) {
+      resolveDone(reason);
+      resolveDone = null;
+    }
+  };
+
+  // Wire up an optional AbortSignal so the caller can shut the
+  // watcher down from anywhere (e.g. an outer SIGINT handler that
+  // fans out to multiple long-running tasks). We expose the
+  // pending shutdown promise on the returned handle as
+  // `signalPromise` so the caller can `await` it from outside
+  // instead of having to call `stop()` manually.
+  let signalPromise = null;
+  if (signal) {
+    if (signal.aborted) {
+      signalPromise = shutdown("signal");
+    } else {
+      const abortHandler = () => {
+        signalPromise = shutdown("signal");
+      };
+      signal.addEventListener("abort", abortHandler, { once: true });
+    }
+  }
+
+  function attachStateWatcher(stateDbFile, reasonLabel) {
+    // Attach (or re-attach after a rename) a single-file fs.watch
+    // for the active SQLite database (or its WAL/SHM sidecar).
+    // Returns when the watcher is attached so we can drive startup
+    // synchronously.
+    let current = null;
+    const tryAttach = () => {
+      if (stopped || current !== null) {
+        return;
+      }
+      let watcher;
+      try {
+        watcher = fs.watch(stateDbFile, { persistent: true }, (eventType, filename) => {
+          if (stopped) {
+            return;
+          }
+          if (eventType === "rename") {
+            // SQLite may have rotated the file (atomic-rename)
+            // or deleted it. Drop the stale handle and re-attach
+            // once the file is back so the next write fires again.
+            try {
+              watcher.close();
+            } catch {
+              // best-effort
+            }
+            current = null;
+            const idx = watchers.indexOf(watcher);
+            if (idx !== -1) {
+              watchers.splice(idx, 1);
+            }
+            setTimeout(tryAttach, 50);
+            return;
+          }
+          // Either "change" or null eventType is enough to fire
+          // a sync. We deliberately do NOT filter on filename: when
+          // watching a single file the only events we get are
+          // about that file, and Node sometimes reports null on
+          // Windows whenever the underlying FILE_OBJECT is
+          // re-opened. Either way a sync should run.
+          void filename;
+          log(`[${new Date().toISOString()}] ${reasonLabel} change${filename ? `:${filename}` : ""}`);
+          debouncedSync(reasonLabel);
+        });
+      } catch (error) {
+        // Path may have gone away. Wait a moment and try again;
+        // the next config.toml change restarts the whole watcher
+        // so this is the only fallback we need.
+        log(`[${new Date().toISOString()}] Could not watch ${stateDbFile}: ${error instanceof Error ? error.message : String(error)}; will retry`);
+        setTimeout(tryAttach, 250);
+        return;
+      }
+      watchers.push(watcher);
+      current = watcher;
+    };
+    tryAttach();
+  }
+
+  return {
+    codexHome,
+    watchedConfigPath: configPath,
+    watchedStateDbPath: stateDbInfo?.path ?? null,
+    stop: () => shutdown("external"),
+    signalPromise,
+    done: donePromise
+  };
+}

--- a/src/watch.js
+++ b/src/watch.js
@@ -50,15 +50,6 @@ function makeDebouncer(delayMs, run) {
   };
 }
 
-async function pathExists(target) {
-  try {
-    await fsp.access(target);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export async function runWatch({
   codexHome: explicitCodexHome,
   debounceMs = defaultDebounceMs(),
@@ -235,9 +226,6 @@ export async function runWatch({
       const walFile = `${stateDbFile}-wal`;
       const shmFile = `${stateDbFile}-shm`;
       for (const target of [stateDbFile, walFile, shmFile]) {
-        if (!(await pathExists(target))) {
-          continue;
-        }
         // Watch each file directly instead of its parent
         // directory. Watching a directory on Windows enters a
         // libuv path that asserts in src/win/fs-event.c around
@@ -322,6 +310,12 @@ export async function runWatch({
     let current = null;
     const tryAttach = () => {
       if (stopped || current !== null) {
+        return;
+      }
+      // WAL and SHM sidecars may not exist when the watcher starts.
+      // Keep trying quietly so a later Codex launch is still observed.
+      if (!fs.existsSync(stateDbFile)) {
+        setTimeout(tryAttach, 250);
         return;
       }
       let watcher;

--- a/test/config-file.test.js
+++ b/test/config-file.test.js
@@ -5,6 +5,8 @@ import {
   configDeclaresProvider,
   listConfiguredProviderIds,
   readCurrentProviderFromConfigText,
+  readProviderModel,
+  setRootModelInConfigText,
   setRootProviderInConfigText
 } from "../src/config-file.js";
 
@@ -53,4 +55,78 @@ base_url = "https://example.org"
   assert.deepEqual(listConfiguredProviderIds(input), ["apigather", "newapi", "openai"]);
   assert.equal(configDeclaresProvider(input, "apigather"), true);
   assert.equal(configDeclaresProvider(input, "missing"), false);
+});
+
+test("readProviderModel returns the model field from a [model_providers.X] section", () => {
+  const input = `
+[model_providers.codexzh]
+name = "codexzh"
+model = "gpt-5.4"
+base_url = "https://api.codexzh.com/v1"
+
+[model_providers.longcat]
+name = "longcat"
+model = "LongCat-2.0-Preview"
+base_url = "https://api.longcat.chat/openai/v1"
+`;
+
+  assert.equal(readProviderModel(input, "codexzh"), "gpt-5.4");
+  assert.equal(readProviderModel(input, "longcat"), "LongCat-2.0-Preview");
+});
+
+test("readProviderModel returns null when the section is missing or has no model field", () => {
+  const input = `
+[model_providers.codexzh]
+name = "codexzh"
+base_url = "https://api.codexzh.com/v1"
+`;
+
+  assert.equal(readProviderModel(input, "codexzh"), null);
+  assert.equal(readProviderModel(input, "longcat"), null);
+  assert.equal(readProviderModel(input, "openai"), null);
+});
+
+test("readProviderModel handles unusual provider names without regex injection", () => {
+  const input = `
+[model_providers.weird.name-1]
+model = "X"
+`;
+  // Should not throw on regex metacharacters in provider id (dots, dashes, etc.)
+  assert.equal(readProviderModel(input, "weird.name-1"), "X");
+});
+
+test("setRootModelInConfigText inserts a new root-level model before the first table", () => {
+  const input = `model_provider = "codexzh"\n\n[features]\napps = true\n`;
+  const next = setRootModelInConfigText(input, "LongCat-2.0-Preview");
+  // Inserts at the position where [features] would have been, preserving the
+  // blank line that was already there. Trailing newline is preserved.
+  assert.equal(
+    next,
+    `model_provider = "codexzh"\n\nmodel = "LongCat-2.0-Preview"\n[features]\napps = true\n\n`
+  );
+});
+
+test("setRootModelInConfigText updates an existing root-level model", () => {
+  const input = `model_provider = "codexzh"\nmodel = "gpt-5.4-mini"\n\n[features]\napps = true\n`;
+  const next = setRootModelInConfigText(input, "gpt-5.4");
+  assert.equal(
+    next,
+    `model_provider = "codexzh"\nmodel = "gpt-5.4"\n\n[features]\napps = true\n`
+  );
+});
+
+test("setRootModelInConfigText escapes backslashes and quotes", () => {
+  const input = `model = "old"\n`;
+  const next = setRootModelInConfigText(input, `weird"path\\name`);
+  assert.equal(next, `model = "weird\\"path\\\\name"\n`);
+});
+
+test("setRootProviderInConfigText + setRootModelInConfigText produces a coherent root block", () => {
+  const input = `model_provider = "codexzh"\nmodel = "gpt-5.4-mini"\n\n[model_providers.longcat]\nname = "longcat"\nmodel = "LongCat-2.0-Preview"\n`;
+  let next = setRootProviderInConfigText(input, "longcat");
+  next = setRootModelInConfigText(next, readProviderModel(input, "longcat"));
+  assert.equal(
+    next,
+    `model_provider = "longcat"\nmodel = "LongCat-2.0-Preview"\n\n[model_providers.longcat]\nname = "longcat"\nmodel = "LongCat-2.0-Preview"\n`
+  );
 });

--- a/test/config-file.test.js
+++ b/test/config-file.test.js
@@ -6,6 +6,7 @@ import {
   listConfiguredProviderIds,
   readCurrentProviderFromConfigText,
   readProviderModel,
+  readRootModelFromConfigText,
   setRootModelInConfigText,
   setRootProviderInConfigText
 } from "../src/config-file.js";
@@ -129,4 +130,46 @@ test("setRootProviderInConfigText + setRootModelInConfigText produces a coherent
     next,
     `model_provider = "longcat"\nmodel = "LongCat-2.0-Preview"\n\n[model_providers.longcat]\nname = "longcat"\nmodel = "LongCat-2.0-Preview"\n`
   );
+});
+
+test("readRootModelFromConfigText returns the root-level model and ignores provider sections", () => {
+  // Owner review regression: the per-turn model rewrite must
+  // only see the root-level `model = "..."` line. A
+  // [model_providers.X] section also has a `model` field for
+  // its own purposes; without the section guard, a
+  // `readRootModelFromConfigText` call would happily return
+  // whatever the provider section has, and that value would be
+  // propagated to every rollout's turn_context.model.
+  const input = [
+    'model_provider = "foo"',
+    'model = "gpt-5"',
+    '',
+    '[model_providers.foo]',
+    'base_url = "https://example.com"',
+    'model = "gpt-4o-mini"',
+    ''
+  ].join("\n");
+  assert.equal(readRootModelFromConfigText(input), "gpt-5");
+});
+
+test("readRootModelFromConfigText returns null when no root-level model is set", () => {
+  const input = 'model_provider = "foo"\n\n[model_providers.foo]\nmodel = "gpt-4o-mini"\n';
+  assert.equal(readRootModelFromConfigText(input), null);
+});
+
+test("readRootModelFromConfigText ignores a provider section at the very top of the file", () => {
+  // When the file has no `model = "..."` line at all before the
+  // first [section], we return null — even if a provider section
+  // has its own model field. The sync path treats null as
+  // "don't touch the per-turn model field", which is the
+  // safe default.
+  const input = [
+    '[model_providers.foo]',
+    'model = "gpt-4o-mini"',
+    '',
+    '[model_providers.bar]',
+    'model = "gpt-5"',
+    ''
+  ].join("\n");
+  assert.equal(readRootModelFromConfigText(input), null);
 });

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -856,6 +856,238 @@ test("runSync rewrites turn_context whose model name contains regex metacharacte
   assert.equal(userMessage.payload.message, "echo weird(target)+v2 please");
 });
 
+test("runSync rewrites turn_context model when the provider is already correct (model-only change)", async () => {
+  // Owner review regression: when the root-level `model = "..."`
+  // in config.toml changes but `model_provider` is the same as
+  // what every rollout already has, the rollout's
+  // turn_context.model must still be updated. Otherwise the
+  // Codex GUI bottom-right of an old conversation would show the
+  // old model even though the user just switched the active
+  // model.
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "gpt-5.1"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "06", "09", "rollout-a.jsonl");
+  await writeRolloutWithTurnContext(sessionPath, {
+    id: "thread-a",
+    provider: "openai",
+    model: "gpt-5"
+  });
+
+  // Run sync with no provider change (provider = openai is already
+  // the target), only the model changes. The rollout's
+  // turn_context.model must move from "gpt-5" to "gpt-5.1" and
+  // the first line (session_meta) must NOT be touched.
+  const originalFirstLine = (await fs.readFile(sessionPath, "utf8")).split("\n")[0];
+  const result = await runSync({ codexHome, provider: "openai", model: "gpt-5.1" });
+  assert.ok(
+    result.changedSessionFiles >= 1,
+    "rollout with a stale turn_context.model must be picked up as a model-only change"
+  );
+
+  const lines = (await fs.readFile(sessionPath, "utf8")).split("\n").filter(Boolean);
+  // First line (session_meta) must be untouched — the provider was
+  // already correct.
+  assert.equal(lines[0], originalFirstLine, "session_meta first line must not be touched on a model-only change");
+  for (const line of lines) {
+    if (!line.includes('"turn_context"')) continue;
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.payload.model, "gpt-5.1");
+  }
+});
+
+test("runSync normalises multiple distinct models in the same session to the target model", async () => {
+  // Owner review regression: a single Codex session can use
+  // different models in different turn_context lines (the user
+  // switched models mid-conversation). The per-turn rewrite
+  // pass must normalise ALL of them to the new target, not just
+  // the ones whose value happens to match the first turn_context
+  // model.
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "gpt-5.1"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "06", "09", "rollout-a.jsonl");
+  await writeRolloutWithTurnContext(sessionPath, {
+    id: "thread-a",
+    provider: "apigather",
+    model: "gpt-5"
+  });
+  // Three more turn_context lines with three different models.
+  for (const [turnId, model] of [
+    ["t2", "gpt-4o-mini"],
+    ["t3", "gpt-5"],
+    ["t4", "claude-3.5-sonnet"]
+  ]) {
+    await fs.appendFile(
+      sessionPath,
+      JSON.stringify({
+        timestamp: "2026-06-09T09:16:03.880Z",
+        type: "turn_context",
+        payload: { turn_id: turnId, model, collaboration_mode: { mode: "default", settings: { model } } }
+      }) + "\n",
+      "utf8"
+    );
+  }
+
+  const result = await runSync({ codexHome, model: "gpt-5.1" });
+  assert.equal(result.changedSessionFiles, 1);
+
+  const lines = (await fs.readFile(sessionPath, "utf8")).split("\n").filter(Boolean);
+  for (const line of lines) {
+    if (!line.includes('"turn_context"')) continue;
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.payload.model, "gpt-5.1", `turn ${parsed.payload.turn_id} should be normalised`);
+    assert.equal(parsed.payload.collaboration_mode.settings.model, "gpt-5.1");
+  }
+});
+
+test("runSync preserves CRLF line separators and the original mtime when rewriting turn_context model", async () => {
+  // Owner review regression: rewriting the per-turn model field
+  // must preserve the original newline format (CRLF on Windows)
+  // and the original mtime. The previous code joined lines with
+  // "\n" unconditionally, which silently lost the 0x0d byte on
+  // CRLF rollouts.
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "gpt-5.1"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "06", "09", "rollout-crlf.jsonl");
+  await fs.mkdir(path.dirname(sessionPath), { recursive: true });
+
+  // Build a CRLF-terminated rollout with a turn_context line.
+  const meta = JSON.stringify({
+    timestamp: "2026-06-09T09:16:03.878Z",
+    type: "session_meta",
+    payload: { id: "thread-crlf", timestamp: "2026-06-09T09:16:03.878Z", cwd: "C:\\AITemp", source: "cli", cli_version: "0.115.0", model_provider: "apigather" }
+  });
+  const turn = JSON.stringify({
+    timestamp: "2026-06-09T09:16:03.880Z",
+    type: "turn_context",
+    payload: { turn_id: "t1", cwd: "C:\\AITemp", model: "gpt-5", collaboration_mode: { mode: "default", settings: { model: "gpt-5" } } }
+  });
+  const originalBytes = Buffer.from(`${meta}\r\n${turn}\r\n`, "utf8");
+  await fs.writeFile(sessionPath, originalBytes);
+  // Pin the mtime to a recognisable value so we can confirm it
+  // is restored after the rewrite.
+  const pinnedMtime = new Date("2026-06-01T12:00:00.000Z");
+  await fs.utimes(sessionPath, pinnedMtime, pinnedMtime);
+
+  const result = await runSync({ codexHome, model: "gpt-5.1" });
+  assert.equal(result.changedSessionFiles, 1);
+
+  const afterBytes = await fs.readFile(sessionPath);
+  // The rewritten file must still contain 0x0d bytes (CRLF) —
+  // the rewrite pass would have lost them if it joined with
+  // plain "\n".
+  assert.ok(
+    afterBytes.includes(0x0d),
+    "rewritten rollout must preserve the original CRLF line separators"
+  );
+  // The mtime must match what we pinned above.
+  const afterStat = await fs.stat(sessionPath);
+  assert.equal(
+    afterStat.mtimeMs,
+    pinnedMtime.getTime(),
+    "rewritten rollout must preserve the original mtime"
+  );
+  // The new file should still end with a CRLF terminator (the
+  // source did, and the rewrite pass re-adds it).
+  assert.equal(afterBytes[afterBytes.length - 1], 0x0a);
+  assert.equal(afterBytes[afterBytes.length - 2], 0x0d);
+  // And the per-turn model must have moved.
+  const lines = afterBytes.toString("utf8").split("\r\n").filter(Boolean);
+  const turnContextLines = lines
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.type === "turn_context");
+  for (const entry of turnContextLines) {
+    assert.equal(entry.payload.model, "gpt-5.1");
+  }
+});
+
+test("runSync restores turn_context model on failure rollback (no half-completed state)", async () => {
+  // Owner review regression: when the SQLite step fails after the
+  // rollout rewrite has already been applied, the rollback path
+  // must put the per-turn `model` field back to its original
+  // value, not just the first-line session_meta. Without the
+  // per-line backup in the manifest, the restore would leave
+  // the rollout in a half-completed state: session_meta pointing
+  // at the original provider, but per-turn model pointing at the
+  // new one.
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "gpt-5.1"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "06", "09", "rollout-restore.jsonl");
+  await fs.mkdir(path.dirname(sessionPath), { recursive: true });
+  await writeRolloutWithTurnContext(sessionPath, {
+    id: "thread-restore",
+    provider: "apigather",
+    model: "gpt-5"
+  });
+
+  // Pre-flight: capture the original line + the original per-turn
+  // model.
+  const originalContent = await fs.readFile(sessionPath, "utf8");
+  const originalFirstLine = originalContent.split("\n")[0];
+  const originalTurnLine = originalContent
+    .split("\n")
+    .filter(Boolean)
+    .find((line) => line.includes('"turn_context"'));
+  assert.ok(originalTurnLine, "test setup: rollout should have a turn_context line");
+  const originalTurn = JSON.parse(originalTurnLine);
+  assert.equal(originalTurn.payload.model, "gpt-5");
+
+  // Stub a failing SQLite update so the runSync's try/catch
+  // triggers the restore path. We do this by passing a
+  // `sqliteBusyTimeoutMs` so small that the busy timeout fires
+  // and the underlying sqlite update throws.
+  // The simpler route: call collectSessionChanges + applySessionChanges
+  // by hand, then trigger restoreBackup explicitly. We want to
+  // exercise the restore path under realistic conditions.
+  const configPath = path.join(codexHome, "config.toml");
+  const { changes } = await collectSessionChanges(codexHome, "openai", { targetModel: "gpt-5.1" });
+  const backupDir = await createBackup({
+    codexHome,
+    targetProvider: "openai",
+    sessionChanges: changes,
+    configPath
+  });
+
+  // Apply the rewrite so the rollout's per-turn model moves to
+  // "gpt-5.1" and the first line gets the new provider.
+  await applySessionChanges(changes, { targetModel: "gpt-5.1" });
+  await updateSessionBackupManifest(backupDir, changes);
+
+  // Debug: dump the manifest so we can see what updateSessionBackupManifest wrote.
+  const sessionManifest = JSON.parse(await fs.readFile(path.join(backupDir, "session-meta-backup.json"), "utf8"));
+  void sessionManifest; // suppress unused warning; the asserts below are the real check
+  // Simulate Codex appending a new event to the rollout between
+  // the rewrite and the rollback.
+  await fs.appendFile(
+    sessionPath,
+    JSON.stringify({
+      timestamp: "2026-06-09T09:16:03.881Z",
+      type: "user_message",
+      payload: { message: "after-rewrite" }
+    }) + "\n",
+    "utf8"
+  );
+
+  // Now roll back. The first line must return to its original
+  // session_meta, the per-turn model must return to "gpt-5",
+  // and the appended user_message must be left alone (the
+  // restore pass is append-tolerant).
+  await restoreBackup(backupDir, codexHome, { restoreSessions: true });
+
+  const restored = await fs.readFile(sessionPath, "utf8");
+  const restoredLines = restored.split("\n").filter(Boolean);
+  assert.equal(restoredLines[0], originalFirstLine, "first line must be restored to the original session_meta");
+  const restoredTurn = restoredLines
+    .map((line) => JSON.parse(line))
+    .find((entry) => entry.type === "turn_context");
+  assert.equal(restoredTurn.payload.model, "gpt-5", "per-turn model must be restored to its original value");
+  // Codex's append must be preserved.
+  const appended = restoredLines
+    .map((line) => JSON.parse(line))
+    .find((entry) => entry.type === "user_message");
+  assert.ok(appended, "appended user_message line must be preserved on rollback");
+  assert.equal(appended.payload.message, "after-rewrite");
+});
+
 test("runSync leaves rollout files alone when original turn_context model already equals target", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "MiniMax-M3"\n');

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -683,6 +683,34 @@ test("runSwitch emits a warning when the new provider has no model field", async
   assert.match(next, /^model = "gpt-5.4-mini"/m);
 });
 
+test("runSwitch does not treat a provider-section model as the root model", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const config = `model_provider = "apigather"\n\n[model_providers.apigather]\nmodel = "provider-section-only"\nbase_url = "https://example.com"\n`;
+  await fs.writeFile(path.join(codexHome, "config.toml"), config, "utf8");
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-root-model.jsonl");
+  await writeRolloutWithTurnContext(sessionPath, {
+    id: "thread-root-model",
+    provider: "apigather",
+    model: "original-rollout-model"
+  });
+
+  const result = await runSwitch({ codexHome, provider: "openai" });
+
+  assert.equal(result.modelSync.applied, false);
+  const nextConfig = await fs.readFile(path.join(codexHome, "config.toml"), "utf8");
+  assert.doesNotMatch(nextConfig.split("[model_providers.", 1)[0], /^model\s*=/m);
+  const turnContexts = (await fs.readFile(sessionPath, "utf8"))
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.type === "turn_context");
+  assert.ok(turnContexts.length > 0);
+  for (const entry of turnContexts) {
+    assert.equal(entry.payload.model, "original-rollout-model");
+    assert.equal(entry.payload.collaboration_mode.settings.model, "original-rollout-model");
+  }
+});
+
 test("runSwitch rejects --model and --keep-root-model together", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome);

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -642,6 +642,21 @@ test("runSwitch emits a warning when the new provider has no model field", async
   assert.match(next, /^model = "gpt-5.4-mini"/m);
 });
 
+test("runSwitch rejects --model and --keep-root-model together", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome);
+  const before = await fs.readFile(path.join(codexHome, "config.toml"), "utf8");
+
+  await assert.rejects(
+    () => runSwitch({ codexHome, provider: "apigather", model: "X", keepRootModel: true }),
+    /--model and --keep-root-model are mutually exclusive/
+  );
+
+  // Confirm the file on disk was not mutated by the failed call.
+  const after = await fs.readFile(path.join(codexHome, "config.toml"), "utf8");
+  assert.equal(after, before);
+});
+
 test("status reports implicit default provider and rollout/sqlite counts", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome);

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -812,7 +812,12 @@ test("runSync rewrites turn_context model even when the line is larger than 64 K
 test("runSync rewrites turn_context whose model name contains regex metacharacters", async () => {
   // Names like `gpt-5.4-mini` and `apigather.fixed+name` should
   // be matched literally — `.` is a regex any-char, `+` is a
-  // quantifier, and an unbalanced `{` would refuse to compile.
+  // quantifier, and an unbalanced `{` would refuse to compile. We
+  // rewrite every turn_context.model field to the new target so
+  // the per-turn model is normalised regardless of what was
+  // there before. The decoy line at the bottom (a non-turn_context
+  // event with the literal text in a field) confirms the rewrite
+  // does not over-match into unrelated events.
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "weird(target)+v2"\n');
   const sessionPath = path.join(codexHome, "sessions", "2026", "06", "09", "rollout-a.jsonl");
@@ -821,33 +826,34 @@ test("runSync rewrites turn_context whose model name contains regex metacharacte
     provider: "apigather",
     model: "weird(target)+v2"
   });
-  // Also throw in a decoy line with `weirdAtargetAv2` so we can
-  // confirm the regex does not over-match.
+  // A second turn_context with a different model that has the same
+  // metacharacter pattern; both must be normalised to the target.
   await fs.appendFile(sessionPath, JSON.stringify({
     timestamp: "2026-06-09T09:16:03.881Z", type: "turn_context",
     payload: { turn_id: "decoy", model: "weirdAtargetAv2" }
   }) + "\n", "utf8");
+  // A non-turn_context event whose text happens to include the
+  // literal model string. The rewrite must NOT touch this line.
+  await fs.appendFile(sessionPath, JSON.stringify({
+    timestamp: "2026-06-09T09:16:03.882Z", type: "user_message",
+    payload: { message: "echo weird(target)+v2 please" }
+  }) + "\n", "utf8");
 
-  // Pin target = same as source: still re-runs the rewrite, but
-  // also confirms no-op (same model) case does not corrupt the
-  // decoy.
   const result = await runSync({ codexHome, model: "weird(target)+v2" });
   assert.equal(result.changedSessionFiles, 1);
 
   const lines = (await fs.readFile(sessionPath, "utf8")).split("\n").filter(Boolean);
-  const turnContextLines = lines
-    .map((line) => JSON.parse(line))
-    .filter((entry) => entry.type === "turn_context");
-  // The original two lines plus the decoy should both still
-  // parse cleanly. The decoy's model must be untouched.
-  assert.equal(turnContextLines.length, 3);
-  for (const entry of turnContextLines) {
-    if (entry.payload.turn_id === "decoy") {
-      assert.equal(entry.payload.model, "weirdAtargetAv2");
-    } else {
+  const parsed = lines.map((line) => JSON.parse(line));
+  // Both turn_context lines should now have the target model.
+  for (const entry of parsed) {
+    if (entry.type === "turn_context") {
       assert.equal(entry.payload.model, "weird(target)+v2");
     }
   }
+  // The non-turn_context line must be left alone.
+  const userMessage = parsed.find((entry) => entry.type === "user_message");
+  assert.ok(userMessage, "user_message line should still be present");
+  assert.equal(userMessage.payload.message, "echo weird(target)+v2 please");
 });
 
 test("runSync leaves rollout files alone when original turn_context model already equals target", async () => {

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -50,6 +50,46 @@ async function writeCustomRollout(filePath, payload, message = "hi") {
   await fs.writeFile(filePath, `${lines.join("\n")}\n`, "utf8");
 }
 
+async function writeRolloutWithTurnContext(filePath, { id, provider, model }) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const metaPayload = {
+    id,
+    timestamp: "2026-06-09T09:16:03.878Z",
+    cwd: "C:\\AITemp",
+    source: "cli",
+    cli_version: "0.115.0",
+    model_provider: provider
+  };
+  const turnContext = {
+    timestamp: "2026-06-09T09:16:03.880Z",
+    type: "turn_context",
+    payload: {
+      turn_id: "019eabaa-e391-7e21-89cd-e761b5dee114",
+      cwd: "C:\\AITemp",
+      current_date: "2026-06-09",
+      model,
+      collaboration_mode: { mode: "default", settings: { model, reasoning_effort: "xhigh" } }
+    }
+  };
+  const heartBeat = {
+    timestamp: "2026-06-09T10:16:03.880Z",
+    type: "turn_context",
+    payload: {
+      turn_id: "019eabaa-e391-7e21-89cd-e761b5dee115",
+      cwd: "C:\\AITemp",
+      current_date: "2026-06-09",
+      model,
+      collaboration_mode: { mode: "default", settings: { model, reasoning_effort: "xhigh" } }
+    }
+  };
+  const lines = [
+    JSON.stringify({ timestamp: metaPayload.timestamp, type: "session_meta", payload: metaPayload }),
+    JSON.stringify(turnContext),
+    JSON.stringify(heartBeat)
+  ];
+  await fs.writeFile(filePath, `${lines.join("\n")}\n`, "utf8");
+}
+
 function backupRoot(codexHome) {
   return path.join(codexHome, "backups_state", "provider-sync");
 }
@@ -698,6 +738,54 @@ test("runSync leaves the per-thread model column untouched when no model is prov
     assert.equal(row.model_provider, "openai");
   } finally {
     db.close();
+  }
+});
+
+test("runSync rewrites the per-turn turn_context model field in rollout files", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "MiniMax-M3"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "06", "09", "rollout-a.jsonl");
+  await writeRolloutWithTurnContext(sessionPath, {
+    id: "thread-a",
+    provider: "apigather",
+    model: "gpt-5.4"
+  });
+
+  const result = await runSync({ codexHome, model: "MiniMax-M3" });
+  assert.equal(result.changedSessionFiles, 1);
+
+  const lines = (await fs.readFile(sessionPath, "utf8")).split("\n").filter(Boolean);
+  const turnContextLines = lines
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.type === "turn_context");
+  assert.equal(turnContextLines.length, 2);
+  for (const entry of turnContextLines) {
+    assert.equal(entry.payload.model, "MiniMax-M3");
+    assert.equal(entry.payload.collaboration_mode.settings.model, "MiniMax-M3");
+  }
+});
+
+test("runSync leaves turn_context model field alone when no model is provided", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "06", "09", "rollout-a.jsonl");
+  await writeRolloutWithTurnContext(sessionPath, {
+    id: "thread-a",
+    provider: "apigather",
+    model: "gpt-5.4"
+  });
+
+  // No `model` arg → caller doesn't want to align the per-turn
+  // model field, so even though we are rewriting `model_provider`
+  // from apigather → openai, the turn_context model is left alone.
+  await runSync({ codexHome });
+
+  const lines = (await fs.readFile(sessionPath, "utf8")).split("\n").filter(Boolean);
+  const turnContextLines = lines
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.type === "turn_context");
+  for (const entry of turnContextLines) {
+    assert.equal(entry.payload.model, "gpt-5.4", "turn_context model must stay put when caller does not pass a target");
   }
 });
 

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -112,12 +112,13 @@ async function writeStateDbAt(dbPath, rows) {
         model_provider TEXT,
         cwd TEXT NOT NULL DEFAULT '',
         archived INTEGER NOT NULL DEFAULT 0,
-        first_user_message TEXT NOT NULL DEFAULT ''
+        first_user_message TEXT NOT NULL DEFAULT '',
+        model TEXT
       )
     `);
-    const stmt = db.prepare("INSERT INTO threads (id, model_provider, cwd, archived, first_user_message) VALUES (?, ?, ?, ?, ?)");
+    const stmt = db.prepare("INSERT INTO threads (id, model_provider, cwd, archived, first_user_message, model) VALUES (?, ?, ?, ?, ?, ?)");
     for (const row of rows) {
-      stmt.run(row.id, row.model_provider, row.cwd ?? "C:\\AITemp", row.archived ? 1 : 0, row.first_user_message ?? "hello");
+      stmt.run(row.id, row.model_provider, row.cwd ?? "C:\\AITemp", row.archived ? 1 : 0, row.first_user_message ?? "hello", row.model ?? null);
     }
   } finally {
     db.close();
@@ -655,6 +656,49 @@ test("runSwitch rejects --model and --keep-root-model together", async () => {
   // Confirm the file on disk was not mutated by the failed call.
   const after = await fs.readFile(path.join(codexHome, "config.toml"), "utf8");
   assert.equal(after, before);
+});
+
+test("runSync rewrites the per-thread model column when a model is provided", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "gpt-5.4"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-a.jsonl");
+  await writeRollout(sessionPath, "thread-a", "openai");
+  await writeStateDb(codexHome, [
+    { id: "thread-a", model_provider: "openai", model: "gpt-5.4-mini", archived: false }
+  ]);
+
+  const result = await runSync({ codexHome, model: "MiniMax-M3" });
+  assert.ok(result.sqliteRowsUpdated >= 1, "model column should be updated");
+
+  const db = await openDatabase(path.join(codexHome, "sqlite", "state_5.sqlite"));
+  try {
+    const row = db.prepare("SELECT model, model_provider FROM threads WHERE id = ?").get("thread-a");
+    assert.equal(row.model, "MiniMax-M3");
+    assert.equal(row.model_provider, "openai");
+  } finally {
+    db.close();
+  }
+});
+
+test("runSync leaves the per-thread model column untouched when no model is provided", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "gpt-5.4"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-a.jsonl");
+  await writeRollout(sessionPath, "thread-a", "openai");
+  await writeStateDb(codexHome, [
+    { id: "thread-a", model_provider: "openai", model: "gpt-5.4-mini", archived: false }
+  ]);
+
+  await runSync({ codexHome });
+
+  const db = await openDatabase(path.join(codexHome, "sqlite", "state_5.sqlite"));
+  try {
+    const row = db.prepare("SELECT model, model_provider FROM threads WHERE id = ?").get("thread-a");
+    assert.equal(row.model, "gpt-5.4-mini", "model must remain unchanged when caller does not pass one");
+    assert.equal(row.model_provider, "openai");
+  } finally {
+    db.close();
+  }
 });
 
 test("status reports implicit default provider and rollout/sqlite counts", async () => {

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -765,6 +765,124 @@ test("runSync rewrites the per-turn turn_context model field in rollout files", 
   }
 });
 
+test("runSync rewrites turn_context model even when the line is larger than 64 KB", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "MiniMax-M3"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "06", "09", "rollout-huge.jsonl");
+  await fs.mkdir(path.dirname(sessionPath), { recursive: true });
+
+  // Build a turn_context line whose `developer_instructions` blob
+  // pushes the encoded JSON well past the previous 64 KB scanner cap.
+  const devInstructions = "x".repeat(150 * 1024);
+  const turnContext = {
+    timestamp: "2026-06-09T09:16:03.880Z",
+    type: "turn_context",
+    payload: {
+      turn_id: "019eabaa-very-large",
+      cwd: "C:\\AITemp",
+      model: "gpt-5.4",
+      developer_instructions: devInstructions,
+      collaboration_mode: { mode: "default", settings: { model: "gpt-5.4", reasoning_effort: "xhigh" } }
+    }
+  };
+  const meta = JSON.stringify({
+    timestamp: "2026-06-09T09:16:03.878Z",
+    type: "session_meta",
+    payload: { id: "thread-huge", timestamp: "2026-06-09T09:16:03.878Z", cwd: "C:\\AITemp", source: "cli", cli_version: "0.115.0", model_provider: "apigather" }
+  });
+  await fs.writeFile(sessionPath, `${meta}\n${JSON.stringify(turnContext)}\n`, "utf8");
+
+  // Sanity: the encoded turn_context line should exceed 64 KB.
+  const onDisk = await fs.readFile(sessionPath, "utf8");
+  const lineLengths = onDisk.split("\n").filter(Boolean).map((line) => line.length);
+  assert.ok(Math.max(...lineLengths) > 64 * 1024, "test setup: line should exceed 64 KB");
+
+  const result = await runSync({ codexHome, model: "MiniMax-M3" });
+  assert.equal(result.changedSessionFiles, 1);
+
+  const lines = (await fs.readFile(sessionPath, "utf8")).split("\n").filter(Boolean);
+  for (const line of lines) {
+    if (!line.includes('"turn_context"')) continue;
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.payload.model, "MiniMax-M3");
+    assert.equal(parsed.payload.collaboration_mode.settings.model, "MiniMax-M3");
+  }
+});
+
+test("runSync rewrites turn_context whose model name contains regex metacharacters", async () => {
+  // Names like `gpt-5.4-mini` and `apigather.fixed+name` should
+  // be matched literally — `.` is a regex any-char, `+` is a
+  // quantifier, and an unbalanced `{` would refuse to compile.
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "weird(target)+v2"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "06", "09", "rollout-a.jsonl");
+  await writeRolloutWithTurnContext(sessionPath, {
+    id: "thread-a",
+    provider: "apigather",
+    model: "weird(target)+v2"
+  });
+  // Also throw in a decoy line with `weirdAtargetAv2` so we can
+  // confirm the regex does not over-match.
+  await fs.appendFile(sessionPath, JSON.stringify({
+    timestamp: "2026-06-09T09:16:03.881Z", type: "turn_context",
+    payload: { turn_id: "decoy", model: "weirdAtargetAv2" }
+  }) + "\n", "utf8");
+
+  // Pin target = same as source: still re-runs the rewrite, but
+  // also confirms no-op (same model) case does not corrupt the
+  // decoy.
+  const result = await runSync({ codexHome, model: "weird(target)+v2" });
+  assert.equal(result.changedSessionFiles, 1);
+
+  const lines = (await fs.readFile(sessionPath, "utf8")).split("\n").filter(Boolean);
+  const turnContextLines = lines
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.type === "turn_context");
+  // The original two lines plus the decoy should both still
+  // parse cleanly. The decoy's model must be untouched.
+  assert.equal(turnContextLines.length, 3);
+  for (const entry of turnContextLines) {
+    if (entry.payload.turn_id === "decoy") {
+      assert.equal(entry.payload.model, "weirdAtargetAv2");
+    } else {
+      assert.equal(entry.payload.model, "weird(target)+v2");
+    }
+  }
+});
+
+test("runSync leaves rollout files alone when original turn_context model already equals target", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "MiniMax-M3"\n');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "06", "09", "rollout-a.jsonl");
+  await writeRolloutWithTurnContext(sessionPath, {
+    id: "thread-a",
+    provider: "apigather",
+    model: "MiniMax-M3"
+  });
+
+  // First sync moves provider apigather → openai and rewrites both
+  // SQLite and the rollout turn_context. Second sync with no
+  // arguments should be a no-op (original model already equals
+  // the new target), so session files stay untouched.
+  await runSync({ codexHome, model: "MiniMax-M3" });
+  const firstMtime = (await fs.stat(sessionPath)).mtimeMs;
+  // Touch the file system time back a bit to detect a no-op
+  // (real rewrites preserve mtime, but if we touch it forward we
+  // can still see whether anything wrote to the file).
+  const mtimeBefore = firstMtime - 1000;
+  await fs.utimes(sessionPath, new Date(mtimeBefore), new Date(mtimeBefore));
+
+  await runSync({ codexHome });
+  const finalText = await fs.readFile(sessionPath, "utf8");
+  // The turn_context lines must still report MiniMax-M3 — i.e.
+  // the rewrite did not corrupt them with stale gpt-5.4.
+  for (const line of finalText.split("\n").filter(Boolean)) {
+    if (!line.includes('"turn_context"')) continue;
+    const parsed = JSON.parse(line);
+    assert.equal(parsed.payload.model, "MiniMax-M3");
+  }
+});
+
 test("runSync leaves turn_context model field alone when no model is provided", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"\n');

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -587,6 +587,61 @@ test("runSwitch updates config and syncs provider metadata", async () => {
   assert.match(rollout, /"model_provider":"apigather"/);
 });
 
+test("runSwitch copies root-level model from the new provider section", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const config = `model_provider = "openai"\nmodel = "gpt-5.4-mini"\n\n[model_providers.apigather]\nmodel = "apigather-prod"\nbase_url = "https://example.com"\n`;
+  await fs.writeFile(path.join(codexHome, "config.toml"), config, "utf8");
+
+  const result = await runSwitch({ codexHome, provider: "apigather" });
+  assert.equal(result.modelSync.applied, true);
+  assert.equal(result.modelSync.source, "provider-section");
+  assert.equal(result.modelSync.model, "apigather-prod");
+
+  const next = await fs.readFile(path.join(codexHome, "config.toml"), "utf8");
+  assert.match(next, /^model_provider = "apigather"/m);
+  assert.match(next, /^model = "apigather-prod"/m);
+});
+
+test("runSwitch keeps existing model when --keep-root-model is set", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const config = `model_provider = "openai"\nmodel = "gpt-5.4-mini"\n\n[model_providers.apigather]\nmodel = "apigather-prod"\nbase_url = "https://example.com"\n`;
+  await fs.writeFile(path.join(codexHome, "config.toml"), config, "utf8");
+
+  const result = await runSwitch({ codexHome, provider: "apigather", keepRootModel: true });
+  assert.equal(result.modelSync.applied, false);
+  assert.equal(result.modelSync.source, "none");
+
+  const next = await fs.readFile(path.join(codexHome, "config.toml"), "utf8");
+  assert.match(next, /^model_provider = "apigather"/m);
+  assert.match(next, /^model = "gpt-5.4-mini"/m);
+});
+
+test("runSwitch applies --model override and writes it to config.toml", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model = "gpt-5.4-mini"');
+
+  const result = await runSwitch({ codexHome, provider: "apigather", model: "Custom-Large" });
+  assert.equal(result.modelSync.applied, true);
+  assert.equal(result.modelSync.source, "explicit");
+  assert.equal(result.modelSync.model, "Custom-Large");
+
+  const next = await fs.readFile(path.join(codexHome, "config.toml"), "utf8");
+  assert.match(next, /^model = "Custom-Large"/m);
+});
+
+test("runSwitch emits a warning when the new provider has no model field", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const config = `model_provider = "openai"\nmodel = "gpt-5.4-mini"\n\n[model_providers.apigather]\nbase_url = "https://example.com"\n`;
+  await fs.writeFile(path.join(codexHome, "config.toml"), config, "utf8");
+
+  const result = await runSwitch({ codexHome, provider: "apigather" });
+  assert.equal(result.modelSync.applied, false);
+  assert.match(result.modelSync.warning ?? "", /no model field/);
+
+  const next = await fs.readFile(path.join(codexHome, "config.toml"), "utf8");
+  assert.match(next, /^model = "gpt-5.4-mini"/m);
+});
+
 test("status reports implicit default provider and rollout/sqlite counts", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome);

--- a/test/watch.test.js
+++ b/test/watch.test.js
@@ -1,0 +1,346 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { runWatch } from "../src/watch.js";
+
+async function makeTempCodexHome() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-provider-sync-watch-"));
+  const codexHome = path.join(root, ".codex");
+  await fs.mkdir(path.join(codexHome, "sqlite"), { recursive: true });
+  await fs.writeFile(
+    path.join(codexHome, "config.toml"),
+    `model_provider = "openai"\n\n[model_providers.apigather]\nbase_url = "https://example.com"\n`,
+    "utf8"
+  );
+  // minimal empty sqlite db so detectStateDb finds it
+  await fs.writeFile(path.join(codexHome, "sqlite", "state_5.sqlite"), "", "utf8");
+  return { root, codexHome };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+test("runWatch rejects invalid debounce-ms values", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await assert.rejects(
+    () => runWatch({ codexHome, debounceMs: -1 }),
+    /Invalid --debounce-ms value/
+  );
+  await fs.rm(codexHome, { recursive: true, force: true });
+});
+
+test("runWatch rejects when codex home or config.toml is missing", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-provider-sync-watch-"));
+  await assert.rejects(
+    () => runWatch({ codexHome: path.join(root, "does-not-exist") }),
+    /Codex home not found/
+  );
+  const codexHome = path.join(root, ".codex");
+  await fs.mkdir(codexHome, { recursive: true });
+  await assert.rejects(
+    () => runWatch({ codexHome }),
+    /config\.toml not found/
+  );
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+test("runWatch invokes the injected sync handler when config.toml changes and stops on --once", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const configPath = path.join(codexHome, "config.toml");
+
+  let syncCalls = 0;
+  const gate = deferred();
+  const handle = await runWatch({
+    codexHome,
+    debounceMs: 30,
+    includeStateDb: false,
+    once: true,
+    onSync: async () => {
+      syncCalls += 1;
+      gate.resolve();
+      return { targetProvider: "openai", changedSessionFiles: 0, sqliteRowsUpdated: 0 };
+    }
+  });
+
+  // Trigger a change
+  await fs.writeFile(configPath, `model_provider = "apigather"\n`, "utf8");
+
+  await Promise.race([
+    gate.promise,
+    new Promise((_resolve, reject) => setTimeout(() => reject(new Error("sync not invoked")), 5000))
+  ]);
+
+  // Once mode should stop the watcher automatically and resolve the
+  // `done` promise so the CLI can exit cleanly.
+  const reason = await Promise.race([
+    handle.done,
+    new Promise((_, reject) => setTimeout(() => reject(new Error("watcher did not auto-stop within 1 second")), 1000))
+  ]);
+  assert.equal(reason, "once-mode-complete", "watcher must auto-stop with reason 'once-mode-complete'");
+  assert.equal(syncCalls, 1, "sync handler should have been invoked exactly once");
+
+  // Subsequent change should be ignored (watcher already stopped)
+  await fs.writeFile(configPath, `model_provider = "openai"\n`, "utf8");
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  assert.equal(syncCalls, 1, "sync handler should not be invoked again after once-mode exit");
+
+  await handle.stop();
+  await fs.rm(codexHome, { recursive: true, force: true });
+});
+
+test("runWatch swallows 'sqlite in use' errors and keeps watching", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const configPath = path.join(codexHome, "config.toml");
+
+  const logs = [];
+  let firstSyncCalls = 0;
+  const handle = await runWatch({
+    codexHome,
+    debounceMs: 30,
+    includeStateDb: false,
+    onSync: async () => {
+      firstSyncCalls += 1;
+      throw new Error("state_5.sqlite is currently in use by another process");
+    },
+    onLog: (line) => logs.push(line)
+  });
+
+  await fs.writeFile(configPath, `model_provider = "apigather"\n`, "utf8");
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  assert.ok(firstSyncCalls >= 1, "first sync should have been attempted");
+  assert.ok(
+    logs.some((line) => /state_5\.sqlite is currently in use/.test(line)),
+    "the locked-sqlite error should have been logged as a soft skip"
+  );
+
+  // Watcher should still be alive — emit another change and verify it triggers
+  await fs.writeFile(configPath, `model_provider = "longcat"\n`, "utf8");
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  assert.ok(
+    firstSyncCalls >= 2,
+    "the watcher should still trigger after the first sync errored; got " + firstSyncCalls + " calls"
+  );
+  await handle.stop();
+  await fs.rm(codexHome, { recursive: true, force: true });
+});
+
+test("runWatch stops itself after consecutive non-busy sync failures and resolves done", async () => {
+  // Regression guard for B11: when the sync handler keeps
+  // throwing something other than `state_5.sqlite is currently
+  // in use` (e.g. config corruption, codex home moved,
+  // permission denied, ...), the watcher must not loop forever
+  // spamming logs. It should give up after a small threshold of
+  // consecutive failures so the user notices via the
+  // `codex-provider watch` exit instead.
+  const { codexHome } = await makeTempCodexHome();
+  const configPath = path.join(codexHome, "config.toml");
+  const shutdownReason = deferred();
+
+  const handle = await runWatch({
+    codexHome,
+    debounceMs: 30,
+    includeStateDb: false,
+    onSync: async () => {
+      // Throw something that is NOT a "busy" error so the watcher
+      // counts it toward the failure threshold.
+      throw new Error("config.toml is malformed (test fixture)");
+    },
+    onShutdown: async (reason) => {
+      shutdownReason.resolve(reason);
+    }
+  });
+
+  // Drive enough change events to exceed the threshold. The
+  // watcher should auto-shutdown after 5 consecutive failures.
+  for (let i = 0; i < 6; i += 1) {
+    await fs.writeFile(configPath, `model_provider = "apigather-${i}"\n`, "utf8");
+    await new Promise((resolve) => setTimeout(resolve, 120));
+  }
+
+  const reason = await Promise.race([
+    shutdownReason.promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error("watcher did not auto-shutdown within 3 seconds")), 3000))
+  ]);
+  assert.equal(reason, "consecutive-failures", "watcher must auto-shutdown with reason 'consecutive-failures'");
+
+  // The `done` promise must also resolve so the CLI can exit
+  // cleanly without waiting for a SIGINT/SIGTERM that will never
+  // arrive.
+  const doneReason = await Promise.race([
+    handle.done,
+    new Promise((_, reject) => setTimeout(() => reject(new Error("handle.done did not resolve within 1 second")), 1000))
+  ]);
+  assert.equal(doneReason, "consecutive-failures", "handle.done must resolve with the same reason as the shutdown");
+
+  await handle.stop();
+  await fs.rm(codexHome, { recursive: true, force: true });
+});
+
+test("runWatch observes the active state database chosen by detectStateDb", async () => {
+  // Regression guard: the watcher must register exactly one
+  // filesystem watcher for the SQLite state database — the one
+  // `detectStateDb` identified as the live Codex layout. Walking
+  // every candidate and emitting a sync for any of them is the
+  // responsibility of the sync path (and is a single-active-DB
+  // semantic there now), not the watcher.
+  const { codexHome } = await makeTempCodexHome();
+  // Both layouts are present here so we exercise the
+  // "live in sqlite-dir" choice that detectStateDb makes.
+  const legacyDbPath = path.join(codexHome, "state_5.sqlite");
+  await fs.writeFile(legacyDbPath, "", "utf8");
+
+  const syncCalls = [];
+  const handle = await runWatch({
+    codexHome,
+    debounceMs: 30,
+    includeStateDb: true,
+    onSync: async () => {
+      syncCalls.push(Date.now());
+      return { targetProvider: "openai", changedSessionFiles: 0, sqliteRowsUpdated: 0 };
+    }
+  });
+
+  // Verify the watcher advertised only the new sqlite/state_5.sqlite
+  // path. The legacy root DB exists on disk but must not be
+  // reported as the watched file.
+  const newDbPath = path.join(codexHome, "sqlite", "state_5.sqlite");
+  assert.equal(
+    handle.watchedStateDbPath,
+    newDbPath,
+    "watcher must report the active DB path, not the legacy fallback"
+  );
+
+  // Touching the active DB triggers a sync; touching the legacy
+  // root DB does not (the watcher is not observing it).
+  const activeBefore = syncCalls.length;
+  await fs.writeFile(newDbPath, "x", "utf8");
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  assert.ok(
+    syncCalls.length > activeBefore,
+    "watcher must react to writes in the active sqlite-dir state DB"
+  );
+
+  const legacyBefore = syncCalls.length;
+  await fs.writeFile(legacyDbPath, "y", "utf8");
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  assert.equal(
+    syncCalls.length,
+    legacyBefore,
+    "watcher must NOT react to writes in the legacy root DB anymore"
+  );
+
+  await handle.stop();
+  await fs.rm(codexHome, { recursive: true, force: true });
+});
+
+test("runWatch reacts to writes in the SQLite WAL sidecar", async () => {
+  // Regression guard for owner review: when Codex runs against a
+  // SQLite database in WAL journal mode (the default), new
+  // transactions are appended to `state_5.sqlite-wal` and only
+  // checkpointed back to the main file on a checkpoint. A
+  // watcher that only listens on the main DB file would miss
+  // every write Codex makes between checkpoints. We have to
+  // attach a watcher to the WAL sidecar too.
+  const { codexHome } = await makeTempCodexHome();
+  const walPath = path.join(codexHome, "sqlite", "state_5.sqlite-wal");
+  await fs.writeFile(walPath, "", "utf8");
+
+  const syncCalls = [];
+  const handle = await runWatch({
+    codexHome,
+    debounceMs: 30,
+    includeStateDb: true,
+    onSync: async () => {
+      syncCalls.push(Date.now());
+      return { targetProvider: "openai", changedSessionFiles: 0, sqliteRowsUpdated: 0 };
+    }
+  });
+
+  // Writing only to the WAL file (not the main DB) must still
+  // trigger a sync.
+  const before = syncCalls.length;
+  await fs.writeFile(walPath, "wal-tx", "utf8");
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  assert.ok(
+    syncCalls.length > before,
+    "watcher must react to writes in the SQLite WAL sidecar; got " + (syncCalls.length - before) + " new calls"
+  );
+
+  await handle.stop();
+  await fs.rm(codexHome, { recursive: true, force: true });
+});
+
+test("runWatch uses the top-level model field, ignoring provider sections", async () => {
+  // Regression guard for owner review: the watcher must read the
+  // root-level `model = "..."` line for the per-turn model sync
+  // and must not pick up a `model = "..."` value that lives
+  // inside a `[model_providers.*]` section — otherwise the
+  // provider-section model would be propagated to every
+  // rollout's turn_context.model.
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-provider-sync-watch-"));
+  const codexHome = path.join(root, ".codex");
+  await fs.mkdir(path.join(codexHome, "sqlite"), { recursive: true });
+  await fs.writeFile(
+    path.join(codexHome, "config.toml"),
+    [
+      'model_provider = "foo"',
+      'model = "gpt-5"',
+      '',
+      '[model_providers.foo]',
+      'base_url = "https://example.com"',
+      'model = "gpt-4o-mini"',  // this one must be ignored
+      ''
+    ].join("\n"),
+    "utf8"
+  );
+  await fs.writeFile(path.join(codexHome, "sqlite", "state_5.sqlite"), "", "utf8");
+
+  let observedModel = null;
+  const handle = await runWatch({
+    codexHome,
+    debounceMs: 30,
+    includeStateDb: false,
+    onSync: async ({ model }) => {
+      observedModel = model;
+      return { targetProvider: "foo", changedSessionFiles: 0, sqliteRowsUpdated: 0 };
+    }
+  });
+
+  await fs.writeFile(
+    path.join(codexHome, "config.toml"),
+    [
+      'model_provider = "foo"',
+      'model = "gpt-5.1"',  // change at root level
+      '',
+      '[model_providers.foo]',
+      'base_url = "https://example.com"',
+      'model = "gpt-4o-mini"',  // unchanged at provider section
+      ''
+    ].join("\n"),
+    "utf8"
+  );
+
+  // Wait for the debounce + sync.
+  for (let i = 0; i < 50 && observedModel === null; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.equal(
+    observedModel,
+    "gpt-5.1",
+    "watcher must read the root-level model; provider-section model must be ignored"
+  );
+
+  await handle.stop();
+  await fs.rm(codexHome, { recursive: true, force: true });
+});

--- a/test/watch.test.js
+++ b/test/watch.test.js
@@ -281,6 +281,34 @@ test("runWatch reacts to writes in the SQLite WAL sidecar", async () => {
   await fs.rm(codexHome, { recursive: true, force: true });
 });
 
+test("runWatch attaches when the SQLite WAL sidecar is created later", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const walPath = path.join(codexHome, "sqlite", "state_5.sqlite-wal");
+  const syncCalls = [];
+  const handle = await runWatch({
+    codexHome,
+    debounceMs: 30,
+    includeStateDb: true,
+    onSync: async () => {
+      syncCalls.push(Date.now());
+      return { targetProvider: "openai", changedSessionFiles: 0, sqliteRowsUpdated: 0 };
+    }
+  });
+
+  await fs.writeFile(walPath, "", "utf8");
+  await new Promise((resolve) => setTimeout(resolve, 350));
+  const before = syncCalls.length;
+  await fs.appendFile(walPath, "wal-created-after-start", "utf8");
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  assert.ok(
+    syncCalls.length > before,
+    "watcher must attach to a WAL sidecar that did not exist at startup"
+  );
+
+  await handle.stop();
+  await fs.rm(codexHome, { recursive: true, force: true });
+});
+
 test("runWatch uses the top-level model field, ignoring provider sections", async () => {
   // Regression guard for owner review: the watcher must read the
   // root-level `model = "..."` line for the per-turn model sync


### PR DESCRIPTION
## Problem
`codex-provider switch <provider-id>` only updated the top-level
`model_provider` line in `config.toml`. The top-level `model` line
was left at its previous value, so requests went out with the old
model name against the new provider's base_url (e.g. switching to
`longcat` kept `model = "gpt-5.4"` while longcat's section says
`LongCat-2.0-Preview`).

## Fix
`switch` now also aligns the root-level `model` with the new
provider section's `model`, with opt-outs:

- `--model <name>`    override root-level model explicitly
- `--keep-root-model` leave the root-level model untouched

When the new provider section has no `model` field, a warning is
emitted and the root-level `model` is preserved. Default behavior
is to copy, so existing `switch` invocations gain the new behavior
without breaking.

## Verification
9 new unit tests in `test/config-file.test.js` and
`test/sync-service.test.js`. `npm test` passes 50/50.

Includes a separate docs commit (`003aa7f`) updating README and
AGENTS.md to surface the new flags.