### PR TITLE
Feat/csharp switch model and gui

### DIFF
--- a/desktop/CodexProviderSync.App/MainForm.cs
+++ b/desktop/CodexProviderSync.App/MainForm.cs
@@ -146,13 +146,16 @@ public sealed class MainForm : Form
     /// <summary>
     /// Brings the running form back to the foreground. Invoked by the
     /// single-instance focus broker when a second copy of CodexProviderSync
-    /// is launched and asks the first copy to take focus.
+    /// is launched and asks the first copy to take focus. We name it
+    /// `RequestBringToFront` rather than overriding `Form.BringToFront`
+    /// with the `new` keyword so we do not silently break if a future
+    /// .NET version changes the base signature or marks it virtual.
     /// </summary>
-    public new void BringToFront()
+    public void RequestBringToFront()
     {
         if (InvokeRequired)
         {
-            BeginInvoke(new Action(BringToFront));
+            BeginInvoke(new Action(RequestBringToFront));
             return;
         }
         if (WindowState == FormWindowState.Minimized)

--- a/desktop/CodexProviderSync.App/MainForm.cs
+++ b/desktop/CodexProviderSync.App/MainForm.cs
@@ -43,6 +43,30 @@ public sealed class MainForm : Form
         AutoSize = true,
         Margin = new Padding(0, 4, 8, 0)
     };
+    private readonly RadioButton _modelAutoRadio = new()
+    {
+        Text = "跟随 provider 里的 model (默认)",
+        AutoSize = true,
+        Checked = true,
+        Margin = new Padding(0, 2, 12, 2)
+    };
+    private readonly RadioButton _modelKeepRadio = new()
+    {
+        Text = "保留当前顶层 model",
+        AutoSize = true,
+        Margin = new Padding(0, 2, 12, 2)
+    };
+    private readonly RadioButton _modelCustomRadio = new()
+    {
+        Text = "自定义:",
+        AutoSize = true,
+        Margin = new Padding(0, 2, 6, 2)
+    };
+    private readonly TextBox _modelCustomText = new()
+    {
+        Width = 240,
+        Margin = new Padding(0, 0, 0, 2)
+    };
     private readonly CheckBox _restoreConfigCheck = new() { Text = "恢复配置文件（config.toml）", Checked = false, AutoSize = true };
     private readonly CheckBox _restoreDatabaseCheck = new() { Text = "恢复线程数据库（SQLite）", Checked = true, AutoSize = true };
     private readonly CheckBox _restoreSessionsCheck = new() { Text = "恢复会话文件元数据（rollout）", Checked = true, AutoSize = true };
@@ -331,7 +355,43 @@ public sealed class MainForm : Form
         panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
         panel.Controls.Add(_updateConfigCheck, 0, 0);
         panel.Controls.Add(_updateConfigLabel, 1, 0);
+
+        FlowLayoutPanel modelOptions = new()
+        {
+            FlowDirection = FlowDirection.LeftToRight,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Margin = new Padding(24, 0, 0, 0),
+            Dock = DockStyle.Fill
+        };
+        Label modelHeader = new()
+        {
+            Text = "顶层 model:",
+            AutoSize = true,
+            Margin = new Padding(0, 4, 8, 0)
+        };
+        modelOptions.Controls.Add(modelHeader);
+        modelOptions.Controls.Add(_modelAutoRadio);
+        modelOptions.Controls.Add(_modelKeepRadio);
+        modelOptions.Controls.Add(_modelCustomRadio);
+        modelOptions.Controls.Add(_modelCustomText);
+        panel.Controls.Add(modelOptions, 0, 1);
+        panel.SetColumnSpan(modelOptions, 2);
+
+        _modelAutoRadio.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
+        _modelKeepRadio.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
+        _modelCustomRadio.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
+        _updateConfigCheck.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
         return panel;
+    }
+
+    private void UpdateModelOptionsEnabled()
+    {
+        bool enabled = _updateConfigCheck.Checked;
+        _modelAutoRadio.Enabled = enabled;
+        _modelKeepRadio.Enabled = enabled;
+        _modelCustomRadio.Enabled = enabled;
+        _modelCustomText.Enabled = enabled && _modelCustomRadio.Checked;
     }
 
     private Control BuildWarningPanel()
@@ -565,14 +625,33 @@ public sealed class MainForm : Form
         {
             string codexHome = CurrentCodexHome();
             int backupRetentionCount = CurrentBackupRetentionCount();
-            SyncResult result = _updateConfigCheck.Checked
-                ? await Task.Run(async () => await _syncService.RunSwitchAsync(codexHome, provider, backupRetentionCount))
-                : await Task.Run(async () => await _syncService.RunSyncAsync(codexHome, provider: provider, keepCount: backupRetentionCount));
+            SyncResult result;
+            if (_updateConfigCheck.Checked)
+            {
+                bool keepRootModel = _modelKeepRadio.Checked;
+                string? explicitModel = _modelCustomRadio.Checked ? _modelCustomText.Text.Trim() : null;
+                if (_modelCustomRadio.Checked && string.IsNullOrEmpty(explicitModel))
+                {
+                    MessageBox.Show(this, "请填写自定义 model 名称,或改成 \"跟随 provider\"。", Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return;
+                }
+                result = await Task.Run(async () => await _syncService.RunSwitchAsync(
+                    codexHome,
+                    provider,
+                    backupRetentionCount,
+                    model: explicitModel,
+                    keepRootModel: keepRootModel));
+            }
+            else
+            {
+                result = await Task.Run(async () => await _syncService.RunSyncAsync(codexHome, provider: provider, keepCount: backupRetentionCount));
+            }
 
             _settings = _settingsService.UpdateState(_settings, provider, result.BackupDir, CaptureWindowBounds(), backupRetentionCount);
             await _settingsService.SaveAsync(_settings);
             AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] 执行完成");
             AppendLog(TextFormatter.FormatSyncResult(result, _updateConfigCheck.Checked ? "已切换并同步" : "已同步"));
+            AppendLog(FormatModelSyncOutcome(result.ModelSync));
             AppendLog(string.Empty);
             await RefreshStatusCoreAsync(codexHome);
             SelectProvider(provider);
@@ -871,6 +950,23 @@ public sealed class MainForm : Form
         _logBox.AppendText(message);
         _logBox.SelectionStart = _logBox.TextLength;
         _logBox.ScrollToCaret();
+    }
+
+    private static string FormatModelSyncOutcome(ModelSyncOutcome outcome)
+    {
+        if (outcome.Source == "not-applicable")
+        {
+            return string.Empty;
+        }
+        if (outcome.Applied)
+        {
+            return $"顶层 model: {outcome.Model} (来源: {outcome.Source})";
+        }
+        if (!string.IsNullOrEmpty(outcome.Warning))
+        {
+            return $"顶层 model: 未改写 ({outcome.Warning})";
+        }
+        return "顶层 model: 未改写 (已请求保留)";
     }
 
     private bool ConfirmCodexClosed(string message)

--- a/desktop/CodexProviderSync.App/MainForm.cs
+++ b/desktop/CodexProviderSync.App/MainForm.cs
@@ -382,6 +382,7 @@ public sealed class MainForm : Form
         _modelKeepRadio.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
         _modelCustomRadio.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
         _updateConfigCheck.CheckedChanged += (_, _) => UpdateModelOptionsEnabled();
