### PR TITLE
Fix active Codex state DB detection

### DIFF
--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -71,6 +71,69 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSync_UpdatesLegacyRootSqliteDatabase_WhenSqliteDirStateIsStale()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"");
+        string sessionPath = fixture.RolloutPath("sessions", "rollout-active-a.jsonl");
+        string archivedPath = fixture.RolloutPath("archived_sessions", "rollout-active-b.jsonl");
+        await fixture.WriteRolloutAsync(sessionPath, "thread-active-a", "dal");
+        await fixture.WriteRolloutAsync(archivedPath, "thread-active-b", "dal");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-active-a", "dal", false)
+        ]);
+        await fixture.WriteLegacyStateDbAsync(
+        [
+            ("thread-active-a", "dal", false),
+            ("thread-active-b", "dal", true)
+        ]);
+
+        CodexSyncService service = new();
+        SyncResult syncResult = await service.RunSyncAsync(fixture.CodexHome);
+
+        Assert.Equal(2, syncResult.SqliteRowsUpdated);
+        BackupMetadataFile backupMetadata = JsonSerializer.Deserialize<BackupMetadataFile>(
+            await File.ReadAllTextAsync(Path.Combine(syncResult.BackupDir, "metadata.json")),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })!;
+        Assert.Equal([AppConstants.DbFileBasename], backupMetadata.DbFiles);
+
+        await using (SqliteConnection connection = fixture.OpenLegacySqliteConnection())
+        {
+            await connection.OpenAsync();
+            SqliteCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT id, model_provider FROM threads ORDER BY id";
+            await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+            List<(string Id, string Provider)> rows = [];
+            while (await reader.ReadAsync())
+            {
+                rows.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            Assert.Equal(
+            [
+                ("thread-active-a", "openai"),
+                ("thread-active-b", "openai")
+            ], rows);
+        }
+
+        await using (SqliteConnection connection = fixture.OpenSqliteConnection())
+        {
+            await connection.OpenAsync();
+            SqliteCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT id, model_provider FROM threads ORDER BY id";
+            await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+            List<(string Id, string Provider)> rows = [];
+            while (await reader.ReadAsync())
+            {
+                rows.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            Assert.Equal([("thread-active-a", "dal")], rows);
+        }
+    }
+
+    [Fact]
     public async Task RunSwitch_UpdatesConfigAndSyncsProviderMetadata()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
@@ -319,6 +382,45 @@ public sealed class CoreIntegrationTests
         Assert.Equal("legacy-root", status.StateDbLocation!.Source);
         Assert.Equal(fixture.LegacyStateDbPath(), status.StateDbLocation.Path);
         Assert.Equal(1, status.SqliteCounts!.Sessions["openai"]);
+        Assert.Contains("legacy root", TextFormatter.FormatStatus(status));
+    }
+
+    [Fact]
+    public async Task GetStatus_ChoosesLegacyRootSqliteDatabase_WhenSqliteDirStateIsStale()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync(string.Empty);
+        await fixture.WriteRolloutAsync(
+            fixture.RolloutPath("sessions", "rollout-active-a.jsonl"),
+            "thread-active-a",
+            "openai");
+        await fixture.WriteRolloutAsync(
+            fixture.RolloutPath("sessions", "rollout-active-b.jsonl"),
+            "thread-active-b",
+            "openai");
+        await fixture.WriteRolloutAsync(
+            fixture.RolloutPath("archived_sessions", "rollout-active-c.jsonl"),
+            "thread-active-c",
+            "openai");
+        await fixture.WriteStateDbAsync(
+        [
+            ("thread-active-a", "custom", false)
+        ]);
+        await fixture.WriteLegacyStateDbAsync(
+        [
+            ("thread-active-a", "openai", false),
+            ("thread-active-b", "openai", false),
+            ("thread-active-c", "openai", true)
+        ]);
+
+        CodexSyncService service = new();
+        StatusSnapshot status = await service.GetStatusAsync(fixture.CodexHome);
+
+        Assert.NotNull(status.StateDbLocation);
+        Assert.Equal("legacy-root", status.StateDbLocation!.Source);
+        Assert.Equal(fixture.LegacyStateDbPath(), status.StateDbLocation.Path);
+        Assert.Equal(2, status.SqliteCounts!.Sessions["openai"]);
+        Assert.Equal(1, status.SqliteCounts.ArchivedSessions["openai"]);
         Assert.Contains("legacy root", TextFormatter.FormatStatus(status));
     }
 

