### PR TITLE
Fix stale Codex state DB detection

### DIFF
--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import { DB_FILE_BASENAME, SQLITE_DIR_BASENAME } from "./constants.js";
+import { DB_FILE_BASENAME, SESSION_DIRS, SQLITE_DIR_BASENAME } from "./constants.js";
 import { openDatabase } from "./sqlite.js";
 
 const DEFAULT_BUSY_TIMEOUT_MS = 5000;
@@ -19,26 +19,140 @@ export function stateDbCandidates(codexHome) {
     {
       path: stateDbPath(codexHome),
       relativePath: path.join(SQLITE_DIR_BASENAME, DB_FILE_BASENAME),
-      source: "sqlite-dir"
+      source: "sqlite-dir",
+      priority: 0
     },
     {
       path: legacyStateDbPath(codexHome),
       relativePath: DB_FILE_BASENAME,
-      source: "legacy-root"
+      source: "legacy-root",
+      priority: 1
     }
   ];
 }
 
+async function countRolloutFilesInDir(rootDir) {
+  let entries;
+  try {
+    entries = await fs.readdir(rootDir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let count = 0;
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      count += await countRolloutFilesInDir(fullPath);
+      continue;
+    }
+    if (entry.isFile() && entry.name.startsWith("rollout-") && entry.name.endsWith(".jsonl")) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+async function countRolloutFiles(codexHome) {
+  let count = 0;
+  for (const dirname of SESSION_DIRS) {
+    count += await countRolloutFilesInDir(path.join(codexHome, dirname));
+  }
+  return count;
+}
+
+function tableExists(db, tableName) {
+  return Boolean(db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName));
+}
+
+function maxThreadTimestampMs(db) {
+  if (tableHasColumn(db, "threads", "updated_at_ms")) {
+    return db.prepare("SELECT COALESCE(MAX(updated_at_ms), 0) AS value FROM threads").get().value ?? 0;
+  }
+  if (tableHasColumn(db, "threads", "updated_at")) {
+    return (db.prepare("SELECT COALESCE(MAX(updated_at), 0) AS value FROM threads").get().value ?? 0) * 1000;
+  }
+  if (tableHasColumn(db, "threads", "created_at_ms")) {
+    return db.prepare("SELECT COALESCE(MAX(created_at_ms), 0) AS value FROM threads").get().value ?? 0;
+  }
+  if (tableHasColumn(db, "threads", "created_at")) {
+    return (db.prepare("SELECT COALESCE(MAX(created_at), 0) AS value FROM threads").get().value ?? 0) * 1000;
+  }
+  return 0;
+}
+
+async function readStateDbCandidateStats(candidate) {
+  let db;
+  try {
+    db = await openDatabase(candidate.path);
+    if (!tableExists(db, "threads")) {
+      throw new Error("threads table not found");
+    }
+    const threadCount = db.prepare("SELECT COUNT(*) AS count FROM threads").get().count ?? 0;
+    return {
+      ...candidate,
+      readable: true,
+      threadCount,
+      maxThreadTimestampMs: maxThreadTimestampMs(db),
+      mtimeMs: (await fs.stat(candidate.path)).mtimeMs
+    };
+  } finally {
+    db?.close();
+  }
+}
+
+function compareStateDbCandidates(a, b) {
+  if (a.rolloutDistance !== b.rolloutDistance) {
+    return a.rolloutDistance - b.rolloutDistance;
+  }
+  if (a.threadCount !== b.threadCount) {
+    return b.threadCount - a.threadCount;
+  }
+  if (a.maxThreadTimestampMs !== b.maxThreadTimestampMs) {
+    return b.maxThreadTimestampMs - a.maxThreadTimestampMs;
+  }
+  if (a.mtimeMs !== b.mtimeMs) {
+    return b.mtimeMs - a.mtimeMs;
+  }
+  return a.priority - b.priority;
+}
+
 export async function detectStateDb(codexHome) {
+  const existingCandidates = [];
   for (const candidate of stateDbCandidates(codexHome)) {
     try {
       await fs.access(candidate.path);
-      return candidate;
+      existingCandidates.push(candidate);
     } catch {
       // Try the next known Codex state DB location.
     }
   }
-  return null;
+  if (existingCandidates.length === 0) {
+    return null;
+  }
+
+  const rolloutCount = await countRolloutFiles(codexHome);
+  const readableCandidates = [];
+  for (const candidate of existingCandidates) {
+    try {
+      const candidateWithStats = await readStateDbCandidateStats(candidate);
+      readableCandidates.push({
+        ...candidateWithStats,
+        rolloutDistance: rolloutCount > 0 ? Math.abs(candidateWithStats.threadCount - rolloutCount) : 0
+      });
+    } catch {
+      // Keep malformed/unreadable candidates as a fallback so existing error
+      // reporting still points at state_5.sqlite when no usable DB exists.
+    }
+  }
+
+  if (readableCandidates.length === 0) {
+    return existingCandidates[0];
+  }
+
+  return readableCandidates.sort(compareStateDbCandidates)[0];
 }
 
 export async function existingStateDbPath(codexHome) {

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -102,8 +102,7 @@ function legacyStateDbPath(codexHome) {
   return path.join(codexHome, DB_FILE_BASENAME);
 }
 
-async function writeStateDb(codexHome, rows) {
-  const dbPath = stateDbPath(codexHome);
+async function writeStateDbAt(dbPath, rows) {
   await fs.mkdir(path.dirname(dbPath), { recursive: true });
   const db = await openDatabase(dbPath);
   try {
@@ -123,6 +122,14 @@ async function writeStateDb(codexHome, rows) {
   } finally {
     db.close();
   }
+}
+
+async function writeStateDb(codexHome, rows) {
+  await writeStateDbAt(stateDbPath(codexHome), rows);
+}
+
+async function writeLegacyStateDb(codexHome, rows) {
+  await writeStateDbAt(legacyStateDbPath(codexHome), rows);
 }
 
 async function writeStateDbWithUserEventColumn(codexHome, rows) {
@@ -583,6 +590,42 @@ test("status falls back to legacy root sqlite database", async () => {
   assert.equal(status.stateDbLocation.source, "legacy-root");
   assert.equal(status.stateDbLocation.path, legacyStateDbPath(codexHome));
   assert.deepEqual(status.sqliteCounts.sessions, { openai: 1 });
+  assert.match(renderStatus(status), /legacy root/);
+});
+
+test("status chooses legacy root sqlite database when sqlite-dir state is stale", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome);
+  await writeRollout(
+    path.join(codexHome, "sessions", "2026", "03", "19", "rollout-a.jsonl"),
+    "thread-a",
+    "openai"
+  );
+  await writeRollout(
+    path.join(codexHome, "sessions", "2026", "03", "19", "rollout-b.jsonl"),
+    "thread-b",
+    "openai"
+  );
+  await writeRollout(
+    path.join(codexHome, "archived_sessions", "2026", "03", "18", "rollout-c.jsonl"),
+    "thread-c",
+    "openai"
+  );
+  await writeStateDb(codexHome, [
+    { id: "thread-a", model_provider: "custom", archived: false }
+  ]);
+  await writeLegacyStateDb(codexHome, [
+    { id: "thread-a", model_provider: "openai", archived: false },
+    { id: "thread-b", model_provider: "openai", archived: false },
+    { id: "thread-c", model_provider: "openai", archived: true }
+  ]);
+
+  const status = await getStatus({ codexHome });
+
+  assert.equal(status.stateDbLocation.source, "legacy-root");
+  assert.equal(status.stateDbLocation.path, legacyStateDbPath(codexHome));
+  assert.deepEqual(status.sqliteCounts.sessions, { openai: 2 });
+  assert.deepEqual(status.sqliteCounts.archived_sessions, { openai: 1 });
   assert.match(renderStatus(status), /legacy root/);
 });
 


### PR DESCRIPTION
## Summary
- detect both known Codex SQLite state locations instead of returning the first existing path immediately
- when both databases exist, prefer the readable database whose thread count best matches local rollout files
- keep the previous fallback behavior for malformed/unreadable databases when no usable candidate exists

## Why
I hit a case where both `~/.codex/sqlite/state_5.sqlite` and `~/.codex/state_5.sqlite` existed. The tool selected the sqlite-dir database, but the Codex desktop app was using the legacy root database. As a result, `codex-provider sync` updated the stale DB and the desktop history still looked missing.

Concrete local repro from that machine:
- rollout files: 39 sessions + 120 archived sessions
- `~/.codex/sqlite/state_5.sqlite`: 28 sessions + 83 archived sessions
- `~/.codex/state_5.sqlite`: 39 sessions + 120 archived sessions and actively used by Codex

## Test
- `npm test`