+        UpdateModelOptionsEnabled();
         return panel;
     }
 

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -914,6 +914,99 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSync_RewritesPerThreadModelColumnFromConfig()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"MiniMax-M3\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-a", "openai");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-a", "openai", false)
+        ],
+            model: "gpt-5.4-mini");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(1, result.SqliteModelRowsUpdated);
+        await using SqliteConnection connection = new($"Data Source={fixture.StateDbPath()};Mode=ReadOnly;Pooling=False");
+        await connection.OpenAsync();
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT model, model_provider FROM threads WHERE id = 'thread-a'";
+        await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal("MiniMax-M3", reader.GetString(0));
+        Assert.Equal("openai", reader.GetString(1));
+    }
+
+    [Fact]
+    public async Task RunSync_LeavesPerThreadModelAlone_WhenNoRootModelConfigured()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-a", "openai");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-a", "openai", false)
+        ],
+            model: "gpt-5.4-mini");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(0, result.SqliteModelRowsUpdated);
+        await using SqliteConnection connection = new($"Data Source={fixture.StateDbPath()};Mode=ReadOnly;Pooling=False");
+        await connection.OpenAsync();
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT model FROM threads WHERE id = 'thread-a'";
+        Assert.Equal("gpt-5.4-mini", Convert.ToString(await command.ExecuteScalarAsync()));
+    }
+
+    [Fact]
+    public async Task RunSwitch_PropagatesNewModelToSqlitePerThreadColumn()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("""
+            model_provider = "openai"
+            model = "gpt-5.4"
+
+            [model_providers.apigather]
+            name = "apigather"
+            base_url = "https://example.com"
+            model = "MiniMax-M3"
+            """);
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-a", "openai");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-a", "openai", false)
+        ],
+            model: "gpt-5.4");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSwitchAsync(
+            fixture.CodexHome,
+            "apigather",
+            keepRootModel: false,
+            model: null);
+
+        Assert.True(result.ModelSync.Applied);
+        Assert.Equal("MiniMax-M3", result.ModelSync.Model);
+        Assert.Equal(1, result.SqliteModelRowsUpdated);
+
+        await using SqliteConnection connection = new($"Data Source={fixture.StateDbPath()};Mode=ReadOnly;Pooling=False");
+        await connection.OpenAsync();
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT model, model_provider FROM threads WHERE id = 'thread-a'";
+        await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal("MiniMax-M3", reader.GetString(0));
+        Assert.Equal("apigather", reader.GetString(1));
+    }
+
+    [Fact]
     public async Task Status_ReturnsMalformedSqliteAsUnreadable()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -1007,6 +1007,73 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSync_RewritesTurnContextModelFieldInRolloutFiles()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"MiniMax-M3\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutWithTurnContextAsync(sessionPath, "thread-a", "apigather", "gpt-5.4");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(1, result.ChangedSessionFiles);
+        string rewritten = await File.ReadAllTextAsync(sessionPath);
+        using StringReader reader = new(rewritten);
+        string? line;
+        int turnContextCount = 0;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+            {
+                continue;
+            }
+            using JsonDocument doc = JsonDocument.Parse(line);
+            string model = doc.RootElement.GetProperty("payload").GetProperty("model").GetString()!;
+            string collabModel = doc.RootElement
+                .GetProperty("payload")
+                .GetProperty("collaboration_mode")
+                .GetProperty("settings")
+                .GetProperty("model")
+                .GetString()!;
+            Assert.Equal("MiniMax-M3", model);
+            Assert.Equal("MiniMax-M3", collabModel);
+            turnContextCount += 1;
+        }
+        Assert.Equal(2, turnContextCount);
+    }
+
+    [Fact]
+    public async Task RunSync_LeavesTurnContextModelFieldAlone_WhenNoRootModelConfigured()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-a.jsonl");
+        await fixture.WriteRolloutWithTurnContextAsync(sessionPath, "thread-a", "apigather", "gpt-5.4");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(1, result.ChangedSessionFiles);
+        string rewritten = await File.ReadAllTextAsync(sessionPath);
+        using StringReader reader = new(rewritten);
+        string? line;
+        int turnContextCount = 0;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+            {
+                continue;
+            }
+            using JsonDocument doc = JsonDocument.Parse(line);
+            string model = doc.RootElement.GetProperty("payload").GetProperty("model").GetString()!;
+            Assert.Equal("gpt-5.4", model);
+            turnContextCount += 1;
+        }
+        Assert.Equal(2, turnContextCount);
+    }
+
+    [Fact]
     public async Task Status_ReturnsMalformedSqliteAsUnreadable()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -1120,4 +1120,118 @@ public sealed class CoreIntegrationTests
         Assert.Contains("model_provider = \"manual\"", await File.ReadAllTextAsync(Path.Combine(fixture.CodexHome, "config.toml")));
         Assert.Contains("\"model_provider\":\"manual\"", await File.ReadAllTextAsync(sessionPath));
     }
+
+    [Fact]
+    public async Task RunSync_RewritesTurnContextModelField_LinesLargerThan64KB()
+    {
+        // Regression guard for the long-line reader. Codex can pack a
+        // `developer_instructions` blob into a single `turn_context`
+        // payload, easily pushing the encoded JSON past 64 KB. The
+        // previous 64 KB scanner silently returned null for those
+        // files, so the rollout model rewrite was a no-op for
+        // sessions whose first turn was a long planning step.
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"MiniMax-M3\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-huge.jsonl");
+
+        await fixture.WriteRolloutWithTurnContextPayloadAsync(
+            sessionPath,
+            "thread-huge",
+            "apigather",
+            "gpt-5.4",
+            new Dictionary<string, object>
+            {
+                ["developer_instructions"] = new string('x', 150 * 1024)
+            });
+
+        string onDisk = await File.ReadAllTextAsync(sessionPath);
+        long longestLine = onDisk.Split('\n').Where(line => !string.IsNullOrEmpty(line)).Max(line => (long)line.Length);
+        Assert.True(longestLine > 64 * 1024, $"test setup: longest line should exceed 64 KB; got {longestLine}");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+        Assert.Equal(1, result.ChangedSessionFiles);
+
+        string rewritten = await File.ReadAllTextAsync(sessionPath);
+        int rewrittenCount = 0;
+        using (StringReader reader = new(rewritten))
+        {
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                using JsonDocument doc = JsonDocument.Parse(line);
+                Assert.Equal("MiniMax-M3", doc.RootElement.GetProperty("payload").GetProperty("model").GetString());
+                Assert.Equal("MiniMax-M3", doc.RootElement
+                    .GetProperty("payload")
+                    .GetProperty("collaboration_mode")
+                    .GetProperty("settings")
+                    .GetProperty("model")
+                    .GetString());
+                rewrittenCount += 1;
+            }
+        }
+
+        Assert.Equal(2, rewrittenCount);
+    }
+
+    [Fact]
+    public async Task RunSync_RewritesTurnContextModelField_WithRegexMetacharactersInModelName()
+    {
+        // Regression guard for regex escaping in the per-turn
+        // rewrite. A model name containing '.', '+', '*', '?', or
+        // '(' is a regex hazard: '.' is a regex any-char, '+' is a
+        // quantifier, and an unbalanced '{' would refuse to compile.
+        // The rewrite must match literally and not poison a decoy
+        // sibling whose pattern over-matches.
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"weird(target)+v2\"\n");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-rewrite.jsonl");
+        await fixture.WriteRolloutWithTurnContextAsync(sessionPath, "thread-rewrite", "apigather", "weird(target)+v2");
+        await File.AppendAllTextAsync(sessionPath, JsonSerializer.Serialize(new
+        {
+            timestamp = "2026-06-09T09:16:03.881Z",
+            type = "turn_context",
+            payload = new
+            {
+                turn_id = "decoy",
+                model = "weirdAtargetAv2"
+            }
+        }) + "\n");
+
+        CodexSyncService service = new();
+        SyncResult result = await service.RunSyncAsync(fixture.CodexHome);
+        Assert.Equal(1, result.ChangedSessionFiles);
+
+        string rewritten = await File.ReadAllTextAsync(sessionPath);
+        int totalContext = 0;
+        using (StringReader reader = new(rewritten))
+        {
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                totalContext += 1;
+                using JsonDocument doc = JsonDocument.Parse(line);
+                string turnId = doc.RootElement.GetProperty("payload").GetProperty("turn_id").GetString()!;
+                string model = doc.RootElement.GetProperty("payload").GetProperty("model").GetString()!;
+                if (turnId == "decoy")
+                {
+                    Assert.Equal("weirdAtargetAv2", model);
+                }
+                else
+                {
+                    Assert.Equal("weird(target)+v2", model);
+                }
+            }
+        }
+        Assert.Equal(3, totalContext);
+    }
 }

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -94,6 +94,70 @@ internal sealed class TestCodexHomeFixture
         await File.WriteAllTextAsync(filePath, $"{first}\n{second}\n");
     }
 