--- a/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
+++ b/desktop/CodexProviderSync.Core.Tests/TestCodexHomeFixture.cs
@@ -136,7 +136,17 @@ internal sealed class TestCodexHomeFixture
 
     public async Task WriteStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
     {
-        await using SqliteConnection connection = OpenSqliteConnection();
+        await WriteStateDbAtAsync(StateDbPath(), rows);
+    }
+
+    public async Task WriteLegacyStateDbAsync(IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
+    {
+        await WriteStateDbAtAsync(LegacyStateDbPath(), rows);
+    }
+
+    private static async Task WriteStateDbAtAsync(string dbPath, IEnumerable<(string Id, string ModelProvider, bool Archived)> rows)
+    {
+        await using SqliteConnection connection = OpenSqliteConnection(dbPath);
         await connection.OpenAsync();
         SqliteCommand create = connection.CreateCommand();
         create.CommandText = """

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -6,6 +6,14 @@ public sealed class SqliteStateService
 {
     private const int DefaultBusyTimeoutMs = 5000;
 
+    private sealed record StateDbCandidateStats(
+        StateDbLocation Location,
+        int Priority,
+        long ThreadCount,
+        long MaxThreadTimestampMs,
+        long LastWriteTimeUtcTicks,
+        long RolloutDistance);
+
     static SqliteStateService()
     {
         SQLitePCL.Batteries_V2.Init();
@@ -38,15 +46,51 @@ public sealed class SqliteStateService
 
     public StateDbLocation? DetectStateDb(string codexHome)
     {
-        foreach (StateDbLocation candidate in StateDbCandidates(codexHome))
+        List<(StateDbLocation Location, int Priority)> existingCandidates = [];
+        IReadOnlyList<StateDbLocation> candidates = StateDbCandidates(codexHome);
+        for (int index = 0; index < candidates.Count; index += 1)
         {
+            StateDbLocation candidate = candidates[index];
             if (File.Exists(candidate.Path))
             {
-                return candidate;
+                existingCandidates.Add((candidate, index));
             }
         }
 
-        return null;
+        if (existingCandidates.Count == 0)
+        {
+            return null;
+        }
+
+        long rolloutCount = CountRolloutFiles(codexHome);
+        List<StateDbCandidateStats> readableCandidates = [];
+        foreach ((StateDbLocation candidate, int priority) in existingCandidates)
+        {
+            try
+            {
+                StateDbCandidateStats stats = ReadStateDbCandidateStats(candidate, priority, rolloutCount);
+                readableCandidates.Add(stats);
+            }
+            catch
+            {
+                // Keep unreadable candidates as a fallback so existing status/error
+                // handling still points at state_5.sqlite when no usable DB exists.
+            }
+        }
+
+        if (readableCandidates.Count == 0)
+        {
+            return existingCandidates[0].Location;
+        }
+
+        return readableCandidates
+            .OrderBy(static candidate => candidate.RolloutDistance)
+            .ThenByDescending(static candidate => candidate.ThreadCount)
+            .ThenByDescending(static candidate => candidate.MaxThreadTimestampMs)
+            .ThenByDescending(static candidate => candidate.LastWriteTimeUtcTicks)
+            .ThenBy(static candidate => candidate.Priority)
+            .First()
+            .Location;
     }
 
     public string? ExistingStateDbPath(string codexHome)
@@ -331,6 +375,98 @@ public sealed class SqliteStateService
         return new SqliteConnection(builder.ConnectionString);
     }
 
+    private static long CountRolloutFiles(string codexHome)
+    {
+        long count = 0;
+        foreach (string directory in AppConstants.SessionDirectories)
+        {
+            count += CountRolloutFilesInDirectory(Path.Combine(codexHome, directory));
+        }
+
+        return count;
+    }
+
+    private static long CountRolloutFilesInDirectory(string rootDir)
+    {
+        if (!Directory.Exists(rootDir))
+        {
+            return 0;
+        }
+
+        try
+        {
+            return Directory
+                .EnumerateFiles(rootDir, "rollout-*.jsonl", SearchOption.AllDirectories)
+                .LongCount();
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static StateDbCandidateStats ReadStateDbCandidateStats(
+        StateDbLocation candidate,
+        int priority,
+        long rolloutCount)
+    {
+        using SqliteConnection connection = OpenConnection(candidate.Path, SqliteOpenMode.ReadOnly);
+        connection.Open();
+        if (!TableExists(connection, "threads"))
+        {
+            throw new InvalidOperationException("threads table not found");
+        }
+
+        long threadCount = ExecuteScalarLong(connection, "SELECT COUNT(*) FROM threads");
+        long rolloutDistance = rolloutCount > 0 ? Math.Abs(threadCount - rolloutCount) : 0;
+        return new StateDbCandidateStats(
+            candidate,
+            priority,
+            threadCount,
+            MaxThreadTimestampMs(connection),
+            File.GetLastWriteTimeUtc(candidate.Path).Ticks,
+            rolloutDistance);
+    }
+
+    private static bool TableExists(SqliteConnection connection, string tableName)
+    {
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $name";
+        command.Parameters.AddWithValue("$name", tableName);
+        object? value = command.ExecuteScalar();
+        return value is not null && value is not DBNull;
+    }
+
+    private static long MaxThreadTimestampMs(SqliteConnection connection)
+    {
+        if (TableHasColumn(connection, "threads", "updated_at_ms"))
+        {
+            return ExecuteScalarLong(connection, "SELECT COALESCE(MAX(updated_at_ms), 0) FROM threads");
+        }
+        if (TableHasColumn(connection, "threads", "updated_at"))
+        {
+            return ExecuteScalarLong(connection, "SELECT COALESCE(MAX(updated_at), 0) FROM threads") * 1000;
+        }
+        if (TableHasColumn(connection, "threads", "created_at_ms"))
+        {
+            return ExecuteScalarLong(connection, "SELECT COALESCE(MAX(created_at_ms), 0) FROM threads");
+        }
+        if (TableHasColumn(connection, "threads", "created_at"))
+        {
+            return ExecuteScalarLong(connection, "SELECT COALESCE(MAX(created_at), 0) FROM threads") * 1000;
+        }
+
+        return 0;
+    }
+
+    private static long ExecuteScalarLong(SqliteConnection connection, string commandText)
+    {
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = commandText;
+        object? value = command.ExecuteScalar();
+        return value is null || value is DBNull ? 0 : Convert.ToInt64(value);
+    }
+
     private static async Task SetBusyTimeoutAsync(SqliteConnection connection, int? busyTimeoutMs)
     {
         int timeout = busyTimeoutMs is >= 0 ? busyTimeoutMs.Value : DefaultBusyTimeoutMs;
@@ -350,6 +486,22 @@ public sealed class SqliteStateService
         command.CommandText = $"PRAGMA table_info({QuoteIdentifier(tableName)})";
         await using SqliteDataReader reader = await command.ExecuteReaderAsync();
         while (await reader.ReadAsync())
+        {
+            if (string.Equals(reader.GetString(1), columnName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TableHasColumn(SqliteConnection connection, string tableName, string columnName)
+    {
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = $"PRAGMA table_info({QuoteIdentifier(tableName)})";
+        using SqliteDataReader reader = command.ExecuteReader();
+        while (reader.Read())
         {
             if (string.Equals(reader.GetString(1), columnName, StringComparison.Ordinal))
             {

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import { DB_FILE_BASENAME, SQLITE_DIR_BASENAME } from "./constants.js";
+import { DB_FILE_BASENAME, SESSION_DIRS, SQLITE_DIR_BASENAME } from "./constants.js";
 import { openDatabase } from "./sqlite.js";
 
 const DEFAULT_BUSY_TIMEOUT_MS = 5000;
@@ -29,16 +29,129 @@ export function stateDbCandidates(codexHome) {
   ];
 }
 
+async function countRolloutFilesInDir(rootDir) {
+  let entries;
+  try {
+    entries = await fs.readdir(rootDir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let count = 0;
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      count += await countRolloutFilesInDir(fullPath);
+      continue;
+    }
+    if (entry.isFile() && entry.name.startsWith("rollout-") && entry.name.endsWith(".jsonl")) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+async function countRolloutFiles(codexHome) {
+  let count = 0;
+  for (const dirname of SESSION_DIRS) {
+    count += await countRolloutFilesInDir(path.join(codexHome, dirname));
+  }
+  return count;
+}
+
+function tableExists(db, tableName) {
+  return Boolean(db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName));
+}
+
+function maxThreadTimestampMs(db) {
+  if (tableHasColumn(db, "threads", "updated_at_ms")) {
+    return Number(db.prepare("SELECT COALESCE(MAX(updated_at_ms), 0) AS value FROM threads").get().value) || 0;
+  }
+  if (tableHasColumn(db, "threads", "updated_at")) {
+    return (Number(db.prepare("SELECT COALESCE(MAX(updated_at), 0) AS value FROM threads").get().value) || 0) * 1000;
+  }
+  if (tableHasColumn(db, "threads", "created_at_ms")) {
+    return Number(db.prepare("SELECT COALESCE(MAX(created_at_ms), 0) AS value FROM threads").get().value) || 0;
+  }
+  if (tableHasColumn(db, "threads", "created_at")) {
+    return (Number(db.prepare("SELECT COALESCE(MAX(created_at), 0) AS value FROM threads").get().value) || 0) * 1000;
+  }
+  return 0;
+}
+
+async function readStateDbCandidateStats(candidate, priority) {
+  let db;
+  try {
+    db = await openDatabase(candidate.path, { readOnly: true });
+    if (!tableExists(db, "threads")) {
+      throw new Error("threads table not found");
+    }
+    const threadCount = Number(db.prepare("SELECT COUNT(*) AS count FROM threads").get().count) || 0;
+    return {
+      candidate,
+      priority,
+      threadCount,
+      maxThreadTimestampMs: maxThreadTimestampMs(db),
+      mtimeMs: (await fs.stat(candidate.path)).mtimeMs
+    };
+  } finally {
+    db?.close();
+  }
+}
+
+function compareStateDbCandidateStats(a, b) {
+  if (a.rolloutDistance !== b.rolloutDistance) {
+    return a.rolloutDistance - b.rolloutDistance;
+  }
+  if (a.threadCount !== b.threadCount) {
+    return b.threadCount - a.threadCount;
+  }
+  if (a.maxThreadTimestampMs !== b.maxThreadTimestampMs) {
+    return b.maxThreadTimestampMs - a.maxThreadTimestampMs;
+  }
+  if (a.mtimeMs !== b.mtimeMs) {
+    return b.mtimeMs - a.mtimeMs;
+  }
+  return a.priority - b.priority;
+}
+
 export async function detectStateDb(codexHome) {
-  for (const candidate of stateDbCandidates(codexHome)) {
+  const existingCandidates = [];
+  const candidates = stateDbCandidates(codexHome);
+  for (const [priority, candidate] of candidates.entries()) {
     try {
       await fs.access(candidate.path);
-      return candidate;
+      existingCandidates.push({ candidate, priority });
     } catch {
       // Try the next known Codex state DB location.
     }
   }
-  return null;
+  if (existingCandidates.length === 0) {
+    return null;
+  }
+
+  const rolloutCount = await countRolloutFiles(codexHome);
+  const readableCandidates = [];
+  for (const { candidate, priority } of existingCandidates) {
+    try {
+      const stats = await readStateDbCandidateStats(candidate, priority);
+      readableCandidates.push({
+        ...stats,
+        rolloutDistance: rolloutCount > 0 ? Math.abs(stats.threadCount - rolloutCount) : 0
+      });
+    } catch {
+      // Keep unreadable candidates as a fallback so existing status/error
+      // handling still points at state_5.sqlite when no usable DB exists.
+    }
+  }
+
+  if (readableCandidates.length === 0) {
+    return existingCandidates[0].candidate;
+  }
+
+  return readableCandidates.sort(compareStateDbCandidateStats)[0].candidate;
 }
 
 export async function existingStateDbPath(codexHome) {

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -102,8 +102,7 @@ function legacyStateDbPath(codexHome) {
   return path.join(codexHome, DB_FILE_BASENAME);
 }
 
-async function writeStateDb(codexHome, rows) {
-  const dbPath = stateDbPath(codexHome);
+async function writeStateDbAt(dbPath, rows) {
   await fs.mkdir(path.dirname(dbPath), { recursive: true });
   const db = await openDatabase(dbPath);
   try {
@@ -123,6 +122,14 @@ async function writeStateDb(codexHome, rows) {
   } finally {
     db.close();
   }
+}
+
+async function writeStateDb(codexHome, rows) {
+  await writeStateDbAt(stateDbPath(codexHome), rows);
+}
+
+async function writeLegacyStateDb(codexHome, rows) {
+  await writeStateDbAt(legacyStateDbPath(codexHome), rows);
 }
 
 async function writeStateDbWithUserEventColumn(codexHome, rows) {
@@ -313,6 +320,53 @@ test("runSync rewrites rollout files and sqlite, then restore reverts both", asy
   const restoredArchived = await fs.readFile(archivedPath, "utf8");
   assert.match(restoredSession, /"model_provider":"apigather"/);
   assert.match(restoredArchived, /"model_provider":"newapi"/);
+});
+
+test("runSync updates legacy root sqlite database when sqlite-dir state is stale", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-active-a.jsonl");
+  const archivedPath = path.join(codexHome, "archived_sessions", "2026", "03", "18", "rollout-active-b.jsonl");
+  await writeRollout(sessionPath, "thread-active-a", "dal");
+  await writeRollout(archivedPath, "thread-active-b", "dal");
+  await writeStateDb(codexHome, [
+    { id: "thread-active-a", model_provider: "dal", archived: false }
+  ]);
+  await writeLegacyStateDb(codexHome, [
+    { id: "thread-active-a", model_provider: "dal", archived: false },
+    { id: "thread-active-b", model_provider: "dal", archived: true }
+  ]);
+
+  const syncResult = await runSync({ codexHome });
+
+  assert.equal(syncResult.sqliteRowsUpdated, 2);
+  const backupMetadata = JSON.parse(await fs.readFile(path.join(syncResult.backupDir, "metadata.json"), "utf8"));
+  assert.deepEqual(backupMetadata.dbFiles, [DB_FILE_BASENAME]);
+
+  const legacyDb = await openDatabase(legacyStateDbPath(codexHome));
+  try {
+    assert.deepEqual(
+      legacyDb.prepare("SELECT id, model_provider FROM threads ORDER BY id").all().map((row) => ({ ...row })),
+      [
+        { id: "thread-active-a", model_provider: "openai" },
+        { id: "thread-active-b", model_provider: "openai" }
+      ]
+    );
+  } finally {
+    legacyDb.close();
+  }
+
+  const staleDb = await openDatabase(stateDbPath(codexHome));
+  try {
+    assert.deepEqual(
+      staleDb.prepare("SELECT id, model_provider FROM threads ORDER BY id").all().map((row) => ({ ...row })),
+      [
+        { id: "thread-active-a", model_provider: "dal" }
+      ]
+    );
+  } finally {
+    staleDb.close();
+  }
 });
 
 test("runSync reports stage progress and backup duration", async () => {
@@ -583,6 +637,42 @@ test("status falls back to legacy root sqlite database", async () => {
   assert.equal(status.stateDbLocation.source, "legacy-root");
   assert.equal(status.stateDbLocation.path, legacyStateDbPath(codexHome));
   assert.deepEqual(status.sqliteCounts.sessions, { openai: 1 });
+  assert.match(renderStatus(status), /legacy root/);
+});
+
+test("status chooses legacy root sqlite database when sqlite-dir state is stale", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome);
+  await writeRollout(
+    path.join(codexHome, "sessions", "2026", "03", "19", "rollout-active-a.jsonl"),
+    "thread-active-a",
+    "openai"
+  );
+  await writeRollout(
+    path.join(codexHome, "sessions", "2026", "03", "19", "rollout-active-b.jsonl"),
+    "thread-active-b",
+    "openai"
+  );
+  await writeRollout(
+    path.join(codexHome, "archived_sessions", "2026", "03", "18", "rollout-active-c.jsonl"),
+    "thread-active-c",
+    "openai"
+  );
+  await writeStateDb(codexHome, [
+    { id: "thread-active-a", model_provider: "custom", archived: false }
+  ]);
+  await writeLegacyStateDb(codexHome, [
+    { id: "thread-active-a", model_provider: "openai", archived: false },
+    { id: "thread-active-b", model_provider: "openai", archived: false },
+    { id: "thread-active-c", model_provider: "openai", archived: true }
+  ]);
+
+  const status = await getStatus({ codexHome });
+
+  assert.equal(status.stateDbLocation.source, "legacy-root");
+  assert.equal(status.stateDbLocation.path, legacyStateDbPath(codexHome));
+  assert.deepEqual(status.sqliteCounts.sessions, { openai: 2 });
+  assert.deepEqual(status.sqliteCounts.archived_sessions, { openai: 1 });
   assert.match(renderStatus(status), /legacy root/);
 });
 


### PR DESCRIPTION
## Summary
- choose the active Codex state database when both sqlite/state_5.sqlite and legacy state_5.sqlite exist
- apply the same detection to CLI and Windows GUI Core paths
- add JS and C# regressions for stale sqlite-dir DB with active legacy root DB

## Verification
- npm test
- dotnet test desktop\\CodexProviderSync.Core.Tests\\CodexProviderSync.Core.Tests.csproj -c Release
- dotnet publish desktop\\CodexProviderSync.App\\CodexProviderSync.App.csproj -c Release
- node src\\cli.js status confirmed local detection uses legacy root DB