### PR TITLE
feat(single-instance): refuse second launch and forward focus request

### DIFF
--- a/desktop/CodexProviderSync.App/FocusRequestServer.cs
+++ b/desktop/CodexProviderSync.App/FocusRequestServer.cs
@@ -44,7 +44,7 @@ public sealed class FocusRequestServer : IDisposable
         try
         {
             using NamedPipeClientStream client = new(".", PipeName, PipeDirection.Out, PipeOptions.None);
-            await client.ConnectAsync(timeout).ConfigureAwait(false);
+            await client.ConnectAsync((int)timeout.TotalMilliseconds).ConfigureAwait(false);
             using StreamWriter writer = new(client) { AutoFlush = true };
             await writer.WriteLineAsync("FOCUS").ConfigureAwait(false);
             return true;

--- a/desktop/CodexProviderSync.App/FocusRequestServer.cs
+++ b/desktop/CodexProviderSync.App/FocusRequestServer.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CodexProviderSync.App;
+
+/// <summary>
+/// Cross-process focus broker: the first instance of CodexProviderSync runs
+/// this server on a per-user named pipe. Subsequent instances connect, send
+/// the "FOCUS" command, and exit; the server invokes the registered handler
+/// on the main thread, which is expected to bring the existing window to
+/// the foreground.
+/// </summary>
+public sealed class FocusRequestServer : IDisposable
+{
+    private const string PipeNamePrefix = "CodexProviderSync.Focus";
+
+    private readonly Action _onFocusRequested;
+    private readonly CancellationTokenSource _shutdown = new();
+    private Task? _loop;
+    private bool _disposed;
+
+    public FocusRequestServer(Action onFocusRequested)
+    {
+        _onFocusRequested = onFocusRequested ?? throw new ArgumentNullException(nameof(onFocusRequested));
+    }
+
+    public string PipeName { get; } = BuildPipeName();
+
+    public void Start()
+    {
+        if (_loop is not null)
+        {
+            return;
+        }
+        _loop = Task.Run(RunAsync);
+    }
+
+    public async Task<bool> SendFocusRequestAsync(TimeSpan timeout)
+    {
+        try
+        {
+            using NamedPipeClientStream client = new(".", PipeName, PipeDirection.Out, PipeOptions.None);
+            await client.ConnectAsync(timeout).ConfigureAwait(false);
+            using StreamWriter writer = new(client) { AutoFlush = true };
+            await writer.WriteLineAsync("FOCUS").ConfigureAwait(false);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    private async Task RunAsync()
+    {
+        while (!_shutdown.IsCancellationRequested)
+        {
+            try
+            {
+                using NamedPipeServerStream server = new(
+                    PipeName,
+                    PipeDirection.In,
+                    NamedPipeServerStream.MaxAllowedServerInstances,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous);
+                await server.WaitForConnectionAsync(_shutdown.Token).ConfigureAwait(false);
+                using StreamReader reader = new(server);
+                string? line = await reader.ReadLineAsync().ConfigureAwait(false);
+                if (string.Equals(line, "FOCUS", StringComparison.Ordinal))
+                {
+                    _onFocusRequested();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (IOException)
+            {
+                // Pipe was broken mid-handshake; loop and create a fresh one.
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        _shutdown.Cancel();
+        try
+        {
+            _loop?.Wait(TimeSpan.FromSeconds(2));
+        }
+        catch (AggregateException)
+        {
+            // The loop is allowed to fault on cancellation; nothing actionable.
+        }
+        _shutdown.Dispose();
+    }
+
+    private static string BuildPipeName()
+    {
+        // Per-user scope so two users on the same Windows machine do not
+        // collide. Identity.Name is "DOMAIN\User" on Windows; the backslash
+        // is illegal in pipe names so we swap it out.
+        string identity = WindowsIdentity.GetCurrent().Name ?? "default";
+        string sanitized = identity.Replace('\\', '_').Replace('/', '_').Replace(' ', '_');
+        return $"{PipeNamePrefix}.{sanitized}";
+    }
+}

--- a/desktop/CodexProviderSync.App/MainForm.cs
+++ b/desktop/CodexProviderSync.App/MainForm.cs
@@ -124,7 +124,7 @@ public sealed class MainForm : Form
     /// single-instance focus broker when a second copy of CodexProviderSync
     /// is launched and asks the first copy to take focus.
     /// </summary>
-    public void BringToFront()
+    public new void BringToFront()
     {
         if (InvokeRequired)
         {

--- a/desktop/CodexProviderSync.App/MainForm.cs
+++ b/desktop/CodexProviderSync.App/MainForm.cs
@@ -119,6 +119,29 @@ public sealed class MainForm : Form
         await LoadStateAsync();
     }
 
+    /// <summary>
+    /// Brings the running form back to the foreground. Invoked by the
+    /// single-instance focus broker when a second copy of CodexProviderSync
+    /// is launched and asks the first copy to take focus.
+    /// </summary>
+    public void BringToFront()
+    {
+        if (InvokeRequired)
+        {
+            BeginInvoke(new Action(BringToFront));
+            return;
+        }
+        if (WindowState == FormWindowState.Minimized)
+        {
+            WindowState = FormWindowState.Normal;
+        }
+        Show();
+        Activate();
+        TopMost = true;
+        TopMost = false;
+        Focus();
+    }
+
     protected override void OnFormClosing(FormClosingEventArgs e)
     {
         PersistUiState();

--- a/desktop/CodexProviderSync.App/Program.cs
+++ b/desktop/CodexProviderSync.App/Program.cs
@@ -1,3 +1,5 @@
+using CodexProviderSync.Core;
+
 namespace CodexProviderSync.App;
 
 static class Program
@@ -7,8 +9,19 @@ static class Program
     {
         try
         {
+            SingleInstanceGuard guard = new();
+            using SingleInstanceAcquisition acquisition = guard.Acquire("codex-provider-sync");
+            if (!acquisition.IsOwner)
+            {
+                FocusExistingInstanceAndExit(acquisition);
+                return;
+            }
+
             ApplicationConfiguration.Initialize();
-            Application.Run(new MainForm());
+            MainForm mainForm = new();
+            using FocusRequestServer focusServer = new(mainForm.BringToFront);
+            focusServer.Start();
+            Application.Run(mainForm);
         }
         catch (Exception error)
         {
@@ -23,6 +36,33 @@ static class Program
                 "Codex Provider Sync",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Error);
+        }
+    }
+
+    private static void FocusExistingInstanceAndExit(SingleInstanceAcquisition acquisition)
+    {
+        string detail = acquisition.ExistingOwner is { } owner
+            ? $"pid={owner.ProcessId}, started={owner.StartedAt:O}"
+            : "no owner metadata available";
+        Console.WriteLine(
+            $"Another Codex Provider Sync instance is already running ({detail}). Forwarding focus request and exiting.");
+
+        try
+        {
+            using FocusRequestServer client = new(() => { });
+            bool delivered = client
+                .SendFocusRequestAsync(TimeSpan.FromSeconds(2))
+                .GetAwaiter()
+                .GetResult();
+            if (!delivered)
+            {
+                Console.WriteLine(
+                    "Focus request timed out; the existing instance may be busy. It will be brought to the foreground when it next becomes idle.");
+            }
+        }
+        catch (Exception error)
+        {
+            Console.Error.WriteLine($"Failed to forward focus request: {error.Message}");
         }
     }
 }

--- a/desktop/CodexProviderSync.Core.Tests/SingleInstanceGuardTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/SingleInstanceGuardTests.cs
@@ -1,0 +1,152 @@
+namespace CodexProviderSync.Core.Tests;
+
+public sealed class SingleInstanceGuardTests
+{
+    [Fact]
+    public void Acquire_FirstCallerIsOwner_AndLockDirectoryExists()
+    {
+        string lockDir = OverrideLockDirectory(out string settingsRoot);
+        try
+        {
+            SingleInstanceGuard guard = new(_ => false);
+            using SingleInstanceAcquisition acquisition = guard.Acquire("test");
+            Assert.True(acquisition.IsOwner);
+            Assert.Null(acquisition.ExistingOwner);
+            Assert.True(Directory.Exists(lockDir));
+            Assert.True(File.Exists(Path.Combine(lockDir, "owner.json")));
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    [Fact]
+    public void Acquire_SecondCallerSeesExistingOwner_WhenFirstIsAlive()
+    {
+        string lockDir = OverrideLockDirectory(out string settingsRoot);
+        try
+        {
+            SingleInstanceGuard first = new(_ => true);
+            using SingleInstanceAcquisition firstAcq = first.Acquire("first");
+            Assert.True(firstAcq.IsOwner);
+
+            SingleInstanceGuard second = new(_ => true);
+            using SingleInstanceAcquisition secondAcq = second.Acquire("second");
+            Assert.False(secondAcq.IsOwner);
+            Assert.NotNull(secondAcq.ExistingOwner);
+            Assert.Equal(Environment.ProcessId, secondAcq.ExistingOwner!.ProcessId);
+            Assert.Equal("first", secondAcq.ExistingOwner.Label);
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    [Fact]
+    public void Acquire_RecoversFromStaleLock_WhenPreviousOwnerIsDead()
+    {
+        string lockDir = OverrideLockDirectory(out string settingsRoot);
+        try
+        {
+            // First acquisition is "abandoned" without being disposed.
+            SingleInstanceGuard stale = new(_ => true);
+            SingleInstanceAcquisition staleAcq = stale.Acquire("stale");
+            Assert.True(staleAcq.IsOwner);
+            // Pretend the stale owner died by leaving the dir on disk.
+            staleAcq.Dispose();
+
+            // New acquisition must observe a dead owner (probe returns false) and
+            // recover by taking the lock itself.
+            SingleInstanceGuard fresh = new(_ => false);
+            using SingleInstanceAcquisition freshAcq = fresh.Acquire("fresh");
+            Assert.True(freshAcq.IsOwner);
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    [Fact]
+    public void Dispose_RemovesLockDirectoryForOwner()
+    {
+        OverrideLockDirectory(out string settingsRoot);
+        try
+        {
+            SingleInstanceGuard guard = new(_ => false);
+            string lockDir = guard.LockDirectory;
+            using (guard.Acquire("owner"))
+            {
+                Assert.True(Directory.Exists(lockDir));
+            }
+            Assert.False(Directory.Exists(lockDir));
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    [Fact]
+    public void Acquire_ThrowsAfterRetryBudgetExhaustedOnStaleLock()
+    {
+        OverrideLockDirectory(out string settingsRoot);
+        try
+        {
+            // Pre-create the lock directory to force CreateDirectory to return
+            // an error code that is neither 0 (success) nor 183 (already exists).
+            // We achieve this by creating a *file* at the same path so the
+            // OS reports a generic "cannot create" error.
+            SingleInstanceGuard first = new(_ => true);
+            SingleInstanceAcquisition firstAcq = first.Acquire("first");
+            string lockPath = first.LockDirectory;
+            firstAcq.Dispose();
+            File.Create(Path.Combine(lockPath, "BLOCK")).Close();
+            // Now CreateDirectory will fail with ERROR_ALREADY_EXISTS (183) which
+            // the guard handles by trying to clean up; the cleanup of a directory
+            // containing a file should still succeed. So this assertion is just
+            // a smoke test: the second acquire should eventually succeed.
+            SingleInstanceGuard second = new(_ => true);
+            using SingleInstanceAcquisition secondAcq = second.Acquire("second");
+            Assert.True(secondAcq.IsOwner);
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    private static string OverrideLockDirectory(out string settingsRoot)
+    {
+        // Redirect ApplicationData to a unique temp folder so tests do not
+        // touch the user's real %APPDATA%/codex-provider-sync.
+        string root = Path.Combine(Path.GetTempPath(), $"codex-provider-singleton-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        Environment.SetEnvironmentVariable("APPDATA", root, EnvironmentVariableTarget.Process);
+        string lockDir = Path.Combine(root, "codex-provider-sync", "singleton");
+        // Ensure the guard's LockDirectory getter will see the new APPDATA by
+        // creating the singleton dir explicitly (the guard itself also creates it).
+        if (Directory.Exists(lockDir))
+        {
+            Directory.Delete(lockDir, recursive: true);
+        }
+        return lockDir;
+    }
+
+    private static void Cleanup(string settingsRoot)
+    {
+        try
+        {
+            if (Directory.Exists(settingsRoot))
+            {
+                Directory.Delete(settingsRoot, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+}

--- a/desktop/CodexProviderSync.Core.Tests/SingleInstanceGuardTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/SingleInstanceGuardTests.cs
@@ -1,3 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace CodexProviderSync.Core.Tests;
 
 public sealed class SingleInstanceGuardTests
@@ -145,6 +152,113 @@ public sealed class SingleInstanceGuardTests
             using SingleInstanceAcquisition secondAcq = second.Acquire("second");
             Assert.True(secondAcq.IsOwner);
             Assert.False(File.Exists(Path.Combine(lockDir, "BLOCK")));
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    [Fact]
+    public void Acquire_FirstCallOnSharedParentDirCreatesLockDirAtomically_AndSecondCallSeesExistingOwner()
+    {
+        // Regression guard: previously `Acquire` called
+        // `Directory.CreateDirectory(LockDirectory)` first, which
+        // recursively creates the lock dir on the very first
+        // launch. The follow-up atomic `TryCreateDirectory(LockDirectory)`
+        // then always returned `Win32ErrorAlreadyExists` and
+        // routed the first caller into the stale-lock recovery
+        // branch. With the fix, only the parent directory is
+        // pre-created; the lock dir itself is created atomically
+        // by `TryCreateDirectory`, so the first launch takes the
+        // owner branch directly without touching the recovery
+        // path. We verify both halves of that contract here:
+        //
+        //   1. The very first call writes `owner.json` (i.e.
+        //      took the atomic-create success branch, not the
+        //      stale-recovery branch).
+        //   2. A second call, when the lock dir already exists
+        //      and owner.json names a live pid, returns
+        //      `IsOwner == false` instead of clearing the lock
+        //      and reclaiming it.
+        //
+        // We cannot use two callers in the same test process
+        // because `Environment.ProcessId` is constant for the
+        // whole process — a second in-process `Acquire` would
+        // see its own pid in the just-written `owner.json` and
+        // fall into the stale-recovery branch (a Windows pid
+        // recycle scenario, not a real concurrent-launch race).
+        // Instead, we seed `owner.json` with a fictitious live
+        // pid and let the second caller observe it. This is
+        // exactly what a concurrent launch from another process
+        // looks like at the filesystem level.
+        string settingsRoot = Path.Combine(Path.GetTempPath(), $"codex-provider-singleton-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(settingsRoot);
+        string lockDir = Path.Combine(settingsRoot, "singleton");
+        try
+        {
+            // First caller: lockDir does not exist yet, the
+            // atomic `TryCreateDirectory` must succeed and we
+            // must take the owner branch.
+            SingleInstanceGuard firstGuard = new(static _ => true, lockDir);
+            using SingleInstanceAcquisition firstAcq = firstGuard.Acquire("first");
+            Assert.True(firstAcq.IsOwner);
+            Assert.Null(firstAcq.ExistingOwner);
+            Assert.True(File.Exists(Path.Combine(lockDir, "owner.json")),
+                "first caller must take the atomic-create success branch and write owner.json directly");
+            firstAcq.Dispose();
+
+            // Seed `owner.json` with a fictitious live pid so
+            // the second caller observes the existing-owner
+            // branch instead of the pid-recycle stale branch.
+            // We use `pid = 1` (system init / PID 1 is always
+            // alive on Windows/Linux/macOS for the duration of
+            // any test run) and a probe that returns true for
+            // any pid.
+            Directory.CreateDirectory(lockDir);
+            File.WriteAllText(Path.Combine(lockDir, "owner.json"),
+                "{\"processId\":1,\"startedAt\":\"2026-01-01T00:00:00+00:00\",\"label\":\"existing\",\"currentDirectory\":\"C:\\\\\"}");
+
+            SingleInstanceGuard secondGuard = new(static _ => true, lockDir);
+            using SingleInstanceAcquisition secondAcq = secondGuard.Acquire("second");
+            Assert.False(secondAcq.IsOwner);
+            Assert.NotNull(secondAcq.ExistingOwner);
+            Assert.Equal(1, secondAcq.ExistingOwner!.ProcessId);
+            Assert.True(File.Exists(Path.Combine(lockDir, "owner.json")),
+                "second caller must not delete the lock directory when the owner is still alive");
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    [Fact]
+    public void Acquire_PidRecycleInOwnerJson_TreatedAsStaleAndReclaimed()
+    {
+        // Companion regression guard: when `owner.json`
+        // contains a pid that matches the current process but
+        // the process did NOT actually take the lock (e.g.,
+        // Windows reused our pid for a brand-new process while
+        // the previous owner crashed mid-write), the guard
+        // must treat that as stale and reclaim the lock. The
+        // signal we use is: the lock dir contains an
+        // `owner.json` with our pid but no leftover file from
+        // a partial write, and a probe that says the pid is
+        // dead. We hand-craft that scenario here.
+        string settingsRoot = Path.Combine(Path.GetTempPath(), $"codex-provider-singleton-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(settingsRoot);
+        string lockDir = Path.Combine(settingsRoot, "singleton");
+        try
+        {
+            Directory.CreateDirectory(lockDir);
+            File.WriteAllText(Path.Combine(lockDir, "owner.json"),
+                $"{{\"processId\":{Environment.ProcessId},\"startedAt\":\"2026-01-01T00:00:00+00:00\",\"label\":\"dead-recycle\",\"currentDirectory\":\"C:\\\\\"}}");
+
+            SingleInstanceGuard guard = new(static _ => false, lockDir);
+            using SingleInstanceAcquisition acq = guard.Acquire("recycled");
+            Assert.True(acq.IsOwner);
+            Assert.Null(acq.ExistingOwner);
         }
         finally
         {

--- a/desktop/CodexProviderSync.Core.Tests/SingleInstanceGuardTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/SingleInstanceGuardTests.cs
@@ -2,137 +2,12 @@ namespace CodexProviderSync.Core.Tests;
 
 public sealed class SingleInstanceGuardTests
 {
-    [Fact]
-    public void Acquire_FirstCallerIsOwner_AndLockDirectoryExists()
+    private static (string lockDir, string settingsRoot) NewIsolatedLockDir()
     {
-        string lockDir = OverrideLockDirectory(out string settingsRoot);
-        try
-        {
-            SingleInstanceGuard guard = new(_ => false);
-            using SingleInstanceAcquisition acquisition = guard.Acquire("test");
-            Assert.True(acquisition.IsOwner);
-            Assert.Null(acquisition.ExistingOwner);
-            Assert.True(Directory.Exists(lockDir));
-            Assert.True(File.Exists(Path.Combine(lockDir, "owner.json")));
-        }
-        finally
-        {
-            Cleanup(settingsRoot);
-        }
-    }
-
-    [Fact]
-    public void Acquire_SecondCallerSeesExistingOwner_WhenFirstIsAlive()
-    {
-        string lockDir = OverrideLockDirectory(out string settingsRoot);
-        try
-        {
-            SingleInstanceGuard first = new(_ => true);
-            using SingleInstanceAcquisition firstAcq = first.Acquire("first");
-            Assert.True(firstAcq.IsOwner);
-
-            SingleInstanceGuard second = new(_ => true);
-            using SingleInstanceAcquisition secondAcq = second.Acquire("second");
-            Assert.False(secondAcq.IsOwner);
-            Assert.NotNull(secondAcq.ExistingOwner);
-            Assert.Equal(Environment.ProcessId, secondAcq.ExistingOwner!.ProcessId);
-            Assert.Equal("first", secondAcq.ExistingOwner.Label);
-        }
-        finally
-        {
-            Cleanup(settingsRoot);
-        }
-    }
-
-    [Fact]
-    public void Acquire_RecoversFromStaleLock_WhenPreviousOwnerIsDead()
-    {
-        string lockDir = OverrideLockDirectory(out string settingsRoot);
-        try
-        {
-            // First acquisition is "abandoned" without being disposed.
-            SingleInstanceGuard stale = new(_ => true);
-            SingleInstanceAcquisition staleAcq = stale.Acquire("stale");
-            Assert.True(staleAcq.IsOwner);
-            // Pretend the stale owner died by leaving the dir on disk.
-            staleAcq.Dispose();
-
-            // New acquisition must observe a dead owner (probe returns false) and
-            // recover by taking the lock itself.
-            SingleInstanceGuard fresh = new(_ => false);
-            using SingleInstanceAcquisition freshAcq = fresh.Acquire("fresh");
-            Assert.True(freshAcq.IsOwner);
-        }
-        finally
-        {
-            Cleanup(settingsRoot);
-        }
-    }
-
-    [Fact]
-    public void Dispose_RemovesLockDirectoryForOwner()
-    {
-        OverrideLockDirectory(out string settingsRoot);
-        try
-        {
-            SingleInstanceGuard guard = new(_ => false);
-            string lockDir = guard.LockDirectory;
-            using (guard.Acquire("owner"))
-            {
-                Assert.True(Directory.Exists(lockDir));
-            }
-            Assert.False(Directory.Exists(lockDir));
-        }
-        finally
-        {
-            Cleanup(settingsRoot);
-        }
-    }
-
-    [Fact]
-    public void Acquire_ThrowsAfterRetryBudgetExhaustedOnStaleLock()
-    {
-        OverrideLockDirectory(out string settingsRoot);
-        try
-        {
-            // Pre-create the lock directory to force CreateDirectory to return
-            // an error code that is neither 0 (success) nor 183 (already exists).
-            // We achieve this by creating a *file* at the same path so the
-            // OS reports a generic "cannot create" error.
-            SingleInstanceGuard first = new(_ => true);
-            SingleInstanceAcquisition firstAcq = first.Acquire("first");
-            string lockPath = first.LockDirectory;
-            firstAcq.Dispose();
-            File.Create(Path.Combine(lockPath, "BLOCK")).Close();
-            // Now CreateDirectory will fail with ERROR_ALREADY_EXISTS (183) which
-            // the guard handles by trying to clean up; the cleanup of a directory
-            // containing a file should still succeed. So this assertion is just
-            // a smoke test: the second acquire should eventually succeed.
-            SingleInstanceGuard second = new(_ => true);
-            using SingleInstanceAcquisition secondAcq = second.Acquire("second");
-            Assert.True(secondAcq.IsOwner);
-        }
-        finally
-        {
-            Cleanup(settingsRoot);
-        }
-    }
-
-    private static string OverrideLockDirectory(out string settingsRoot)
-    {
-        // Redirect ApplicationData to a unique temp folder so tests do not
-        // touch the user's real %APPDATA%/codex-provider-sync.
         string root = Path.Combine(Path.GetTempPath(), $"codex-provider-singleton-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
-        Environment.SetEnvironmentVariable("APPDATA", root, EnvironmentVariableTarget.Process);
-        string lockDir = Path.Combine(root, "codex-provider-sync", "singleton");
-        // Ensure the guard's LockDirectory getter will see the new APPDATA by
-        // creating the singleton dir explicitly (the guard itself also creates it).
-        if (Directory.Exists(lockDir))
-        {
-            Directory.Delete(lockDir, recursive: true);
-        }
-        return lockDir;
+        string lockDir = Path.Combine(root, "singleton");
+        return (lockDir, root);
     }
 
     private static void Cleanup(string settingsRoot)
@@ -147,6 +22,133 @@ public sealed class SingleInstanceGuardTests
         catch
         {
             // best-effort
+        }
+    }
+
+    [Fact]
+    public void Acquire_FirstCallerIsOwner_AndLockDirectoryExists()
+    {
+        (string lockDir, string settingsRoot) = NewIsolatedLockDir();
+        try
+        {
+            SingleInstanceGuard guard = new(_ => false, lockDir);
+            using SingleInstanceAcquisition acquisition = guard.Acquire("test");
+            Assert.True(acquisition.IsOwner);
+            Assert.Null(acquisition.ExistingOwner);
+            Assert.Equal(lockDir, guard.LockDirectory);
+            Assert.True(Directory.Exists(lockDir));
+            Assert.True(File.Exists(Path.Combine(lockDir, "owner.json")));
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    [Fact]
+    public void Acquire_SecondCallerSeesExistingOwner_WhenFirstIsAlive()
+    {
+        (string lockDir, string settingsRoot) = NewIsolatedLockDir();
+        try
+        {
+            // First call takes the lock. We then mutate owner.json to
+            // advertise a different (synthetic) pid so the test simulates a
+            // different process holding the lock — within a single test
+            // process we cannot Acquire twice as owner (the guard's
+            // stale-recovery path would treat the first as a self-stale).
+            SingleInstanceGuard first = new(_ => true, lockDir);
+            using SingleInstanceAcquisition firstAcq = first.Acquire("first");
+            Assert.True(firstAcq.IsOwner);
+
+            string ownerPath = Path.Combine(lockDir, "owner.json");
+            string ownerJson = File.ReadAllText(ownerPath);
+            File.WriteAllText(ownerPath, ownerJson.Replace(
+                $"\"processId\": {Environment.ProcessId}",
+                "\"processId\": 99999"));
+
+            SingleInstanceGuard second = new(_ => true, lockDir);
+            using SingleInstanceAcquisition secondAcq = second.Acquire("second");
+            Assert.False(secondAcq.IsOwner);
+            Assert.NotNull(secondAcq.ExistingOwner);
+            Assert.Equal(99999, secondAcq.ExistingOwner!.ProcessId);
+            Assert.Equal("first", secondAcq.ExistingOwner.Label);
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    [Fact]
+    public void Acquire_RecoversFromStaleLock_WhenPreviousOwnerIsDead()
+    {
+        (string lockDir, string settingsRoot) = NewIsolatedLockDir();
+        try
+        {
+            // First acquisition is "abandoned" without being disposed.
+            SingleInstanceGuard stale = new(_ => true, lockDir);
+            SingleInstanceAcquisition staleAcq = stale.Acquire("stale");
+            Assert.True(staleAcq.IsOwner);
+            // Pretend the stale owner died by leaving the dir on disk.
+            staleAcq.Dispose();
+
+            // New acquisition must observe a dead owner (probe returns false) and
+            // recover by taking the lock itself.
+            SingleInstanceGuard fresh = new(_ => false, lockDir);
+            using SingleInstanceAcquisition freshAcq = fresh.Acquire("fresh");
+            Assert.True(freshAcq.IsOwner);
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    [Fact]
+    public void Dispose_RemovesLockDirectoryForOwner()
+    {
+        (string lockDir, string settingsRoot) = NewIsolatedLockDir();
+        try
+        {
+            SingleInstanceGuard guard = new(_ => false, lockDir);
+            using (guard.Acquire("owner"))
+            {
+                Assert.True(Directory.Exists(lockDir));
+            }
+            Assert.False(Directory.Exists(lockDir));
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
+        }
+    }
+
+    [Fact]
+    public void Acquire_RecoversWhenPreviousLockContainsLeftoverFile()
+    {
+        (string lockDir, string settingsRoot) = NewIsolatedLockDir();
+        try
+        {
+            // First call takes the lock with a live probe, then we abandon it
+            // (Dispose). Dispose() removes the lock directory, so we recreate
+            // it manually and drop a stray file inside to simulate a partial
+            // cleanup. The second call has the probe say "dead", so the guard
+            // has to clear the entire tree (including the stray file) and
+            // reclaim the lock.
+            SingleInstanceGuard first = new(_ => true, lockDir);
+            SingleInstanceAcquisition firstAcq = first.Acquire("first");
+            firstAcq.Dispose();
+            Directory.CreateDirectory(lockDir);
+            File.WriteAllText(Path.Combine(lockDir, "BLOCK"), "leftover");
+
+            SingleInstanceGuard second = new(_ => false, lockDir);
+            using SingleInstanceAcquisition secondAcq = second.Acquire("second");
+            Assert.True(secondAcq.IsOwner);
+            Assert.False(File.Exists(Path.Combine(lockDir, "BLOCK")));
+        }
+        finally
+        {
+            Cleanup(settingsRoot);
         }
     }
 }

--- a/desktop/CodexProviderSync.Core/SingleInstanceGuard.cs
+++ b/desktop/CodexProviderSync.Core/SingleInstanceGuard.cs
@@ -17,8 +17,15 @@ public sealed class SingleInstanceGuard
 {
     private const int Win32ErrorAlreadyExists = 183;
     private const int Win32ErrorAccessDenied = 5;
-    private const int DefaultCreateRetryCount = 3;
-    private const int DefaultCreateRetryDelayMs = 75;
+    private const int Win32ErrorSharingViolation = 32;
+    private const int Win32ErrorLockViolation = 33;
+    // The previous default budget (3 × 75 ms = 225 ms) was too tight for
+    // Windows Defender / OneDrive / antivirus file-locking drivers which
+    // can hold the directory open for several seconds on first launch.
+    // 30 × 100 ms = 3 s gives the OS enough breathing room to release
+    // the lock without making genuine failures drag on indefinitely.
+    private const int DefaultCreateRetryCount = 30;
+    private const int DefaultCreateRetryDelayMs = 100;
     private const int RaceWindowRetryCount = 20;
     private const int RaceWindowRetryDelayMs = 25;
 
@@ -263,7 +270,15 @@ if (owner is null)
 
     private static bool IsTransientLockCreateError(int errorCode)
     {
-        return errorCode == Win32ErrorAccessDenied;
+        // Access-denied, sharing-violation, and lock-violation are
+        // all transient Windows errors that mean "the lock directory
+        // is currently held by another process". Anti-virus and
+        // cloud-sync drivers often hold these for a few seconds on
+        // first launch; retrying through the default budget lets the
+        // OS release them without surfacing an error to the user.
+        return errorCode == Win32ErrorAccessDenied
+            || errorCode == Win32ErrorSharingViolation
+            || errorCode == Win32ErrorLockViolation;
     }
 
     // True when the lock directory exists, `owner.json` is not

--- a/desktop/CodexProviderSync.Core/SingleInstanceGuard.cs
+++ b/desktop/CodexProviderSync.Core/SingleInstanceGuard.cs
@@ -35,16 +35,32 @@ public sealed class SingleInstanceGuard
     /// still alive?" so unit tests do not depend on a real running process.
     /// </summary>
     internal SingleInstanceGuard(Func<int, bool> isProcessAlive)
+        : this(isProcessAlive, DefaultLockDirectory())
+    {
+    }
+
+    /// <summary>
+    /// Test-only constructor: lets callers inject the lock directory and the
+    /// process probe. Use this to point the guard at a temp folder instead
+    /// of the user's real <c>%APPDATA%/codex-provider-sync/singleton</c>.
+    /// </summary>
+    internal SingleInstanceGuard(Func<int, bool> isProcessAlive, string lockDirectory)
     {
         IsProcessAlive = isProcessAlive;
+        LockDirectory = lockDirectory;
     }
 
     internal Func<int, bool> IsProcessAlive { get; }
 
-    public string LockDirectory { get; } = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "codex-provider-sync",
-        "singleton");
+    public string LockDirectory { get; }
+
+    private static string DefaultLockDirectory()
+    {
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "codex-provider-sync",
+            "singleton");
+    }
 
     public SingleInstanceAcquisition Acquire(string label = "codex-provider-sync")
     {
@@ -147,7 +163,7 @@ public sealed class SingleInstanceGuard
     {
         return OperatingSystem.IsWindows()
             ? TryCreateDirectoryWindows(path)
-            : TryCreateDirectoryUnix(path);
+            : TryCreateDirectoryPosix(path);
     }
 
     internal static int TryCreateDirectoryWindows(string path)
@@ -155,17 +171,19 @@ public sealed class SingleInstanceGuard
         return CreateDirectory(path, IntPtr.Zero) ? 0 : Marshal.GetLastWin32Error();
     }
 
-    internal static int TryCreateDirectoryUnix(string path)
+    internal static int TryCreateDirectoryPosix(string path)
     {
-        if (Mkdir(path, 448) == 0)
+        // 448 = 0700 octal; only the owner needs to read/write/execute the
+        // singleton directory.
+        if (PosixMkdir(path, 448) == 0)
         {
             return 0;
         }
         int errorCode = Marshal.GetLastWin32Error();
         return errorCode switch
         {
-            17 => Win32ErrorAlreadyExists,
-            1 or 13 => Win32ErrorAccessDenied,
+            17 => Win32ErrorAlreadyExists,   // EEXIST
+            1 or 13 => Win32ErrorAccessDenied, // EPERM / EACCES
             _ => errorCode
         };
     }
@@ -173,8 +191,23 @@ public sealed class SingleInstanceGuard
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     private static extern bool CreateDirectory(string lpPathName, IntPtr lpSecurityAttributes);
 
-    [DllImport("libc", SetLastError = true, EntryPoint = "mkdir")]
-    private static extern int Mkdir(string pathname, uint mode);
+    // Linux: glibc ships mkdir in libc. macOS: the same symbol resolves
+    // through libSystem. Pin the EntryPoint and let the runtime pick the
+    // right library on each platform via the DllImportResolver. Without
+    // this, macOS hits an unresolved-symbol DllNotFoundException the
+    // moment we call into this path.
+    [DllImport("libc", EntryPoint = "mkdir", SetLastError = true)]
+    private static extern int LibcMkdir(string pathname, uint mode);
+
+    [DllImport("libSystem", EntryPoint = "mkdir", SetLastError = true)]
+    private static extern int LibSystemMkdir(string pathname, uint mode);
+
+    private static int PosixMkdir(string path, uint mode)
+    {
+        return OperatingSystem.IsMacOS()
+            ? LibSystemMkdir(path, mode)
+            : LibcMkdir(path, mode);
+    }
 
     private static bool IsTransientLockCreateError(int errorCode)
     {
@@ -194,11 +227,20 @@ public sealed class SingleInstanceGuard
         }
         catch (ArgumentException)
         {
+            // No process with that id.
             return false;
         }
         catch (InvalidOperationException)
         {
+            // The process has already exited by the time we touched it.
             return false;
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // On Linux the owner may belong to another user; we cannot
+            // query it, so treat it as "alive" to be safe and avoid
+            // stealing the lock out from under another user.
+            return true;
         }
     }
 }

--- a/desktop/CodexProviderSync.Core/SingleInstanceGuard.cs
+++ b/desktop/CodexProviderSync.Core/SingleInstanceGuard.cs
@@ -19,6 +19,8 @@ public sealed class SingleInstanceGuard
     private const int Win32ErrorAccessDenied = 5;
     private const int DefaultCreateRetryCount = 3;
     private const int DefaultCreateRetryDelayMs = 75;
+    private const int RaceWindowRetryCount = 20;
+    private const int RaceWindowRetryDelayMs = 25;
 
     private static readonly JsonSerializerOptions OwnerJsonOptions = new()
     {
@@ -64,7 +66,20 @@ public sealed class SingleInstanceGuard
 
     public SingleInstanceAcquisition Acquire(string label = "codex-provider-sync")
     {
-        Directory.CreateDirectory(LockDirectory);
+        // The lock directory itself is the contested resource, so it
+        // must be created atomically below. Only its parent path
+        // should be pre-created — using `Directory.CreateDirectory`
+        // on the lock directory here would silently succeed on the
+        // first launch, which then makes the atomic `TryCreateDirectory`
+        // always report `Win32ErrorAlreadyExists` and route the first
+        // caller into the stale-lock recovery branch. Two concurrent
+        // launches could then race deleting each other's lock dir and
+        // violate the single-instance guarantee.
+        string? parentDirectory = Path.GetDirectoryName(LockDirectory);
+        if (!string.IsNullOrEmpty(parentDirectory))
+        {
+            Directory.CreateDirectory(parentDirectory);
+        }
 
         int attempts = 0;
         while (true)
@@ -105,6 +120,43 @@ public sealed class SingleInstanceGuard
                     existingOwner: owner,
                     lockDirectory: LockDirectory,
                     guard: this);
+            }
+
+            // If the lock dir exists but `owner.json` is missing
+            // we have two possible cases:
+//   (a) race window — the winning process atomically created
+//       the lock dir but has not yet finished writing
+//       `owner.json`. Do NOT delete the directory here; that
+//       would race the winner's write and produce a
+//       stale-lock IOException in both processes. Back off
+//       briefly and let the winner finish.
+//   (b) stale leftover — the previous owner died (or crashed)
+//       and left behind arbitrary files (e.g., an unowned
+//       `BLOCK` file from an interrupted cleanup). The lock
+//       directory contains entries that are not `owner.json`,
+//       so we can safely delete and reclaim.
+// We disambiguate by checking the lock dir's contents: an
+// empty lock dir signals the race window; a non-empty lock
+// dir with no `owner.json` signals stale leftover. We give
+// the race-window case a much larger retry budget (20 × 25 ms
+// = 500 ms) than the default because the winner's write of a
+// few-KB JSON file under anti-virus / filesystem contention
+// can easily exceed a couple hundred milliseconds on Windows.
+if (owner is null)
+            {
+                bool lockDirHasLeftovers = HasLockDirLeftovers();
+                if (!lockDirHasLeftovers)
+                {
+                    attempts += 1;
+                    if (attempts >= RaceWindowRetryCount)
+                    {
+                        throw new IOException(
+                            $"Single-instance lock at {LockDirectory} exists but its owner metadata has not appeared yet. The owning process may be hung or under load.");
+                    }
+                    System.Threading.Thread.Sleep(RaceWindowRetryDelayMs);
+                    continue;
+                }
+                // Fall through to the stale-leftover delete branch.
             }
 
             // Stale lock (previous owner died or wrote no metadata). Best-effort
@@ -212,6 +264,43 @@ public sealed class SingleInstanceGuard
     private static bool IsTransientLockCreateError(int errorCode)
     {
         return errorCode == Win32ErrorAccessDenied;
+    }
+
+    // True when the lock directory exists, `owner.json` is not
+    // present, and there is at least one other entry inside the
+    // lock directory. Used to tell apart the "race window"
+    // (lock dir is empty, winner is mid-write) from the
+    // "stale leftover" (previous owner crashed and left
+    // arbitrary files behind) cases without trusting timing.
+    private bool HasLockDirLeftovers()
+    {
+        try
+        {
+            if (!Directory.Exists(LockDirectory))
+            {
+                return false;
+            }
+            foreach (string entry in Directory.EnumerateFileSystemEntries(LockDirectory))
+            {
+                string name = Path.GetFileName(entry);
+                if (!string.Equals(name, "owner.json", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+        catch (IOException)
+        {
+            // Treat unreadable lock dirs as "leftovers" so the
+            // caller can attempt the stale-delete branch rather
+            // than spinning in the race-window backoff.
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return true;
+        }
     }
 
     internal static bool StandardOwnerProbe(int processId)

--- a/desktop/CodexProviderSync.Core/SingleInstanceGuard.cs
+++ b/desktop/CodexProviderSync.Core/SingleInstanceGuard.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace CodexProviderSync.Core;
+
+/// <summary>
+/// Cross-platform single-instance guard. The first process to call
+/// <see cref="Acquire"/> owns the lock; subsequent callers get back a
+/// <see cref="SingleInstanceAcquisition"/> with <c>IsOwner == false</c> and
+/// the metadata of the existing owner so the caller can route a "focus"
+/// request to it.
+/// </summary>
+public sealed class SingleInstanceGuard
+{
+    private const int Win32ErrorAlreadyExists = 183;
+    private const int Win32ErrorAccessDenied = 5;
+    private const int DefaultCreateRetryCount = 3;
+    private const int DefaultCreateRetryDelayMs = 75;
+
+    private static readonly JsonSerializerOptions OwnerJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    public SingleInstanceGuard() : this(StandardOwnerProbe)
+    {
+    }
+
+    /// <summary>
+    /// Test-only constructor: lets callers inject a probe for "is this PID
+    /// still alive?" so unit tests do not depend on a real running process.
+    /// </summary>
+    internal SingleInstanceGuard(Func<int, bool> isProcessAlive)
+    {
+        IsProcessAlive = isProcessAlive;
+    }
+
+    internal Func<int, bool> IsProcessAlive { get; }
+
+    public string LockDirectory { get; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "codex-provider-sync",
+        "singleton");
+
+    public SingleInstanceAcquisition Acquire(string label = "codex-provider-sync")
+    {
+        Directory.CreateDirectory(LockDirectory);
+
+        int attempts = 0;
+        while (true)
+        {
+            int errorCode = TryCreateDirectory(LockDirectory);
+            if (errorCode == 0)
+            {
+                WriteOwnerMetadata(label);
+                return new SingleInstanceAcquisition(
+                    isOwner: true,
+                    existingOwner: null,
+                    lockDirectory: LockDirectory,
+                    guard: this);
+            }
+
+            if (errorCode != Win32ErrorAlreadyExists)
+            {
+                if (!IsTransientLockCreateError(errorCode) || attempts >= DefaultCreateRetryCount)
+                {
+                    throw new IOException(
+                        $"Unable to acquire single-instance lock at {LockDirectory}. Win32 error: {errorCode}");
+                }
+                attempts += 1;
+                System.Threading.Thread.Sleep(DefaultCreateRetryDelayMs);
+                continue;
+            }
+
+            // Lock directory already exists. Inspect the owner and either
+            // (a) refuse to start because the owner is still alive, or
+            // (b) clean up and retry if the previous owner has died.
+            SingleInstanceOwner? owner = ReadOwnerMetadata();
+            if (owner is not null
+                && owner.ProcessId != Environment.ProcessId
+                && IsProcessAlive(owner.ProcessId))
+            {
+                return new SingleInstanceAcquisition(
+                    isOwner: false,
+                    existingOwner: owner,
+                    lockDirectory: LockDirectory,
+                    guard: this);
+            }
+
+            // Stale lock (previous owner died or wrote no metadata). Best-effort
+            // cleanup; if the delete loses a race, the next iteration will retry.
+            try
+            {
+                Directory.Delete(LockDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+                attempts += 1;
+                if (attempts >= DefaultCreateRetryCount)
+                {
+                    throw new IOException(
+                        $"Single-instance lock at {LockDirectory} is held by a stale owner and could not be cleared. Remove the directory manually and retry.");
+                }
+                System.Threading.Thread.Sleep(DefaultCreateRetryDelayMs);
+            }
+        }
+    }
+
+    private void WriteOwnerMetadata(string label)
+    {
+        SingleInstanceOwner owner = new()
+        {
+            ProcessId = Environment.ProcessId,
+            StartedAt = DateTimeOffset.UtcNow,
+            Label = label,
+            CurrentDirectory = Environment.CurrentDirectory
+        };
+        File.WriteAllText(
+            Path.Combine(LockDirectory, "owner.json"),
+            JsonSerializer.Serialize(owner, OwnerJsonOptions));
+    }
+
+    internal SingleInstanceOwner? ReadOwnerMetadata()
+    {
+        string path = Path.Combine(LockDirectory, "owner.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+        try
+        {
+            string text = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<SingleInstanceOwner>(text, OwnerJsonOptions);
+        }
+        catch (Exception)
+        {
+            // Corrupt metadata; treat as no owner so the caller can decide.
+            return null;
+        }
+    }
+
+    internal static int TryCreateDirectory(string path)
+    {
+        return OperatingSystem.IsWindows()
+            ? TryCreateDirectoryWindows(path)
+            : TryCreateDirectoryUnix(path);
+    }
+
+    internal static int TryCreateDirectoryWindows(string path)
+    {
+        return CreateDirectory(path, IntPtr.Zero) ? 0 : Marshal.GetLastWin32Error();
+    }
+
+    internal static int TryCreateDirectoryUnix(string path)
+    {
+        if (Mkdir(path, 448) == 0)
+        {
+            return 0;
+        }
+        int errorCode = Marshal.GetLastWin32Error();
+        return errorCode switch
+        {
+            17 => Win32ErrorAlreadyExists,
+            1 or 13 => Win32ErrorAccessDenied,
+            _ => errorCode
+        };
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool CreateDirectory(string lpPathName, IntPtr lpSecurityAttributes);
+
+    [DllImport("libc", SetLastError = true, EntryPoint = "mkdir")]
+    private static extern int Mkdir(string pathname, uint mode);
+
+    private static bool IsTransientLockCreateError(int errorCode)
+    {
+        return errorCode == Win32ErrorAccessDenied;
+    }
+
+    internal static bool StandardOwnerProbe(int processId)
+    {
+        if (processId <= 0)
+        {
+            return false;
+        }
+        try
+        {
+            using Process probe = Process.GetProcessById(processId);
+            return !probe.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+}
+
+public sealed class SingleInstanceAcquisition : IDisposable
+{
+    private readonly SingleInstanceGuard _guard;
+    private bool _disposed;
+
+    internal SingleInstanceAcquisition(
+        bool isOwner,
+        SingleInstanceOwner? existingOwner,
+        string lockDirectory,
+        SingleInstanceGuard guard)
+    {
+        IsOwner = isOwner;
+        ExistingOwner = existingOwner;
+        LockDirectory = lockDirectory;
+        _guard = guard;
+    }
+
+    public bool IsOwner { get; }
+
+    public SingleInstanceOwner? ExistingOwner { get; }
+
+    public string LockDirectory { get; }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        if (IsOwner && Directory.Exists(LockDirectory))
+        {
+            try
+            {
+                Directory.Delete(LockDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup; the OS will release the directory on
+                // process exit anyway.
+            }
+        }
+    }
+}
+
+public sealed class SingleInstanceOwner
+{
+    public int ProcessId { get; set; }
+    public DateTimeOffset StartedAt { get; set; }
+    public string Label { get; set; } = string.Empty;
+    public string CurrentDirectory { get; set; } = string.Empty;
+}


### PR DESCRIPTION
CodexProviderSync.exe previously allowed arbitrarily many copies to launch. The first copy would not know it had company, the SQLite lock acquire would race, and the user ended up with N parallel sessions all trying to coordinate the same Codex history.

This change introduces a per-user single-instance guard:

- SingleInstanceGuard (Core, cross-platform):
  - Acquires %APPDATA%/codex-provider-sync/singleton via the same atomic CreateDirectory trick LockService already uses for the codex-home lock. The first caller becomes the owner; subsequent callers get a SingleInstanceAcquisition with IsOwner=false and the metadata of the existing owner.
  - Reads owner.json and probes the recorded PID via Process. If the owner is dead, the guard removes the stale lock and retries up to a small budget; only then does it throw.

- FocusRequestServer (App, Windows named pipe):
  - The owning instance binds to CodexProviderSync.Focus.<user>.
  - New launches detect they are not the owner, open a client pipe, write "FOCUS", and exit within 2 seconds.
  - The owning instance reads "FOCUS" on a background task and invokes MainForm.BringToFront (which restores from minimized, shows, activates, and re-asserts topmost).

- MainForm.BringToFront: new public method marshalled to the UI thread so the focus broker can call it from any thread.

- Program.cs: wires both pieces around the existing MainForm lifecycle. The existing try/catch startup-error path still applies if either step throws.

- Tests: SingleInstanceGuardTests covers owner/non-owner/stale-recovery using a custom probe so the suite does not depend on a real running process.

Files touched:
- desktop/CodexProviderSync.Core/SingleInstanceGuard.cs       (new)
- desktop/CodexProviderSync.Core.Tests/SingleInstanceGuardTests.cs (new)
- desktop/CodexProviderSync.App/FocusRequestServer.cs        (new)
- desktop/CodexProviderSync.App/Program.cs                   (rewrite Main)
- desktop/CodexProviderSync.App/MainForm.cs                  (add BringToFront)

Note: the project targets net10.0-windows and the local Windows box only has 6.0/8.0 runtimes (no SDK). I could not run dotnet test in this session; please build via Visual Studio or install the .NET 10 SDK before merging. All logic mirrors the existing LockService pattern so the risk is low.