+    public async Task WriteRolloutWithTurnContextAsync(string filePath, string id, string provider, string model)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        object payload = new
+        {
+            id,
+            timestamp = "2026-06-09T09:16:03.878Z",
+            cwd = "C:\\AITemp",
+            source = "cli",
+            cli_version = "0.115.0",
+            model_provider = provider
+        };
+        string first = JsonSerializer.Serialize(new
+        {
+            timestamp = "2026-06-09T09:16:03.878Z",
+            type = "session_meta",
+            payload
+        });
+        string turnContext = JsonSerializer.Serialize(new
+        {
+            timestamp = "2026-06-09T09:16:03.880Z",
+            type = "turn_context",
+            payload = new
+            {
+                turn_id = "019eabaa-e391-7e21-89cd-e761b5dee114",
+                cwd = "C:\\AITemp",
+                current_date = "2026-06-09",
+                model,
+                collaboration_mode = new
+                {
+                    mode = "default",
+                    settings = new
+                    {
+                        model,
+                        reasoning_effort = "xhigh"
+                    }
+                }
+            }
+        });
+        string heartbeat = JsonSerializer.Serialize(new
+        {
+            timestamp = "2026-06-09T10:16:03.880Z",
+            type = "turn_context",
+            payload = new
+            {
+                turn_id = "019eabaa-e391-7e21-89cd-e761b5dee115",
+                cwd = "C:\\AITemp",
+                current_date = "2026-06-09",
+                model,
+                collaboration_mode = new
+                {
+                    mode = "default",
+                    settings = new
+                    {
+                        model,
+                        reasoning_effort = "xhigh"
+                    }
+                }
+            }
+        });
+
+        await File.WriteAllTextAsync(filePath, $"{first}\n{turnContext}\n{heartbeat}\n");
+    }
+
     public async Task AppendEncryptedContentAsync(string filePath)
     {
         await File.AppendAllTextAsync(filePath, "{\"type\":\"event_msg\",\"payload\":{\"encrypted_content\":\"gAAA\"}}\n");

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -96,6 +96,16 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteRolloutWithTurnContextAsync(string filePath, string id, string provider, string model)
     {
+        await WriteRolloutWithTurnContextPayloadAsync(filePath, id, provider, model, extraFields: null);
+    }
+
+    public async Task WriteRolloutWithTurnContextPayloadAsync(
+        string filePath,
+        string id,
+        string provider,
+        string model,
+        Dictionary<string, object>? extraFields)
+    {
         Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
         object payload = new
         {
@@ -112,26 +122,34 @@ internal sealed class TestCodexHomeFixture
             type = "session_meta",
             payload
         });
+        Dictionary<string, object> turnPayload = new()
+        {
+            ["turn_id"] = "019eabaa-e391-7e21-89cd-e761b5dee114",
+            ["cwd"] = "C:\\AITemp",
+            ["current_date"] = "2026-06-09",
+            ["model"] = model,
+            ["collaboration_mode"] = new
+            {
+                mode = "default",
+                settings = new
+                {
+                    model,
+                    reasoning_effort = "xhigh"
+                }
+            }
+        };
+        if (extraFields is not null)
+        {
+            foreach ((string key, object value) in extraFields)
+            {
+                turnPayload[key] = value;
+            }
+        }
         string turnContext = JsonSerializer.Serialize(new
         {
             timestamp = "2026-06-09T09:16:03.880Z",
             type = "turn_context",
-            payload = new
-            {
-                turn_id = "019eabaa-e391-7e21-89cd-e761b5dee114",
-                cwd = "C:\\AITemp",
-                current_date = "2026-06-09",
-                model,
-                collaboration_mode = new
-                {
-                    mode = "default",
-                    settings = new
-                    {
-                        model,
-                        reasoning_effort = "xhigh"
-                    }
-                }
-            }
+            payload = turnPayload
         });
         string heartbeat = JsonSerializer.Serialize(new
         {

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -136,15 +136,20 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
     {
-        await WriteStateDbAtAsync(StateDbPath(), rows);
+        await WriteStateDbAtAsync(StateDbPath(), rows, model: null);
+    }
+
+    public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows, string? model)
+    {
+        await WriteStateDbAtAsync(StateDbPath(), rows, model: model);
     }
 
     public async Task WriteLegacyStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
     {
-        await WriteStateDbAtAsync(LegacyStateDbPath(), rows);
+        await WriteStateDbAtAsync(LegacyStateDbPath(), rows, model: null);
     }
 
-    private static async Task WriteStateDbAtAsync(string dbPath, IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
+    public async Task WriteStateDbAtAsync(string dbPath, IEnumerable<(string Id, string ModelProvider, bool Archived)> rows, string? model)
     {
         await using SqliteConnection connection = OpenSqliteConnection(dbPath);
         await connection.OpenAsync();
@@ -155,7 +160,8 @@ internal sealed class TestCodexHomeFixture
               model_provider TEXT,
               cwd TEXT NOT NULL DEFAULT '',
               archived INTEGER NOT NULL DEFAULT 0,
-              first_user_message TEXT NOT NULL DEFAULT ''
+              first_user_message TEXT NOT NULL DEFAULT '',
+              model TEXT
             )
             """;
         await create.ExecuteNonQueryAsync();
@@ -164,12 +170,13 @@ internal sealed class TestCodexHomeFixture
         {
             SqliteCommand insert = connection.CreateCommand();
             insert.CommandText = """
-                INSERT INTO threads (id, model_provider, cwd, archived, first_user_message)
-                VALUES ($id, $provider, 'C:\AITemp', $archived, 'hello')
+                INSERT INTO threads (id, model_provider, cwd, archived, first_user_message, model)
+                VALUES ($id, $provider, 'C:\AITemp', $archived, 'hello', $model)
                 """;
             insert.Parameters.AddWithValue("$id", id);
             insert.Parameters.AddWithValue("$provider", modelProvider);
             insert.Parameters.AddWithValue("$archived", archived ? 1 : 0);
+            insert.Parameters.AddWithValue("$model", (object?)model ?? DBNull.Value);
             await insert.ExecuteNonQueryAsync();
         }
     }

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -238,7 +238,9 @@ public sealed class CodexSyncService
     public async Task<SyncResult> RunSwitchAsync(
         string? explicitCodexHome,
         string provider,
-        int keepCount = AppConstants.DefaultBackupRetentionCount)
+        int keepCount = AppConstants.DefaultBackupRetentionCount,
+        string? model = null,
+        bool keepRootModel = false)
     {
         if (string.IsNullOrWhiteSpace(provider))
         {
@@ -257,6 +259,12 @@ public sealed class CodexSyncService
         }
 
         string nextConfigText = _configFileService.SetRootProviderInConfigText(originalConfigText, provider);
+        ModelSyncOutcome modelSync = ResolveModelSyncOutcome(originalConfigText, provider, model, keepRootModel);
+        if (modelSync.Applied)
+        {
+            nextConfigText = _configFileService.SetRootModelInConfigText(nextConfigText, modelSync.Model!);
+        }
+
         await _configFileService.WriteConfigTextAsync(configPath, nextConfigText);
 
         try
@@ -282,6 +290,7 @@ public sealed class CodexSyncService
                 EncryptedContentCounts = result.EncryptedContentCounts,
                 EncryptedContentWarning = result.EncryptedContentWarning,
                 ConfigUpdated = true,
+                ModelSync = modelSync,
                 AutoPruneResult = result.AutoPruneResult,
                 AutoPruneWarning = result.AutoPruneWarning
             };
@@ -291,6 +300,44 @@ public sealed class CodexSyncService
             await _configFileService.WriteConfigTextAsync(configPath, originalConfigText);
             throw;
         }
+    }
+
+    private static ModelSyncOutcome ResolveModelSyncOutcome(
+        string originalConfigText,
+        string provider,
+        string? model,
+        bool keepRootModel)
+    {
+        if (model is not null)
+        {
+            if (model.Length == 0)
+            {
+                throw new ArgumentException(
+                    "Invalid --model value. Expected a non-empty string.",
+                    nameof(model));
+            }
+            return ModelSyncOutcome.CreateApplied("explicit", model);
+        }
+
+        if (keepRootModel)
+        {
+            return ModelSyncOutcome.CreateSkipped("keep-root-model", warning: null);
+        }
+
+        string? providerModel = new ConfigFileService().ReadProviderModel(originalConfigText, provider);
+        if (providerModel is not null)
+        {
+            return ModelSyncOutcome.CreateApplied("provider-section", providerModel);
+        }
+
+        if (!string.Equals(provider, AppConstants.DefaultProvider, StringComparison.Ordinal))
+        {
+            return ModelSyncOutcome.CreateSkipped(
+                "none",
+                warning: $"Provider \"{provider}\" has no model field in [model_providers.{provider}]; root-level model left unchanged. Use --model <name> to set it explicitly, or pass keepRootModel to suppress this warning.");
+        }
+
+        return ModelSyncOutcome.CreateSkipped("none", warning: null);
     }
 
     public async Task<RestoreResult> RunRestoreAsync(string? explicitCodexHome, string backupDir)

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -97,7 +97,8 @@ public sealed class CodexSyncService
         string? provider = null,
         string? configBackupText = null,
         int keepCount = AppConstants.DefaultBackupRetentionCount,
-        int? sqliteBusyTimeoutMs = null)
+        int? sqliteBusyTimeoutMs = null,
+        string? model = null)
     {
         if (keepCount < 1)
         {
@@ -110,6 +111,17 @@ public sealed class CodexSyncService
         string configText = await _configFileService.ReadConfigTextAsync(configPath);
         CurrentProviderInfo current = _configFileService.ReadCurrentProviderFromConfigText(configText);
         string targetProvider = provider ?? current.Provider ?? AppConstants.DefaultProvider;
+
+        // When the caller did not pin a model, mirror the active root-level
+        // `model = "..."` field from config.toml into the per-thread SQLite
+        // `model` column. Without this, old sessions keep showing the model
+        // they were created with in Codex's bottom-right UI label, even after
+        // the root-level `model` changes.
+        string? targetModel = model;
+        if (string.IsNullOrEmpty(targetModel))
+        {
+            targetModel = _configFileService.ReadRootModelFromConfigText(configText);
+        }
 
         await using LockHandle _ = await _lockService.AcquireLockAsync(codexHome, "sync");
 
@@ -141,9 +153,10 @@ public sealed class CodexSyncService
         try
         {
             SessionApplyResult? applyResult = null;
-            (int updatedRows, int providerRowsUpdated, int userEventRowsUpdated, int cwdRowsUpdated, bool databasePresent) = await _sqliteStateService.UpdateSqliteProviderAsync(
+            (int updatedRows, int providerRowsUpdated, int modelRowsUpdated, int userEventRowsUpdated, int cwdRowsUpdated, bool databasePresent) = await _sqliteStateService.UpdateSqliteProviderAsync(
                 codexHome,
                 targetProvider,
+                targetModel,
                 async _ =>
                 {
                     if (writableChanges.Count > 0)
@@ -186,6 +199,7 @@ public sealed class CodexSyncService
                 SkippedUnreadableRolloutFiles = skippedUnreadableRolloutFiles,
                 SqliteRowsUpdated = updatedRows,
                 SqliteProviderRowsUpdated = providerRowsUpdated,
+                SqliteModelRowsUpdated = modelRowsUpdated,
                 SqliteUserEventRowsUpdated = userEventRowsUpdated,
                 SqliteCwdRowsUpdated = cwdRowsUpdated,
                 UpdatedWorkspaceRoots = workspaceRootResult.UpdatedWorkspaceRoots,
@@ -269,7 +283,12 @@ public sealed class CodexSyncService
 
         try
         {
-            SyncResult result = await RunSyncAsync(codexHome, provider, originalConfigText, keepCount);
+            // Forward the resolved model to RunSyncAsync so the per-thread
+            // SQLite `model` column also gets aligned with the new value. If
+            // the switch did not apply a model (keepRootModel, no model
+            // found, etc.), pass null so the legacy behaviour is preserved.
+            string? modelForThreads = modelSync.Applied ? modelSync.Model : null;
+            SyncResult result = await RunSyncAsync(codexHome, provider, originalConfigText, keepCount, model: modelForThreads);
             return new SyncResult
             {
                 CodexHome = result.CodexHome,
@@ -281,6 +300,7 @@ public sealed class CodexSyncService
                 SkippedUnreadableRolloutFiles = result.SkippedUnreadableRolloutFiles,
                 SqliteRowsUpdated = result.SqliteRowsUpdated,
                 SqliteProviderRowsUpdated = result.SqliteProviderRowsUpdated,
+                SqliteModelRowsUpdated = result.SqliteModelRowsUpdated,
                 SqliteUserEventRowsUpdated = result.SqliteUserEventRowsUpdated,
                 SqliteCwdRowsUpdated = result.SqliteCwdRowsUpdated,
                 UpdatedWorkspaceRoots = result.UpdatedWorkspaceRoots,

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -161,7 +161,7 @@ public sealed class CodexSyncService
                 {
                     if (writableChanges.Count > 0)
                     {
-                        applyResult = await _sessionRolloutService.ApplySessionChangesAsync(writableChanges);
+                        applyResult = await _sessionRolloutService.ApplySessionChangesAsync(writableChanges, targetModel);
                         HashSet<string> appliedPathSet = new(applyResult.AppliedPaths, StringComparer.Ordinal);
                         appliedSessionChanges = writableChanges.Where(change => appliedPathSet.Contains(change.Path)).ToList();
                         sessionRestoreNeeded = appliedSessionChanges.Count > 0;

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -322,7 +322,7 @@ public sealed class CodexSyncService
         }
     }
 
-    private static ModelSyncOutcome ResolveModelSyncOutcome(
+    private ModelSyncOutcome ResolveModelSyncOutcome(
         string originalConfigText,
         string provider,
         string? model,
@@ -344,7 +344,7 @@ public sealed class CodexSyncService
             return ModelSyncOutcome.CreateSkipped("keep-root-model", warning: null);
         }
 
-        string? providerModel = new ConfigFileService().ReadProviderModel(originalConfigText, provider);
+        string? providerModel = _configFileService.ReadProviderModel(originalConfigText, provider);
         if (providerModel is not null)
         {
             return ModelSyncOutcome.CreateApplied("provider-section", providerModel);

--- a/desktop/CodexProviderSync.Core/ConfigFileService.cs
+++ b/desktop/CodexProviderSync.Core/ConfigFileService.cs
@@ -69,6 +69,48 @@ public sealed partial class ConfigFileService
         return ListConfiguredProviderIds(configText).Contains(provider, StringComparer.Ordinal);
     }
 
+    public string? ReadRootModelFromConfigText(string configText)
+    {
+        if (string.IsNullOrEmpty(configText))
+        {
+            return null;
+        }
+
+        // The root-level `model` field lives in the preamble before any
+        // [table] header. We scan line-by-line, stop at the first [section],
+        // and return the value of `model = "..."` if present. This mirrors
+        // the JS side's `^\s*model\s*=\s*"([^"]+)"\s*$/m` walk, and is what
+        // Sync uses to mirror the active model into the per-thread SQLite
+        // `model` column. Commented-out lines (starting with `#`) and blank
+        // lines are skipped, matching the JS behavior.
+        foreach (string raw in SplitLines(configText))
+        {
+            string line = raw.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            if (line.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (line.StartsWith('['))
+            {
+                break;
+            }
+
+            Match match = ModelAssignmentRegex().Match(line);
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+
+        return null;
+    }
+
     public string SetRootProviderInConfigText(string configText, string provider)
     {
         string newline = DetectNewline(configText);

--- a/desktop/CodexProviderSync.Core/ConfigFileService.cs
+++ b/desktop/CodexProviderSync.Core/ConfigFileService.cs
@@ -11,6 +11,9 @@ public sealed partial class ConfigFileService
     [GeneratedRegex("""^\[model_providers\.([A-Za-z0-9_.-]+)]\s*$""", RegexOptions.Multiline)]
     private static partial Regex ProviderRegex();
 
+    [GeneratedRegex("""^\s*model\s*=\s*"([^"]+)"\s*$""")]
+    private static partial Regex ModelAssignmentRegex();
+
     public Task<string> ReadConfigTextAsync(string configPath)
     {
         return File.ReadAllTextAsync(configPath);
@@ -149,25 +152,23 @@ public sealed partial class ConfigFileService
             return null;
         }
 
-        string? sectionStart = null;
+        List<string> lines = SplitLines(configText).ToList();
+        string sectionHeader = $"[model_providers.{Regex.Escape(provider)}]";
         int sectionStartIndex = -1;
-        for (int index = 0; index < SplitLines(configText).Count(); index += 1)
+        for (int index = 0; index < lines.Count; index += 1)
         {
-            string trimmed = SplitLines(configText).ElementAt(index).Trim();
-            if (trimmed.Equals($"[model_providers.{provider}]", StringComparison.Ordinal))
+            if (lines[index].Trim().Equals(sectionHeader, StringComparison.Ordinal))
             {
-                sectionStart = $"[model_providers.{provider}]";
                 sectionStartIndex = index;
                 break;
             }
         }
 
-        if (sectionStart is null)
+        if (sectionStartIndex < 0)
         {
             return null;
         }
 
-        List<string> lines = SplitLines(configText).ToList();
         for (int index = sectionStartIndex + 1; index < lines.Count; index += 1)
         {
             string trimmed = lines[index].Trim();
@@ -175,7 +176,7 @@ public sealed partial class ConfigFileService
             {
                 break;
             }
-            Match match = Regex.Match(lines[index], "^\\s*model\\s*=\\s*\"([^\"]+)\"\\s*$");
+            Match match = ModelAssignmentRegex().Match(lines[index]);
             if (match.Success)
             {
                 return match.Groups[1].Value;

--- a/desktop/CodexProviderSync.Core/ConfigFileService.cs
+++ b/desktop/CodexProviderSync.Core/ConfigFileService.cs
@@ -101,6 +101,90 @@ public sealed partial class ConfigFileService
         return configText.EndsWith(newline, StringComparison.Ordinal) ? nextText + newline : nextText;
     }
 
+    public string SetRootModelInConfigText(string configText, string model)
+    {
+        if (string.IsNullOrEmpty(model))
+        {
+            throw new ArgumentException("Model must be a non-empty string.", nameof(model));
+        }
+
+        string newline = DetectNewline(configText);
+        List<string> lines = SplitLines(configText).ToList();
+        int insertIndex = lines.Count;
+
+        for (int index = 0; index < lines.Count; index += 1)
+        {
+            string trimmed = lines[index].Trim();
+            if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith('#'))
+            {
+                insertIndex = index + 1;
+                continue;
+            }
+
+            if (trimmed.StartsWith('['))
+            {
+                insertIndex = index;
+                break;
+            }
+
+            if (trimmed.StartsWith("model =", StringComparison.Ordinal))
+            {
+                lines[index] = $"model = \"{EscapeTomlString(model)}\"";
+                return string.Join(newline, lines) + (configText.EndsWith(newline, StringComparison.Ordinal) ? newline : string.Empty);
+            }
+
+            insertIndex = index + 1;
+        }
+
+        lines.Insert(insertIndex, $"model = \"{EscapeTomlString(model)}\"");
+        string nextText = string.Join(newline, lines);
+        return configText.EndsWith(newline, StringComparison.Ordinal) ? nextText + newline : nextText;
+    }
+
+    public string? ReadProviderModel(string configText, string provider)
+    {
+        if (string.Equals(provider, AppConstants.DefaultProvider, StringComparison.Ordinal))
+        {
+            // Built-in openai has no [model_providers.openai] section.
+            return null;
+        }
+
+        string? sectionStart = null;
+        int sectionStartIndex = -1;
+        for (int index = 0; index < SplitLines(configText).Count(); index += 1)
+        {
+            string trimmed = SplitLines(configText).ElementAt(index).Trim();
+            if (trimmed.Equals($"[model_providers.{provider}]", StringComparison.Ordinal))
+            {
+                sectionStart = $"[model_providers.{provider}]";
+                sectionStartIndex = index;
+                break;
+            }
+        }
+
+        if (sectionStart is null)
+        {
+            return null;
+        }
+
+        List<string> lines = SplitLines(configText).ToList();
+        for (int index = sectionStartIndex + 1; index < lines.Count; index += 1)
+        {
+            string trimmed = lines[index].Trim();
+            if (trimmed.StartsWith('['))
+            {
+                break;
+            }
+            Match match = Regex.Match(lines[index], "^\\s*model\\s*=\\s*\"([^\"]+)\"\\s*$");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+
+        return null;
+    }
+
     private static IEnumerable<string> SplitLines(string text)
     {
         return text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');

--- a/desktop/CodexProviderSync.Core/Models.cs
+++ b/desktop/CodexProviderSync.Core/Models.cs
@@ -101,6 +101,7 @@ public sealed class SyncResult
     public required IReadOnlyList<string> SkippedUnreadableRolloutFiles { get; init; }
     public required int SqliteRowsUpdated { get; init; }
     public int SqliteProviderRowsUpdated { get; init; }
+    public int SqliteModelRowsUpdated { get; init; }
     public int SqliteUserEventRowsUpdated { get; init; }
     public int SqliteCwdRowsUpdated { get; init; }
     public int UpdatedWorkspaceRoots { get; init; }

--- a/desktop/CodexProviderSync.Core/Models.cs
+++ b/desktop/CodexProviderSync.Core/Models.cs
@@ -76,6 +76,15 @@ public sealed class SessionChange
     public required long OriginalFileLength { get; init; }
     public required long OriginalLastWriteTimeUtcTicks { get; init; }
     public required string OriginalProvider { get; init; }
+    // The model that the rollout's first `turn_context` event
+    // currently advertises. Used by the rewrite pass to know which
+    // value to swap out across every turn_context line in the file
+    // so that the Codex GUI bottom-right of an old conversation
+    // reflects the active provider's model. Null when the rollout
+    // does not expose a model field we recognise (e.g. legacy or
+    // unusually formatted files), in which case the model rewrite
+    // pass is a no-op.
+    public string? OriginalModel { get; init; }
     public required string UpdatedFirstLine { get; init; }
 }
 

--- a/desktop/CodexProviderSync.Core/Models.cs
+++ b/desktop/CodexProviderSync.Core/Models.cs
@@ -110,8 +110,37 @@ public sealed class SyncResult
     public required ProviderCounts EncryptedContentCounts { get; init; }
     public string? EncryptedContentWarning { get; init; }
     public bool ConfigUpdated { get; init; }
+    public ModelSyncOutcome ModelSync { get; init; } = ModelSyncOutcome.NotApplicable();
     public BackupPruneResult? AutoPruneResult { get; init; }
     public string? AutoPruneWarning { get; init; }
+}
+
+public sealed class ModelSyncOutcome
+{
+    public required bool Applied { get; init; }
+    public string Source { get; init; } = "none";
+    public string? Model { get; init; }
+    public string? Warning { get; init; }
+
+    public static ModelSyncOutcome CreateApplied(string source, string model) => new()
+    {
+        Applied = true,
+        Source = source,
+        Model = model
+    };
+
+    public static ModelSyncOutcome CreateSkipped(string source, string? warning) => new()
+    {
+        Applied = false,
+        Source = source,
+        Warning = warning
+    };
+
+    public static ModelSyncOutcome NotApplicable() => new()
+    {
+        Applied = false,
+        Source = "not-applicable"
+    };
 }
 
 public sealed class SessionApplyResult

--- a/desktop/CodexProviderSync.Core/SessionRolloutService.cs
+++ b/desktop/CodexProviderSync.Core/SessionRolloutService.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace CodexProviderSync.Core;
@@ -97,6 +98,12 @@ public sealed class SessionRolloutService
                 {
                     FileSnapshot snapshot = GetFileSnapshot(rolloutPath);
                     payload["model_provider"] = targetProvider;
+                    // Peek at the first turn_context event in the rollout
+                    // to capture the per-turn `model` field that the
+                    // Codex GUI bottom-right of an old conversation
+                    // reads. This is the value the model rewrite pass
+                    // will swap to the active root-level model.
+                    string? originalModel = await ReadFirstTurnContextModelAsync(rolloutPath, record);
                     changes.Add(new SessionChange
                     {
                         Path = rolloutPath,
@@ -108,6 +115,7 @@ public sealed class SessionRolloutService
                         OriginalFileLength = snapshot.Length,
                         OriginalLastWriteTimeUtcTicks = snapshot.LastWriteTimeUtcTicks,
                         OriginalProvider = currentProvider,
+                        OriginalModel = originalModel,
                         UpdatedFirstLine = root!.ToJsonString()
                     });
                 }
@@ -134,7 +142,9 @@ public sealed class SessionRolloutService
         };
     }
 
-    public async Task<SessionApplyResult> ApplySessionChangesAsync(IEnumerable<SessionChange> changes)
+    public async Task<SessionApplyResult> ApplySessionChangesAsync(
+        IEnumerable<SessionChange> changes,
+        string? targetModel = null)
     {
         int appliedCount = 0;
         List<string> appliedPaths = [];
@@ -147,6 +157,16 @@ public sealed class SessionRolloutService
                 TryRestoreLastWriteTimeUtc(change.Path, change.OriginalLastWriteTimeUtcTicks);
                 appliedCount += 1;
                 appliedPaths.Add(change.Path);
+                // After the first-line rewrite succeeds, do a
+                // second pass that updates the per-turn `model`
+                // field in every turn_context event of the file.
+                // The Codex GUI bottom-right of an old conversation
+                // reads that field, so we have to keep it in sync
+                // with the active root-level model.
+                if (!string.IsNullOrEmpty(targetModel))
+                {
+                    await TryRewriteRolloutModelFieldAsync(change, targetModel);
+                }
             }
             else
             {
@@ -378,6 +398,210 @@ public sealed class SessionRolloutService
         {
             ArrayPool<byte>.Shared.Return(buffer);
         }
+    }
+
+    // Scan the start of a rollout file looking for the first
+    // `turn_context` event and return its `payload.model` field.
+    // This is the field that the Codex GUI bottom-right of an old
+    // conversation reads, so we have to capture it here and rewrite
+    // it (along with `payload.collaboration_mode.settings.model`)
+    // on every sync, in addition to the per-thread SQLite `model`
+    // column. We peek at the first 64 KB only — the first
+    // `turn_context` after the leading `session_meta` line is
+    // enough to know what model the rest of the file uses.
+    private static async Task<string?> ReadFirstTurnContextModelAsync(
+        string rolloutPath,
+        FirstLineRecord record)
+    {
+        try
+        {
+            await using FileStream stream = new(
+                rolloutPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            stream.Seek(record.Offset, SeekOrigin.Begin);
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
+            try
+            {
+                int bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length));
+                if (bytesRead == 0)
+                {
+                    return null;
+                }
+
+                string text = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                using StringReader reader = new(text);
+                string? line;
+                while ((line = reader.ReadLine()) is not null)
+                {
+                    if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        JsonNode? node = JsonNode.Parse(line);
+                        if (node is null)
+                        {
+                            continue;
+                        }
+
+                        string? type = node["type"]?.GetValue<string>();
+                        if (!string.Equals(type, "turn_context", StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+
+                        string? model = node["payload"]?["model"]?.GetValue<string>();
+                        if (!string.IsNullOrEmpty(model))
+                        {
+                            return model;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Skip malformed lines and keep scanning.
+                    }
+                }
+                return null;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+        catch (Exception error) when (IsRolloutFileBusyError(error))
+        {
+            throw WrapRolloutFileBusyError(error, rolloutPath, "read");
+        }
+    }
+
+    // Rewrite the per-turn `model` field in every `turn_context`
+    // event of the rollout. The Codex GUI bottom-right of an old
+    // conversation reads that field, so we have to keep it aligned
+    // with the active root-level model. We do a line-by-line
+    // regex rewrite instead of round-tripping the JSON tree to
+    // avoid mangling the multi-megabyte `developer_instructions`
+    // blob Codex writes into every `turn_context`.
+    private async Task TryRewriteRolloutModelFieldAsync(SessionChange change, string targetModel)
+    {
+        if (string.IsNullOrEmpty(change.OriginalModel))
+        {
+            return;
+        }
+        if (string.IsNullOrEmpty(targetModel))
+        {
+            return;
+        }
+        if (string.Equals(change.OriginalModel, targetModel, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Snapshot the file as it stands after the first-line
+        // rewrite. We cannot compare against `change.OriginalFileLength`
+        // because the first-line rewrite already changed the size
+        // (the new first line is often a different length than the
+        // original one).
+        FileInfo beforeInfo = new(change.Path);
+        long beforeSize = beforeInfo.Length;
+        DateTime beforeMtimeUtc = beforeInfo.LastWriteTimeUtc;
+
+        string tempPath = $"{change.Path}.provider-sync-model.{Environment.ProcessId}.{DateTime.UtcNow.Ticks}.{Guid.NewGuid():N}.tmp";
+        // If a previous run left a leftover at the same path (which
+        // shouldn't normally happen because of the Guid suffix, but
+        // can occur when tests share a process and timestamps
+        // collide), clean it up before opening.
+        if (File.Exists(tempPath))
+        {
+            File.Delete(tempPath);
+        }
+
+        bool replacements = false;
+        try
+        {
+            await using (FileStream sourceStream = OpenExclusiveRewriteStream(change.Path))
+            {
+                await using FileStream writeStream = new(
+                    tempPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None);
+                await using StreamWriter writer = new(writeStream, new UTF8Encoding(false));
+                using StreamReader reader = new(sourceStream, Encoding.UTF8, false, 64 * 1024, leaveOpen: true);
+                bool firstLine = true;
+                string? line;
+                while ((line = await reader.ReadLineAsync()) is not null)
+                {
+                    string next = firstLine
+                        ? line
+                        : RewriteTurnContextModelInLine(line, change.OriginalModel!, targetModel);
+                    if (!string.Equals(next, line, StringComparison.Ordinal))
+                    {
+                        replacements = true;
+                    }
+                    if (!firstLine)
+                    {
+                        await writer.WriteAsync('\n');
+                    }
+                    firstLine = false;
+                    await writer.WriteAsync(next);
+                }
+            }
+
+            if (!replacements)
+            {
+                File.Delete(tempPath);
+                return;
+            }
+
+            // Refuse to swap in the new file if Codex appended
+            // anything between our snapshot and the rename, so we
+            // do not silently drop trailing events.
+            FileInfo afterInfo = new(change.Path);
+            if (afterInfo.Length != beforeSize || afterInfo.LastWriteTimeUtc != beforeMtimeUtc)
+            {
+                File.Delete(tempPath);
+                return;
+            }
+
+            File.Move(tempPath, change.Path, overwrite: true);
+        }
+        catch (Exception error)
+        {
+            try
+            {
+                File.Delete(tempPath);
+            }
+            catch
+            {
+                // Ignore cleanup failures and surface the original error.
+            }
+            throw WrapRolloutFileBusyError(error, change.Path, "rewrite model field");
+        }
+    }
+
+    private static string RewriteTurnContextModelInLine(string line, string oldModel, string newModel)
+    {
+        if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+        {
+            return line;
+        }
+        string escapedOld = EscapeForJsonString(oldModel);
+        string escapedNew = EscapeForJsonString(newModel);
+        return System.Text.RegularExpressions.Regex.Replace(
+            line,
+            "\"model\"\\s*:\\s*\"" + escapedOld + "\"",
+            m => "\"model\":\"" + escapedNew + "\"");
+    }
+
+    private static string EscapeForJsonString(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
     }
 
     private static async Task RewriteFirstLineAsync(

--- a/desktop/CodexProviderSync.Core/SessionRolloutService.cs
+++ b/desktop/CodexProviderSync.Core/SessionRolloutService.cs
@@ -406,7 +406,13 @@ public sealed class SessionRolloutService
     // conversation reads, so we have to capture it here and rewrite
     // it (along with `payload.collaboration_mode.settings.model`)
     // on every sync, in addition to the per-thread SQLite `model`
-    // column. We peek at the first 64 KB only — the first
+    // column. We stream line-by-line because individual
+    // `turn_context` lines can easily exceed 64 KB once Codex
+    // embeds a `developer_instructions` blob into the payload — the
+    // previous 64 KB scanner silently missed those, which made the
+    // rollout model rewrite a no-op for sessions whose first turn
+    // was a long planning step. We stop as soon as we find a
+    // matching line.
     // `turn_context` after the leading `session_meta` line is
     // enough to know what model the rest of the file uses.
     private static async Task<string?> ReadFirstTurnContextModelAsync(
@@ -421,56 +427,41 @@ public sealed class SessionRolloutService
                 FileAccess.Read,
                 FileShare.ReadWrite | FileShare.Delete);
             stream.Seek(record.Offset, SeekOrigin.Begin);
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
-            try
+            using StreamReader reader = new(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 4096, leaveOpen: true);
+            string? line;
+            while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
             {
-                int bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length));
-                if (bytesRead == 0)
+                if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
                 {
-                    return null;
+                    continue;
                 }
 
-                string text = Encoding.UTF8.GetString(buffer, 0, bytesRead);
-                using StringReader reader = new(text);
-                string? line;
-                while ((line = reader.ReadLine()) is not null)
+                try
                 {
-                    if (!line.Contains("\"turn_context\"", StringComparison.Ordinal))
+                    JsonNode? node = JsonNode.Parse(line);
+                    if (node is null)
                     {
                         continue;
                     }
 
-                    try
+                    string? type = node["type"]?.GetValue<string>();
+                    if (!string.Equals(type, "turn_context", StringComparison.Ordinal))
                     {
-                        JsonNode? node = JsonNode.Parse(line);
-                        if (node is null)
-                        {
-                            continue;
-                        }
-
-                        string? type = node["type"]?.GetValue<string>();
-                        if (!string.Equals(type, "turn_context", StringComparison.Ordinal))
-                        {
-                            continue;
-                        }
-
-                        string? model = node["payload"]?["model"]?.GetValue<string>();
-                        if (!string.IsNullOrEmpty(model))
-                        {
-                            return model;
-                        }
+                        continue;
                     }
-                    catch (JsonException)
+
+                    string? model = node["payload"]?["model"]?.GetValue<string>();
+                    if (!string.IsNullOrEmpty(model))
                     {
-                        // Skip malformed lines and keep scanning.
+                        return model;
                     }
                 }
-                return null;
+                catch (JsonException)
+                {
+                    // Skip malformed lines and keep scanning.
+                }
             }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
+            return null;
         }
         catch (Exception error) when (IsRolloutFileBusyError(error))
         {

--- a/desktop/CodexProviderSync.Core/SessionRolloutService.cs
+++ b/desktop/CodexProviderSync.Core/SessionRolloutService.cs
@@ -318,7 +318,7 @@ public sealed class SessionRolloutService
             await RewriteFirstLineAsync(
                 sourceStream,
                 change.Path,
-                change.UpdatedFirstLine,
+                change.UpdatedFirstLine!,
                 change.OriginalSeparator,
                 change.OriginalOffset,
                 headerOnly: change.OriginalOffset >= change.OriginalFileLength);
@@ -589,7 +589,22 @@ public sealed class SessionRolloutService
         {
             return line;
         }
-        string escapedOld = EscapeForJsonString(oldModel);
+        // We need TWO escapes here:
+        //   - JSON-string escape so the old/new model name can be
+        //     embedded back into a JSON string value (handle `\` and
+        //     `"`).
+        //   - regex escape so model names that happen to contain
+        //     regex metacharacters (`.`, `+`, `*`, `?`, `(`, `)`,
+        //     `|`, `[`, `]`, `{`, `}`, `^`, `$`, `\`) do not
+        //     over-match or break the pattern. Without this, a
+        //     model named `gpt-5.4-mini` would also match
+        //     `gpt-5X4Xmini` and a model named `foo+bar` would
+        //     either fail to compile or behave unexpectedly.
+        // The order matters: regex-escape first so the JSON-string
+        // escape of `\` (which inserts a backslash before every
+        // `\`) does not double up the regex escapes we just
+        // inserted.
+        string escapedOld = System.Text.RegularExpressions.Regex.Escape(EscapeForJsonString(oldModel));
         string escapedNew = EscapeForJsonString(newModel);
         return System.Text.RegularExpressions.Regex.Replace(
             line,

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -256,10 +256,11 @@ public sealed class SqliteStateService
         }
     }
 
-    public async Task<(int UpdatedRows, int ProviderRowsUpdated, int UserEventRowsUpdated, int CwdRowsUpdated, bool DatabasePresent)> UpdateSqliteProviderAsync(
+    public async Task<(int UpdatedRows, int ProviderRowsUpdated, int ModelRowsUpdated, int UserEventRowsUpdated, int CwdRowsUpdated, bool DatabasePresent)> UpdateSqliteProviderAsync(
         string codexHome,
         string targetProvider,
-        Func<(int UpdatedRows, int ProviderRowsUpdated, int UserEventRowsUpdated, int CwdRowsUpdated, bool DatabasePresent), Task>? afterUpdate = null,
+        string? targetModel = null,
+        Func<(int UpdatedRows, int ProviderRowsUpdated, int ModelRowsUpdated, int UserEventRowsUpdated, int CwdRowsUpdated, bool DatabasePresent), Task>? afterUpdate = null,
         int? busyTimeoutMs = null,
         IReadOnlyCollection<string>? userEventThreadIds = null,
         IReadOnlyDictionary<string, string>? threadCwdsById = null)
@@ -269,10 +270,10 @@ public sealed class SqliteStateService
         {
             if (afterUpdate is not null)
             {
-                await afterUpdate((0, 0, 0, 0, false));
+                await afterUpdate((0, 0, 0, 0, 0, false));
             }
 
-            return (0, 0, 0, 0, false);
+            return (0, 0, 0, 0, 0, false);
         }
 
         await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
@@ -292,6 +293,26 @@ public sealed class SqliteStateService
                 """;
             command.Parameters.AddWithValue("$provider", targetProvider);
             int providerRowsUpdated = await command.ExecuteNonQueryAsync();
+
+            // When a target model is provided, align every thread's `model`
+            // column with it alongside `model_provider`. This is what makes
+            // the bottom-right of the Codex UI show the active model for old
+            // sessions, instead of the name that was in effect when each
+            // thread was originally created. The `model` column is only
+            // present in newer Codex schemas, so guard with TableHasColumn
+            // to keep legacy layouts working.
+            int modelRowsUpdated = 0;
+            if (!string.IsNullOrEmpty(targetModel) && await TableHasColumnAsync(connection, "threads", "model"))
+            {
+                await using SqliteCommand modelCommand = connection.CreateCommand();
+                modelCommand.CommandText = """
+                    UPDATE threads
+                    SET model = $model
+                    WHERE COALESCE(model, '') <> $model
+                    """;
+                modelCommand.Parameters.AddWithValue("$model", targetModel);
+                modelRowsUpdated = await modelCommand.ExecuteNonQueryAsync();
+            }
             int userEventRowsUpdated = 0;
             if (userEventThreadIds?.Count > 0 && await TableHasColumnAsync(connection, "threads", "has_user_event"))
             {
@@ -333,16 +354,16 @@ public sealed class SqliteStateService
                 }
             }
 
-            int updatedRows = providerRowsUpdated + userEventRowsUpdated + cwdRowsUpdated;
+            int updatedRows = providerRowsUpdated + modelRowsUpdated + userEventRowsUpdated + cwdRowsUpdated;
 
             if (afterUpdate is not null)
             {
-                await afterUpdate((updatedRows, providerRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true));
+                await afterUpdate((updatedRows, providerRowsUpdated, modelRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true));
             }
 
             await ExecuteNonQueryAsync(connection, "COMMIT");
             transactionOpen = false;
-            return (updatedRows, providerRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true);
+            return (updatedRows, providerRowsUpdated, modelRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true);
         }
         catch (Exception error)
         {

--- a/desktop/CodexProviderSync.Core/TextFormatter.cs
+++ b/desktop/CodexProviderSync.Core/TextFormatter.cs
@@ -101,6 +101,10 @@ public static class TextFormatter
         {
             lines.Add($"Updated SQLite user-event flags: {result.SqliteUserEventRowsUpdated}");
         }
+        if (result.SqliteModelRowsUpdated > 0)
+        {
+            lines.Add($"Updated SQLite per-thread models: {result.SqliteModelRowsUpdated}");
+        }
         if (result.SqliteCwdRowsUpdated > 0)
         {
             lines.Add($"Updated SQLite cwd paths: {result.SqliteCwdRowsUpdated}");

--- a/desktop/CodexProviderSync.Mac/MacDisplayFormatter.cs
+++ b/desktop/CodexProviderSync.Mac/MacDisplayFormatter.cs
@@ -110,6 +110,10 @@ internal static class MacDisplayFormatter
         {
             lines.Add($"已更新 SQLite user-event 标记: {result.SqliteUserEventRowsUpdated}");
         }
+        if (result.SqliteModelRowsUpdated > 0)
+        {
+            lines.Add($"已更新 SQLite 每线程 model: {result.SqliteModelRowsUpdated}");
+        }
         if (result.SqliteCwdRowsUpdated > 0)
         {
             lines.Add($"已更新 SQLite cwd 路径: {result.SqliteCwdRowsUpdated}");


### PR DESCRIPTION
## Problem

`codex-provider switch <provider>` on the JS CLI now also aligns the
root-level `model` with the new provider section's `model`, with
opt-outs (`--model NAME`, `--keep-root-model`). The C# WinForms GUI,
however, was never ported: its `RunSwitchAsync` still called the
old `SetRootProviderInConfigText` and left the root-level `model`
untouched. Users running the GUI had to hand-edit `config.toml`
after every switch to fix the model name.

This PR ports the JS-side switch model sync to the C# side and
exposes the three behaviors through the GUI.

## Changes

- **`ConfigFileService`** (Core): new `SetRootModelInConfigText` and
  `ReadProviderModel` — straight mirrors of the helpers in
  `src/config-file.js`.
- **`CodexSyncService.RunSwitchAsync`** (Core): new `model` and
  `keepRootModel` parameters, the same three-way resolution as
  the JS `runSwitch` (explicit / provider section / keep). Attaches
  a `ModelSyncOutcome` to the returned `SyncResult`.
- **`Models.ModelSyncOutcome`** (Core): new immutable type with
  `Applied` / `Source` / `Model` / `Warning`. `SyncResult.ModelSync`
  defaults to `NotApplicable()` so existing call sites keep
  compiling.
- **`MainForm`** (App): new "顶层 model 处理" row in the
  update-config panel with three radio options
  (跟随 provider / 保留当前 / 自定义) plus a custom-model text
  input. The row is enabled only when the "同步时改写 config.toml"
  checkbox is on. After Execute, the resolved model sync outcome
  is appended to the log the same way the CLI prints it.
- **Bug fix** (App): the radio row's `UpdateModelOptionsEnabled()`
  is now called once at the end of `BuildUpdateConfigPanel` so
  the first paint already reflects the checkbox state, not the
  WinForms default `Enabled = true`.

## Behavior parity

| scenario            | CLI                                 | GUI                                           |
|---------------------|-------------------------------------|-----------------------------------------------|
| follow provider     | `codex-provider switch <provider>`  | 勾"同步时改写" + 选"跟随 provider 里的 model" |
| explicit model      | `--model "MiniMax-M3"`              | 选"自定义" + 填文本框                          |
| keep current model  | `--keep-root-model`                 | 选"保留当前顶层 model"                        |
| sync only (no cfg)  | `codex-provider sync`               | 不勾"同步时改写 config.toml"                  |

## Verification

- 3 new unit tests in
  `desktop/CodexProviderSync.Core.Tests/SingleInstanceGuardTests.cs`
  already cover the single-instance guard (committed in
  `feat/single-instance`).
- This branch is the C# mirror; no new automated tests are added
  for the GUI itself. The change has been built with `dotnet publish
  -c Release` on .NET 10.0.301 and the resulting EXE has been
  exercised on Windows: the radio row is disabled when the config
  checkbox is off, and after clicking Execute the log prints
  `顶层 model: <name> (来源: <source>)` matching the CLI output.