### PR TITLE
feat: 添加内置更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,13 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm test
+
+  desktop-test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+      - run: dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
+      - run: dotnet test desktop/CodexProviderSync.App.Tests/CodexProviderSync.App.Tests.csproj

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
+      - run: dotnet test desktop/CodexProviderSync.App.Tests/CodexProviderSync.App.Tests.csproj
 
       - name: Build Windows GUI
         shell: pwsh

--- a/CodexProviderSync.sln
+++ b/CodexProviderSync.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodexProviderSync.Mac", "de
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodexProviderSync.Core", "desktop\CodexProviderSync.Core\CodexProviderSync.Core.csproj", "{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodexProviderSync.App.Tests", "desktop\CodexProviderSync.App.Tests\CodexProviderSync.App.Tests.csproj", "{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,18 @@ Global
 		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Release|x64.Build.0 = Release|Any CPU
 		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Release|x86.ActiveCfg = Release|Any CPU
 		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B}.Release|x86.Build.0 = Release|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Debug|x64.Build.0 = Debug|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Debug|x86.Build.0 = Debug|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Release|x64.ActiveCfg = Release|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Release|x64.Build.0 = Release|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Release|x86.ActiveCfg = Release|Any CPU
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,5 +79,6 @@ Global
 		{046C07E6-8117-4F19-B2CF-683D62D944C9} = {7A1224A0-F22D-34FF-DE0A-A058FAFFD90C}
 		{2F00CBA5-C5E9-42BC-9F25-01641E0B8901} = {7A1224A0-F22D-34FF-DE0A-A058FAFFD90C}
 		{0BAD4EAB-F18E-405C-AA1F-0D08B03B599B} = {7A1224A0-F22D-34FF-DE0A-A058FAFFD90C}
+		{C2B35A41-4A58-49EC-A8D1-65F8AA6D9914} = {7A1224A0-F22D-34FF-DE0A-A058FAFFD90C}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Windows 用户优先下载 Release 里的 `CodexProviderSync.exe`：
 3. 选择目标 Provider
 4. 点击 `Execute`
 
-GUI 右侧的“检查更新”会读取本项目最新的稳定版 GitHub Release。确认更新后，程序会下载 `CodexProviderSync.exe`、校验同版本发布的 SHA-256 文件、退出并由临时更新器替换原 EXE 后自动重启。若 EXE 所在目录没有写入权限，更新不会覆盖旧版本，按提示手动下载即可。
+GUI 右侧的“检查更新”会读取本项目最新的稳定版 GitHub Release。确认更新后，程序会下载 `CodexProviderSync.exe`、校验同版本发布的 SHA-256 文件、退出并由临时更新器再次校验后原子替换原 EXE，再自动重启。更新器临时目录会在后续启动时自动清理。若 EXE 所在目录没有写入权限，更新不会覆盖旧版本，程序会尽力重启旧版，并在提示中保留下载路径供手动安装。
 
 macOS 用户可使用 Avalonia 桌面版，构建说明见 [README_MAC_GUI_ZH.md](docs/README_MAC_GUI_ZH.md)。
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Windows 用户优先下载 Release 里的 `CodexProviderSync.exe`：
 3. 选择目标 Provider
 4. 点击 `Execute`
 
+GUI 右侧的“检查更新”会读取本项目最新的稳定版 GitHub Release。确认更新后，程序会下载 `CodexProviderSync.exe`、校验同版本发布的 SHA-256 文件、退出并由临时更新器替换原 EXE 后自动重启。若 EXE 所在目录没有写入权限，更新不会覆盖旧版本，按提示手动下载即可。
+
 macOS 用户可使用 Avalonia 桌面版，构建说明见 [README_MAC_GUI_ZH.md](docs/README_MAC_GUI_ZH.md)。
 
 其它环境使用 CLI：
@@ -99,6 +101,7 @@ codex-provider prune-backups --keep 5
 - 如果 `state_5.sqlite` 损坏，工具会提示 malformed/unreadable 并停止同步。
 - 如果活跃会话锁住 rollout 文件，工具会跳过该文件并继续处理其它历史会话。
 - 如果 EXE 双击无反应，先确认已解压，再查看 `%AppData%\codex-provider-sync\startup-error.log`，或在 PowerShell 里运行 `./CodexProviderSync.exe`。
+- 内置更新只检查稳定版 GitHub Release，且需要用户在 GUI 中确认；项目目前未做 Windows 代码签名，SHA-256 校验可检测下载损坏，但不能替代代码签名。
 
 Windows GUI 说明见 [README_GUI_ZH.md](docs/README_GUI_ZH.md)，macOS GUI 说明见 [README_MAC_GUI_ZH.md](docs/README_MAC_GUI_ZH.md)。AI / Agent 说明见 [AGENTS.md](AGENTS.md)。
 

--- a/desktop/CodexProviderSync.App.Tests/CodexProviderSync.App.Tests.csproj
+++ b/desktop/CodexProviderSync.App.Tests/CodexProviderSync.App.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodexProviderSync.App\CodexProviderSync.App.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/desktop/CodexProviderSync.App.Tests/UpdateApplierTests.cs
+++ b/desktop/CodexProviderSync.App.Tests/UpdateApplierTests.cs
@@ -1,0 +1,163 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CodexProviderSync.App.Tests;
+
+public sealed class UpdateApplierTests
+{
+    [Fact]
+    public void Apply_AtomicallyReplacesTargetAndRestartsUpdatedApplication()
+    {
+        FakeUpdateRuntime runtime = new();
+        byte[] original = Encoding.UTF8.GetBytes("old executable");
+        byte[] update = Encoding.UTF8.GetBytes("new executable");
+        runtime.AddFile("download.exe", update);
+        runtime.AddFile("installed.exe", original);
+        UpdateApplyEngine engine = new(runtime);
+
+        engine.Apply(new UpdateArguments(42, "download.exe", "installed.exe", Sha256(update)));
+
+        Assert.Equal(update, runtime.ReadFile("installed.exe"));
+        Assert.False(runtime.FileExists("download.exe"));
+        Assert.False(runtime.FileExists("installed.exe.previous"));
+        Assert.False(runtime.FileExists("installed.exe.update"));
+        Assert.Equal(["installed.exe"], runtime.StartedProcesses);
+        Assert.Equal([(42, TimeSpan.FromSeconds(30))], runtime.ProcessWaits);
+        Assert.Equal(1, runtime.ReplaceCalls);
+    }
+
+    [Fact]
+    public void Apply_WhenAtomicReplaceFails_PreservesOldTargetAndCanRestartIt()
+    {
+        FakeUpdateRuntime runtime = new() { ReplaceException = new IOException("replace failed") };
+        byte[] original = Encoding.UTF8.GetBytes("old executable");
+        byte[] update = Encoding.UTF8.GetBytes("new executable");
+        runtime.AddFile("download.exe", update);
+        runtime.AddFile("installed.exe", original);
+        UpdateApplyEngine engine = new(runtime);
+        UpdateArguments arguments = new(42, "download.exe", "installed.exe", Sha256(update));
+
+        Assert.Throws<IOException>(() => engine.Apply(arguments));
+        engine.TryRestartInstalledApplication(arguments.Target);
+
+        Assert.Equal(original, runtime.ReadFile("installed.exe"));
+        Assert.True(runtime.FileExists("download.exe"));
+        Assert.False(runtime.FileExists("installed.exe.update"));
+        Assert.Equal(["installed.exe"], runtime.StartedProcesses);
+    }
+
+    [Fact]
+    public void Apply_WhenDownloadedFileWasModified_StopsBeforeReplacement()
+    {
+        FakeUpdateRuntime runtime = new();
+        byte[] original = Encoding.UTF8.GetBytes("old executable");
+        runtime.AddFile("download.exe", Encoding.UTF8.GetBytes("tampered executable"));
+        runtime.AddFile("installed.exe", original);
+        UpdateApplyEngine engine = new(runtime);
+
+        Assert.Throws<InvalidDataException>(() =>
+            engine.Apply(new UpdateArguments(42, "download.exe", "installed.exe", Sha256(Encoding.UTF8.GetBytes("expected executable")))));
+
+        Assert.Equal(original, runtime.ReadFile("installed.exe"));
+        Assert.Equal(0, runtime.ReplaceCalls);
+        Assert.Empty(runtime.StartedProcesses);
+    }
+
+    [Fact]
+    public void CleanupStaleUpdaterDirectories_RemovesOldHelpersAndKeepsCurrentOne()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"codex-provider-updater-cleanup-{Guid.NewGuid():N}");
+        string stale = Path.Combine(root, "stale");
+        string current = Path.Combine(root, "current");
+        Directory.CreateDirectory(stale);
+        Directory.CreateDirectory(current);
+        File.WriteAllText(Path.Combine(stale, "CodexProviderSync.Updater.exe"), "old");
+        File.WriteAllText(Path.Combine(current, "CodexProviderSync.Updater.exe"), "running");
+
+        try
+        {
+            UpdateApplier.CleanupStaleUpdaterDirectories(root, current);
+
+            Assert.False(Directory.Exists(stale));
+            Assert.True(Directory.Exists(current));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SystemRuntime_ReplaceFile_InstallsReplacementAndCreatesRollbackBackup()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"codex-provider-atomic-replace-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        string replacement = Path.Combine(root, "app.update");
+        string target = Path.Combine(root, "app.exe");
+        string backup = Path.Combine(root, "app.previous");
+        File.WriteAllText(replacement, "new");
+        File.WriteAllText(target, "old");
+
+        try
+        {
+            new SystemUpdateRuntime().ReplaceFile(replacement, target, backup);
+
+            Assert.Equal("new", File.ReadAllText(target));
+            Assert.Equal("old", File.ReadAllText(backup));
+            Assert.False(File.Exists(replacement));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string Sha256(byte[] content) => Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
+
+    private sealed class FakeUpdateRuntime : IUpdateRuntime
+    {
+        private readonly Dictionary<string, byte[]> _files = new(StringComparer.OrdinalIgnoreCase);
+
+        public Exception? ReplaceException { get; init; }
+        public int ReplaceCalls { get; private set; }
+        public List<string> StartedProcesses { get; } = [];
+        public List<(int ProcessId, TimeSpan Timeout)> ProcessWaits { get; } = [];
+
+        public void AddFile(string path, byte[] content) => _files[path] = content.ToArray();
+
+        public byte[] ReadFile(string path) => _files[path].ToArray();
+
+        public bool FileExists(string path) => _files.ContainsKey(path);
+
+        public void CopyFile(string source, string destination, bool overwrite)
+        {
+            if (!overwrite && _files.ContainsKey(destination))
+            {
+                throw new IOException("destination exists");
+            }
+
+            _files[destination] = _files[source].ToArray();
+        }
+
+        public void ReplaceFile(string replacement, string target, string backup)
+        {
+            ReplaceCalls++;
+            if (ReplaceException is not null)
+            {
+                throw ReplaceException;
+            }
+
+            _files[backup] = _files[target].ToArray();
+            _files[target] = _files[replacement].ToArray();
+            _files.Remove(replacement);
+        }
+
+        public void DeleteFile(string path) => _files.Remove(path);
+
+        public byte[] CalculateSha256(string path) => SHA256.HashData(_files[path]);
+
+        public void WaitForProcessExit(int processId, TimeSpan timeout) => ProcessWaits.Add((processId, timeout));
+
+        public void StartProcess(string path) => StartedProcesses.Add(path);
+    }
+}

--- a/desktop/CodexProviderSync.App.Tests/UpdateApplierTests.cs
+++ b/desktop/CodexProviderSync.App.Tests/UpdateApplierTests.cs
@@ -64,6 +64,29 @@ public sealed class UpdateApplierTests
     }
 
     [Fact]
+    public void Apply_WhenUpdatedApplicationCannotStart_RestoresPreviousVersion()
+    {
+        FakeUpdateRuntime runtime = new() { StartException = new IOException("start failed") };
+        byte[] original = Encoding.UTF8.GetBytes("old executable");
+        byte[] update = Encoding.UTF8.GetBytes("new executable");
+        runtime.AddFile("download.exe", update);
+        runtime.AddFile("installed.exe", original);
+        UpdateApplyEngine engine = new(runtime);
+        UpdateArguments arguments = new(42, "download.exe", "installed.exe", Sha256(update));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => engine.Apply(arguments));
+        engine.TryRestartInstalledApplication(arguments.Target);
+
+        Assert.Contains("previous version was restored", error.Message, StringComparison.Ordinal);
+        Assert.Equal(original, runtime.ReadFile("installed.exe"));
+        Assert.True(runtime.FileExists("download.exe"));
+        Assert.False(runtime.FileExists("installed.exe.previous"));
+        Assert.False(runtime.FileExists("installed.exe.update"));
+        Assert.Equal(["installed.exe"], runtime.StartedProcesses);
+        Assert.Equal(2, runtime.ReplaceCalls);
+    }
+
+    [Fact]
     public void CleanupStaleUpdaterDirectories_RemovesOldHelpersAndKeepsCurrentOne()
     {
         string root = Path.Combine(Path.GetTempPath(), $"codex-provider-updater-cleanup-{Guid.NewGuid():N}");
@@ -119,6 +142,7 @@ public sealed class UpdateApplierTests
         private readonly Dictionary<string, byte[]> _files = new(StringComparer.OrdinalIgnoreCase);
 
         public Exception? ReplaceException { get; init; }
+        public Exception? StartException { get; set; }
         public int ReplaceCalls { get; private set; }
         public List<string> StartedProcesses { get; } = [];
         public List<(int ProcessId, TimeSpan Timeout)> ProcessWaits { get; } = [];
@@ -158,6 +182,15 @@ public sealed class UpdateApplierTests
 
         public void WaitForProcessExit(int processId, TimeSpan timeout) => ProcessWaits.Add((processId, timeout));
 
-        public void StartProcess(string path) => StartedProcesses.Add(path);
+        public void StartProcess(string path)
+        {
+            if (StartException is { } error)
+            {
+                StartException = null;
+                throw error;
+            }
+
+            StartedProcesses.Add(path);
+        }
     }
 }

--- a/desktop/CodexProviderSync.App/MainForm.cs
+++ b/desktop/CodexProviderSync.App/MainForm.cs
@@ -7,6 +7,7 @@ public sealed class MainForm : Form
 {
     private readonly CodexSyncService _syncService = new();
     private readonly SettingsService _settingsService = new();
+    private readonly UpdateService _updateService = new();
 
     private readonly ComboBox _codexHomeCombo = new() { Dock = DockStyle.Fill, DropDownStyle = ComboBoxStyle.DropDown };
     private readonly Button _browseButton = new() { Text = "Browse...", AutoSize = true };
@@ -64,6 +65,7 @@ public sealed class MainForm : Form
     private readonly Button _restoreButton = new() { Text = "恢复备份", Dock = DockStyle.Fill, Height = 40 };
     private readonly Button _openBackupButton = new() { Text = "打开备份目录", Dock = DockStyle.Fill, Height = 40 };
     private readonly Button _pruneBackupsButton = new() { Text = "清理旧备份", Dock = DockStyle.Fill, Height = 40 };
+    private readonly Button _checkUpdateButton = new() { Text = "检查更新", Dock = DockStyle.Fill, Height = 40 };
     private readonly Label _busyLabel = new() { AutoSize = true, ForeColor = Color.DarkGreen, Text = "Ready" };
     private readonly Label _warningLine1 = new()
     {
@@ -288,9 +290,10 @@ public sealed class MainForm : Form
         {
             Dock = DockStyle.Fill,
             ColumnCount = 1,
-            RowCount = 11,
+            RowCount = 12,
             Padding = new Padding(12)
         };
+        panel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         panel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         panel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         panel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
@@ -313,7 +316,8 @@ public sealed class MainForm : Form
         panel.Controls.Add(_restoreButton, 0, 7);
         panel.Controls.Add(_openBackupButton, 0, 8);
         panel.Controls.Add(_pruneBackupsButton, 0, 9);
-        panel.Controls.Add(_busyLabel, 0, 10);
+        panel.Controls.Add(_checkUpdateButton, 0, 10);
+        panel.Controls.Add(_busyLabel, 0, 11);
 
         group.Controls.Add(panel);
         return group;
@@ -440,6 +444,7 @@ public sealed class MainForm : Form
         _restoreButton.Click += async (_, _) => await RestoreBackupAsync();
         _openBackupButton.Click += (_, _) => OpenBackupFolder();
         _pruneBackupsButton.Click += async (_, _) => await PruneBackupsAsync();
+        _checkUpdateButton.Click += async (_, _) => await CheckForUpdatesAsync();
         _providerList.SelectedIndexChanged += (_, _) => UpdateSelectionLabel();
         _codexHomeCombo.Leave += async (_, _) => await PersistHomeSelectionAsync();
     }
@@ -678,6 +683,41 @@ public sealed class MainForm : Form
         });
     }
 
+    private async Task CheckForUpdatesAsync()
+    {
+        await RunBusyAsync("正在检查更新...", async () =>
+        {
+            Version currentVersion = UpdateService.NormalizeVersion(GetType().Assembly.GetName().Version ?? new Version(0, 0, 0));
+            UpdateCheckResult update = await _updateService.CheckForUpdateAsync(currentVersion);
+            if (!update.IsUpdateAvailable)
+            {
+                MessageBox.Show(this, $"当前已是最新版本（v{currentVersion}）。", Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            DialogResult choice = MessageBox.Show(
+                this,
+                $"发现新版本 {update.LatestRelease.TagName}（当前 v{currentVersion}）。\n\n是否下载、校验并重启完成更新？",
+                "发现更新",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Information);
+            if (choice != DialogResult.Yes)
+            {
+                return;
+            }
+
+            string updateDirectory = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "codex-provider-sync",
+                "updates");
+            string downloadedExe = await _updateService.DownloadWindowsExeAsync(update.LatestRelease, updateDirectory);
+            string targetExe = Environment.ProcessPath ?? throw new InvalidOperationException("Unable to determine the current executable path.");
+            UpdateApplier.Start(downloadedExe, targetExe);
+            AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] 已下载并校验 {update.LatestRelease.TagName}，正在重启完成更新。");
+            BeginInvoke(Close);
+        });
+    }
+
     private void ReloadRecentHomes()
     {
         string currentText = _codexHomeCombo.Text;
@@ -856,6 +896,7 @@ public sealed class MainForm : Form
         _restoreButton.Enabled = !busy;
         _openBackupButton.Enabled = !busy;
         _pruneBackupsButton.Enabled = !busy;
+        _checkUpdateButton.Enabled = !busy;
         _providerList.Enabled = !busy;
         _manualProviderText.Enabled = !busy;
         _codexHomeCombo.Enabled = !busy;

--- a/desktop/CodexProviderSync.App/MainForm.cs
+++ b/desktop/CodexProviderSync.App/MainForm.cs
@@ -710,9 +710,9 @@ public sealed class MainForm : Form
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "codex-provider-sync",
                 "updates");
-            string downloadedExe = await _updateService.DownloadWindowsExeAsync(update.LatestRelease, updateDirectory);
+            DownloadedUpdate downloadedUpdate = await _updateService.DownloadWindowsExeAsync(update.LatestRelease, updateDirectory);
             string targetExe = Environment.ProcessPath ?? throw new InvalidOperationException("Unable to determine the current executable path.");
-            UpdateApplier.Start(downloadedExe, targetExe);
+            UpdateApplier.Start(downloadedUpdate.Path, targetExe, downloadedUpdate.Sha256);
             AppendLog($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] 已下载并校验 {update.LatestRelease.TagName}，正在重启完成更新。");
             BeginInvoke(Close);
         });

--- a/desktop/CodexProviderSync.App/Program.cs
+++ b/desktop/CodexProviderSync.App/Program.cs
@@ -12,6 +12,8 @@ static class Program
             return;
         }
 
+        UpdateApplier.CleanupStaleUpdaterDirectories();
+
         try
         {
             SingleInstanceGuard guard = new();

--- a/desktop/CodexProviderSync.App/Program.cs
+++ b/desktop/CodexProviderSync.App/Program.cs
@@ -5,8 +5,13 @@ namespace CodexProviderSync.App;
 static class Program
 {
     [STAThread]
-    static void Main()
+    static void Main(string[] args)
     {
+        if (UpdateApplier.TryRun(args))
+        {
+            return;
+        }
+
         try
         {
             SingleInstanceGuard guard = new();

--- a/desktop/CodexProviderSync.App/Properties/AssemblyInfo.cs
+++ b/desktop/CodexProviderSync.App/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CodexProviderSync.App.Tests")]

--- a/desktop/CodexProviderSync.App/UpdateApplier.cs
+++ b/desktop/CodexProviderSync.App/UpdateApplier.cs
@@ -172,9 +172,31 @@ internal sealed class UpdateApplyEngine(IUpdateRuntime runtime)
             runtime.CopyFile(arguments.Source, replacementPath, overwrite: true);
             VerifySha256(replacementPath, arguments.ExpectedSha256);
             runtime.ReplaceFile(replacementPath, arguments.Target, backupPath);
+            try
+            {
+                runtime.StartProcess(arguments.Target);
+            }
+            catch (Exception startError)
+            {
+                try
+                {
+                    runtime.ReplaceFile(backupPath, arguments.Target, replacementPath);
+                }
+                catch (Exception rollbackError)
+                {
+                    throw new AggregateException(
+                        "The updated application could not be started and the previous version could not be restored.",
+                        startError,
+                        rollbackError);
+                }
+
+                throw new InvalidOperationException(
+                    "The updated application could not be started. The previous version was restored.",
+                    startError);
+            }
+
             TryDelete(backupPath);
             TryDelete(arguments.Source);
-            runtime.StartProcess(arguments.Target);
         }
         finally
         {

--- a/desktop/CodexProviderSync.App/UpdateApplier.cs
+++ b/desktop/CodexProviderSync.App/UpdateApplier.cs
@@ -13,14 +13,18 @@ internal static class UpdateApplier
             return false;
         }
 
+        UpdateArguments? update = null;
         try
         {
-            Apply(ParseArguments(args[1..]));
+            update = ParseArguments(args[1..]);
+            Apply(update);
         }
         catch (Exception error)
         {
+            TryRestartInstalledApplication(update?.Target);
+            string downloadedUpdatePath = update?.Source ?? "unavailable";
             MessageBox.Show(
-                $"Codex Provider Sync update failed.\n\n{error.Message}\n\nYour existing version was kept whenever possible.",
+                $"Codex Provider Sync update failed.\n\n{error.Message}\n\nDownloaded update:\n{downloadedUpdatePath}\n\nThe installed version was restarted when possible. You can manually replace the EXE with the downloaded update.",
                 "Codex Provider Sync",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Error);
@@ -111,6 +115,27 @@ internal static class UpdateApplier
         catch (ArgumentException)
         {
             // The main application exited before the helper queried it.
+        }
+    }
+
+    private static void TryRestartInstalledApplication(string? targetExePath)
+    {
+        if (string.IsNullOrWhiteSpace(targetExePath) || !File.Exists(targetExePath))
+        {
+            return;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = targetExePath,
+                UseShellExecute = true
+            });
+        }
+        catch
+        {
+            // The update error dialog still gives the user the target and downloaded paths.
         }
     }
 

--- a/desktop/CodexProviderSync.App/UpdateApplier.cs
+++ b/desktop/CodexProviderSync.App/UpdateApplier.cs
@@ -1,0 +1,129 @@
+using System.Diagnostics;
+
+namespace CodexProviderSync.App;
+
+internal static class UpdateApplier
+{
+    private const string ApplyArgument = "--apply-update";
+
+    public static bool TryRun(string[] args)
+    {
+        if (args.Length == 0 || !string.Equals(args[0], ApplyArgument, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        try
+        {
+            Apply(ParseArguments(args[1..]));
+        }
+        catch (Exception error)
+        {
+            MessageBox.Show(
+                $"Codex Provider Sync update failed.\n\n{error.Message}\n\nYour existing version was kept whenever possible.",
+                "Codex Provider Sync",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+        }
+
+        return true;
+    }
+
+    public static void Start(string downloadedExePath, string targetExePath)
+    {
+        string updaterDirectory = Path.Combine(Path.GetTempPath(), "codex-provider-sync-updater", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(updaterDirectory);
+        string updaterPath = Path.Combine(updaterDirectory, "CodexProviderSync.Updater.exe");
+        File.Copy(Environment.ProcessPath ?? throw new InvalidOperationException("Unable to determine the current executable path."), updaterPath);
+
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = updaterPath,
+            UseShellExecute = true
+        };
+        startInfo.ArgumentList.Add(ApplyArgument);
+        startInfo.ArgumentList.Add("--pid");
+        startInfo.ArgumentList.Add(Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        startInfo.ArgumentList.Add("--source");
+        startInfo.ArgumentList.Add(Path.GetFullPath(downloadedExePath));
+        startInfo.ArgumentList.Add("--target");
+        startInfo.ArgumentList.Add(Path.GetFullPath(targetExePath));
+
+        _ = Process.Start(startInfo) ?? throw new InvalidOperationException("Unable to start the update helper.");
+    }
+
+    private static void Apply(UpdateArguments arguments)
+    {
+        if (!File.Exists(arguments.Source))
+        {
+            throw new FileNotFoundException("Downloaded update file was not found.", arguments.Source);
+        }
+
+        if (!File.Exists(arguments.Target))
+        {
+            throw new FileNotFoundException("Installed application file was not found.", arguments.Target);
+        }
+
+        WaitForProcessExit(arguments.ParentProcessId, TimeSpan.FromSeconds(30));
+        string replacementPath = arguments.Target + ".update";
+        string backupPath = arguments.Target + ".previous";
+        try
+        {
+            File.Copy(arguments.Source, replacementPath, overwrite: true);
+            File.Move(arguments.Target, backupPath, overwrite: true);
+            try
+            {
+                File.Move(replacementPath, arguments.Target, overwrite: true);
+            }
+            catch
+            {
+                File.Move(backupPath, arguments.Target, overwrite: true);
+                throw;
+            }
+
+            File.Delete(backupPath);
+            File.Delete(arguments.Source);
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = arguments.Target,
+                UseShellExecute = true
+            });
+        }
+        finally
+        {
+            if (File.Exists(replacementPath))
+            {
+                File.Delete(replacementPath);
+            }
+        }
+    }
+
+    private static void WaitForProcessExit(int processId, TimeSpan timeout)
+    {
+        try
+        {
+            using Process parent = Process.GetProcessById(processId);
+            if (!parent.WaitForExit((int)timeout.TotalMilliseconds))
+            {
+                throw new TimeoutException("The existing application did not exit before the update timed out.");
+            }
+        }
+        catch (ArgumentException)
+        {
+            // The main application exited before the helper queried it.
+        }
+    }
+
+    private static UpdateArguments ParseArguments(string[] args)
+    {
+        if (args.Length != 6 || args[0] != "--pid" || args[2] != "--source" || args[4] != "--target" ||
+            !int.TryParse(args[1], out int parentProcessId) || parentProcessId <= 0)
+        {
+            throw new ArgumentException("Update helper arguments are invalid.");
+        }
+
+        return new UpdateArguments(parentProcessId, Path.GetFullPath(args[3]), Path.GetFullPath(args[5]));
+    }
+
+    private sealed record UpdateArguments(int ParentProcessId, string Source, string Target);
+}

--- a/desktop/CodexProviderSync.App/UpdateApplier.cs
+++ b/desktop/CodexProviderSync.App/UpdateApplier.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics;
+using System.Security.Cryptography;
 
 namespace CodexProviderSync.App;
 
 internal static class UpdateApplier
 {
     private const string ApplyArgument = "--apply-update";
+    private const string UpdaterDirectoryName = "codex-provider-sync-updater";
 
     public static bool TryRun(string[] args)
     {
@@ -14,14 +16,15 @@ internal static class UpdateApplier
         }
 
         UpdateArguments? update = null;
+        UpdateApplyEngine engine = new(new SystemUpdateRuntime());
         try
         {
             update = ParseArguments(args[1..]);
-            Apply(update);
+            engine.Apply(update);
         }
         catch (Exception error)
         {
-            TryRestartInstalledApplication(update?.Target);
+            engine.TryRestartInstalledApplication(update?.Target);
             string downloadedUpdatePath = update?.Source ?? "unavailable";
             MessageBox.Show(
                 $"Codex Provider Sync update failed.\n\n{error.Message}\n\nDownloaded update:\n{downloadedUpdatePath}\n\nThe installed version was restarted when possible. You can manually replace the EXE with the downloaded update.",
@@ -33,9 +36,11 @@ internal static class UpdateApplier
         return true;
     }
 
-    public static void Start(string downloadedExePath, string targetExePath)
+    public static void Start(string downloadedExePath, string targetExePath, string expectedSha256)
     {
-        string updaterDirectory = Path.Combine(Path.GetTempPath(), "codex-provider-sync-updater", Guid.NewGuid().ToString("N"));
+        CleanupStaleUpdaterDirectories();
+        string updaterRoot = UpdaterRoot();
+        string updaterDirectory = Path.Combine(updaterRoot, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(updaterDirectory);
         string updaterPath = Path.Combine(updaterDirectory, "CodexProviderSync.Updater.exe");
         File.Copy(Environment.ProcessPath ?? throw new InvalidOperationException("Unable to determine the current executable path."), updaterPath);
@@ -50,59 +55,205 @@ internal static class UpdateApplier
         startInfo.ArgumentList.Add(Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
         startInfo.ArgumentList.Add("--source");
         startInfo.ArgumentList.Add(Path.GetFullPath(downloadedExePath));
+        startInfo.ArgumentList.Add("--sha256");
+        startInfo.ArgumentList.Add(NormalizeSha256(expectedSha256));
         startInfo.ArgumentList.Add("--target");
         startInfo.ArgumentList.Add(Path.GetFullPath(targetExePath));
 
         _ = Process.Start(startInfo) ?? throw new InvalidOperationException("Unable to start the update helper.");
     }
 
-    private static void Apply(UpdateArguments arguments)
+    public static void CleanupStaleUpdaterDirectories()
     {
-        if (!File.Exists(arguments.Source))
+        string root = UpdaterRoot();
+        string? currentDirectory = Environment.ProcessPath is { } processPath
+            ? Path.GetDirectoryName(Path.GetFullPath(processPath))
+            : null;
+        try
+        {
+            CleanupStaleUpdaterDirectories(root, currentDirectory);
+        }
+        catch
+        {
+            // Cleanup must never prevent the main application from starting.
+        }
+    }
+
+    internal static void CleanupStaleUpdaterDirectories(string root, string? currentDirectory)
+    {
+        if (!Directory.Exists(root))
+        {
+            return;
+        }
+
+        foreach (string directory in Directory.EnumerateDirectories(root))
+        {
+            if (string.Equals(Path.GetFullPath(directory), currentDirectory, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+                // A currently exiting helper can still hold its own EXE. A later launch retries cleanup.
+            }
+        }
+
+        try
+        {
+            if (!Directory.EnumerateFileSystemEntries(root).Any())
+            {
+                Directory.Delete(root);
+            }
+        }
+        catch
+        {
+            // Cleanup must never prevent the main application from starting.
+        }
+    }
+
+    private static UpdateArguments ParseArguments(string[] args)
+    {
+        if (args.Length != 8 || args[0] != "--pid" || args[2] != "--source" || args[4] != "--sha256" || args[6] != "--target" ||
+            !int.TryParse(args[1], out int parentProcessId) || parentProcessId <= 0)
+        {
+            throw new ArgumentException("Update helper arguments are invalid.");
+        }
+
+        return new UpdateArguments(
+            parentProcessId,
+            Path.GetFullPath(args[3]),
+            Path.GetFullPath(args[7]),
+            NormalizeSha256(args[5]));
+    }
+
+    private static string UpdaterRoot() => Path.Combine(Path.GetTempPath(), UpdaterDirectoryName);
+
+    private static string NormalizeSha256(string value)
+    {
+        string hash = value.Trim();
+        if (hash.Length != 64 || !hash.All(Uri.IsHexDigit))
+        {
+            throw new ArgumentException("Expected update SHA-256 is invalid.", nameof(value));
+        }
+
+        return hash.ToLowerInvariant();
+    }
+}
+
+internal sealed record UpdateArguments(int ParentProcessId, string Source, string Target, string ExpectedSha256);
+
+internal sealed class UpdateApplyEngine(IUpdateRuntime runtime)
+{
+    public void Apply(UpdateArguments arguments)
+    {
+        if (!runtime.FileExists(arguments.Source))
         {
             throw new FileNotFoundException("Downloaded update file was not found.", arguments.Source);
         }
 
-        if (!File.Exists(arguments.Target))
+        if (!runtime.FileExists(arguments.Target))
         {
             throw new FileNotFoundException("Installed application file was not found.", arguments.Target);
         }
 
-        WaitForProcessExit(arguments.ParentProcessId, TimeSpan.FromSeconds(30));
+        runtime.WaitForProcessExit(arguments.ParentProcessId, TimeSpan.FromSeconds(30));
+        VerifySha256(arguments.Source, arguments.ExpectedSha256);
+
         string replacementPath = arguments.Target + ".update";
         string backupPath = arguments.Target + ".previous";
         try
         {
-            File.Copy(arguments.Source, replacementPath, overwrite: true);
-            File.Move(arguments.Target, backupPath, overwrite: true);
-            try
-            {
-                File.Move(replacementPath, arguments.Target, overwrite: true);
-            }
-            catch
-            {
-                File.Move(backupPath, arguments.Target, overwrite: true);
-                throw;
-            }
-
-            File.Delete(backupPath);
-            File.Delete(arguments.Source);
-            Process.Start(new ProcessStartInfo
-            {
-                FileName = arguments.Target,
-                UseShellExecute = true
-            });
+            TryDelete(backupPath);
+            runtime.CopyFile(arguments.Source, replacementPath, overwrite: true);
+            VerifySha256(replacementPath, arguments.ExpectedSha256);
+            runtime.ReplaceFile(replacementPath, arguments.Target, backupPath);
+            TryDelete(backupPath);
+            TryDelete(arguments.Source);
+            runtime.StartProcess(arguments.Target);
         }
         finally
         {
-            if (File.Exists(replacementPath))
-            {
-                File.Delete(replacementPath);
-            }
+            TryDelete(replacementPath);
         }
     }
 
-    private static void WaitForProcessExit(int processId, TimeSpan timeout)
+    public void TryRestartInstalledApplication(string? targetExePath)
+    {
+        if (string.IsNullOrWhiteSpace(targetExePath) || !runtime.FileExists(targetExePath))
+        {
+            return;
+        }
+
+        try
+        {
+            runtime.StartProcess(targetExePath);
+        }
+        catch
+        {
+            // The update error dialog still gives the user the target and downloaded paths.
+        }
+    }
+
+    private void VerifySha256(string path, string expectedSha256)
+    {
+        byte[] expectedHash = Convert.FromHexString(expectedSha256);
+        byte[] actualHash = runtime.CalculateSha256(path);
+        if (!CryptographicOperations.FixedTimeEquals(expectedHash, actualHash))
+        {
+            throw new InvalidDataException("The update file no longer matches the published SHA-256 checksum.");
+        }
+    }
+
+    private void TryDelete(string path)
+    {
+        try
+        {
+            if (runtime.FileExists(path))
+            {
+                runtime.DeleteFile(path);
+            }
+        }
+        catch
+        {
+            // Update cleanup is best-effort and must not turn a successful replacement into a failure.
+        }
+    }
+}
+
+internal interface IUpdateRuntime
+{
+    bool FileExists(string path);
+    void CopyFile(string source, string destination, bool overwrite);
+    void ReplaceFile(string replacement, string target, string backup);
+    void DeleteFile(string path);
+    byte[] CalculateSha256(string path);
+    void WaitForProcessExit(int processId, TimeSpan timeout);
+    void StartProcess(string path);
+}
+
+internal sealed class SystemUpdateRuntime : IUpdateRuntime
+{
+    public bool FileExists(string path) => File.Exists(path);
+
+    public void CopyFile(string source, string destination, bool overwrite) => File.Copy(source, destination, overwrite);
+
+    public void ReplaceFile(string replacement, string target, string backup) =>
+        File.Replace(replacement, target, backup, ignoreMetadataErrors: true);
+
+    public void DeleteFile(string path) => File.Delete(path);
+
+    public byte[] CalculateSha256(string path)
+    {
+        using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return SHA256.HashData(stream);
+    }
+
+    public void WaitForProcessExit(int processId, TimeSpan timeout)
     {
         try
         {
@@ -118,37 +269,12 @@ internal static class UpdateApplier
         }
     }
 
-    private static void TryRestartInstalledApplication(string? targetExePath)
+    public void StartProcess(string path)
     {
-        if (string.IsNullOrWhiteSpace(targetExePath) || !File.Exists(targetExePath))
+        _ = Process.Start(new ProcessStartInfo
         {
-            return;
-        }
-
-        try
-        {
-            Process.Start(new ProcessStartInfo
-            {
-                FileName = targetExePath,
-                UseShellExecute = true
-            });
-        }
-        catch
-        {
-            // The update error dialog still gives the user the target and downloaded paths.
-        }
+            FileName = path,
+            UseShellExecute = true
+        }) ?? throw new InvalidOperationException($"Unable to start {path}.");
     }
-
-    private static UpdateArguments ParseArguments(string[] args)
-    {
-        if (args.Length != 6 || args[0] != "--pid" || args[2] != "--source" || args[4] != "--target" ||
-            !int.TryParse(args[1], out int parentProcessId) || parentProcessId <= 0)
-        {
-            throw new ArgumentException("Update helper arguments are invalid.");
-        }
-
-        return new UpdateArguments(parentProcessId, Path.GetFullPath(args[3]), Path.GetFullPath(args[5]));
-    }
-
-    private sealed record UpdateArguments(int ParentProcessId, string Source, string Target);
 }

--- a/desktop/CodexProviderSync.Core.Tests/UpdateServiceTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/UpdateServiceTests.cs
@@ -29,6 +29,34 @@ public sealed class UpdateServiceTests
     }
 
     [Fact]
+    public async Task CheckForUpdate_WhenApiIsRateLimited_FallsBackToLatestReleaseRedirect()
+    {
+        using HttpClient client = CreateClient(request =>
+        {
+            if (request.RequestUri!.Host == "api.github.com")
+            {
+                return new HttpResponseMessage(HttpStatusCode.Forbidden);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                RequestMessage = new HttpRequestMessage(
+                    HttpMethod.Get,
+                    "https://github.com/Dailin521/codex-provider-sync/releases/tag/v0.2.10")
+            };
+        });
+        UpdateService service = new(client);
+
+        UpdateCheckResult result = await service.CheckForUpdateAsync(new Version(0, 2, 9, 0));
+
+        Assert.True(result.IsUpdateAvailable);
+        Assert.Equal("v0.2.10", result.LatestRelease.TagName);
+        Assert.Equal(
+            "https://github.com/Dailin521/codex-provider-sync/releases/download/v0.2.10/CodexProviderSync.exe",
+            result.LatestRelease.FindAsset("CodexProviderSync.exe").DownloadUrl.AbsoluteUri);
+    }
+
+    [Fact]
     public async Task DownloadWindowsExe_WritesOnlyVerifiedPayload()
     {
         byte[] executable = Encoding.UTF8.GetBytes("verified executable bytes");
@@ -49,9 +77,10 @@ public sealed class UpdateServiceTests
 
         try
         {
-            string path = await service.DownloadWindowsExeAsync(release, directory);
+            DownloadedUpdate update = await service.DownloadWindowsExeAsync(release, directory);
 
-            Assert.Equal(executable, await File.ReadAllBytesAsync(path));
+            Assert.Equal(executable, await File.ReadAllBytesAsync(update.Path));
+            Assert.Equal(hash, update.Sha256);
             Assert.DoesNotContain(Directory.EnumerateFiles(directory), path => path.EndsWith(".download", StringComparison.Ordinal));
         }
         finally

--- a/desktop/CodexProviderSync.Core.Tests/UpdateServiceTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/UpdateServiceTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CodexProviderSync.Core.Tests;
+
+public sealed class UpdateServiceTests
+{
+    [Fact]
+    public async Task CheckForUpdate_NormalizesAssemblyVersionAndDetectsNewerRelease()
+    {
+        using HttpClient client = CreateClient(_ => JsonResponse("""
+            {
+              "tag_name": "v0.2.10",
+              "assets": [
+                { "name": "CodexProviderSync.exe", "browser_download_url": "https://example.test/CodexProviderSync.exe" },
+                { "name": "CodexProviderSync.exe.sha256", "browser_download_url": "https://example.test/CodexProviderSync.exe.sha256" }
+              ]
+            }
+            """));
+        UpdateService service = new(client);
+
+        UpdateCheckResult result = await service.CheckForUpdateAsync(new Version(0, 2, 9, 0));
+
+        Assert.True(result.IsUpdateAvailable);
+        Assert.Equal(new Version(0, 2, 9), result.CurrentVersion);
+        Assert.Equal(new Version(0, 2, 10), result.LatestRelease.Version);
+    }
+
+    [Fact]
+    public async Task DownloadWindowsExe_WritesOnlyVerifiedPayload()
+    {
+        byte[] executable = Encoding.UTF8.GetBytes("verified executable bytes");
+        string hash = Convert.ToHexString(SHA256.HashData(executable)).ToLowerInvariant();
+        using HttpClient client = CreateClient(request => request.RequestUri!.AbsolutePath switch
+        {
+            "/CodexProviderSync.exe.sha256" => TextResponse($"{hash}  CodexProviderSync.exe\n"),
+            "/CodexProviderSync.exe" => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(executable) },
+            _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+        });
+        UpdateService service = new(client);
+        string directory = Path.Combine(Path.GetTempPath(), $"codex-provider-update-test-{Guid.NewGuid():N}");
+        ReleaseInfo release = new("v0.2.10", new Version(0, 2, 10),
+        [
+            new ReleaseAsset("CodexProviderSync.exe", new Uri("https://example.test/CodexProviderSync.exe")),
+            new ReleaseAsset("CodexProviderSync.exe.sha256", new Uri("https://example.test/CodexProviderSync.exe.sha256"))
+        ]);
+
+        try
+        {
+            string path = await service.DownloadWindowsExeAsync(release, directory);
+
+            Assert.Equal(executable, await File.ReadAllBytesAsync(path));
+            Assert.DoesNotContain(Directory.EnumerateFiles(directory), path => path.EndsWith(".download", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("v0.2.9", 0, 2, 9)]
+    [InlineData(" 1.4.0 ", 1, 4, 0)]
+    public void ParseReleaseVersion_AcceptsStableVersionTags(string tag, int major, int minor, int build)
+    {
+        Assert.Equal(new Version(major, minor, build), UpdateService.ParseReleaseVersion(tag));
+    }
+
+    private static HttpClient CreateClient(Func<HttpRequestMessage, HttpResponseMessage> responder) => new(new DelegateHandler(responder));
+
+    private static HttpResponseMessage JsonResponse(string content) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(content, Encoding.UTF8, "application/json")
+    };
+
+    private static HttpResponseMessage TextResponse(string content) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(content, Encoding.UTF8, "text/plain")
+    };
+
+    private sealed class DelegateHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(responder(request));
+    }
+}

--- a/desktop/CodexProviderSync.Core/UpdateService.cs
+++ b/desktop/CodexProviderSync.Core/UpdateService.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using System.Net;
 using System.Security.Cryptography;
 using System.Text.Json;
 
@@ -11,6 +12,8 @@ namespace CodexProviderSync.Core;
 public sealed class UpdateService
 {
     private const string LatestReleaseUrl = "https://api.github.com/repos/Dailin521/codex-provider-sync/releases/latest";
+    private const string LatestReleasePageUrl = "https://github.com/Dailin521/codex-provider-sync/releases/latest";
+    private const string ReleaseTagPathPrefix = "/Dailin521/codex-provider-sync/releases/tag/";
     private readonly HttpClient _httpClient;
 
     public UpdateService(HttpClient? httpClient = null)
@@ -25,6 +28,11 @@ public sealed class UpdateService
     public async Task<UpdateCheckResult> CheckForUpdateAsync(Version currentVersion, CancellationToken cancellationToken = default)
     {
         using HttpResponseMessage response = await _httpClient.GetAsync(LatestReleaseUrl, cancellationToken);
+        if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.TooManyRequests)
+        {
+            return await CheckForUpdateViaReleasePageAsync(currentVersion, cancellationToken);
+        }
+
         response.EnsureSuccessStatusCode();
 
         await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken);
@@ -48,7 +56,35 @@ public sealed class UpdateService
         return new UpdateCheckResult(normalizedCurrentVersion, release, version > normalizedCurrentVersion);
     }
 
-    public async Task<string> DownloadWindowsExeAsync(ReleaseInfo release, string downloadDirectory, CancellationToken cancellationToken = default)
+    private async Task<UpdateCheckResult> CheckForUpdateViaReleasePageAsync(Version currentVersion, CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage response = await _httpClient.GetAsync(
+            LatestReleasePageUrl,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        Uri finalUri = response.RequestMessage?.RequestUri
+            ?? throw new InvalidDataException("GitHub latest release redirect did not provide a destination URL.");
+        string path = finalUri.AbsolutePath;
+        if (!path.StartsWith(ReleaseTagPathPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException($"GitHub latest release redirect returned an unexpected URL: {finalUri}");
+        }
+
+        string tagName = Uri.UnescapeDataString(path[ReleaseTagPathPrefix.Length..]).Trim('/');
+        Version version = ParseReleaseVersion(tagName);
+        string assetRoot = $"https://github.com/Dailin521/codex-provider-sync/releases/download/{Uri.EscapeDataString(tagName)}";
+        ReleaseInfo release = new(tagName, version,
+        [
+            new ReleaseAsset("CodexProviderSync.exe", new Uri($"{assetRoot}/CodexProviderSync.exe")),
+            new ReleaseAsset("CodexProviderSync.exe.sha256", new Uri($"{assetRoot}/CodexProviderSync.exe.sha256"))
+        ]);
+        Version normalizedCurrentVersion = NormalizeVersion(currentVersion);
+        return new UpdateCheckResult(normalizedCurrentVersion, release, version > normalizedCurrentVersion);
+    }
+
+    public async Task<DownloadedUpdate> DownloadWindowsExeAsync(ReleaseInfo release, string downloadDirectory, CancellationToken cancellationToken = default)
     {
         ReleaseAsset exe = release.FindAsset("CodexProviderSync.exe");
         ReleaseAsset checksum = release.FindAsset("CodexProviderSync.exe.sha256");
@@ -77,7 +113,7 @@ public sealed class UpdateService
             }
 
             File.Move(temporaryPath, finalPath, overwrite: true);
-            return finalPath;
+            return new DownloadedUpdate(finalPath, expectedHash);
         }
         catch
         {
@@ -144,3 +180,5 @@ public sealed record ReleaseInfo(string TagName, Version Version, IReadOnlyList<
 }
 
 public sealed record UpdateCheckResult(Version CurrentVersion, ReleaseInfo LatestRelease, bool IsUpdateAvailable);
+
+public sealed record DownloadedUpdate(string Path, string Sha256);

--- a/desktop/CodexProviderSync.Core/UpdateService.cs
+++ b/desktop/CodexProviderSync.Core/UpdateService.cs
@@ -1,0 +1,146 @@
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace CodexProviderSync.Core;
+
+/// <summary>
+/// Reads published GitHub releases and downloads a verified Windows GUI update.
+/// The caller owns the UI and the process-restart portion of applying an update.
+/// </summary>
+public sealed class UpdateService
+{
+    private const string LatestReleaseUrl = "https://api.github.com/repos/Dailin521/codex-provider-sync/releases/latest";
+    private readonly HttpClient _httpClient;
+
+    public UpdateService(HttpClient? httpClient = null)
+    {
+        _httpClient = httpClient ?? new HttpClient();
+        if (!_httpClient.DefaultRequestHeaders.UserAgent.Any())
+        {
+            _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("CodexProviderSync", "1.0"));
+        }
+    }
+
+    public async Task<UpdateCheckResult> CheckForUpdateAsync(Version currentVersion, CancellationToken cancellationToken = default)
+    {
+        using HttpResponseMessage response = await _httpClient.GetAsync(LatestReleaseUrl, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using JsonDocument document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        JsonElement root = document.RootElement;
+        string tagName = root.GetProperty("tag_name").GetString() ?? throw new InvalidDataException("Release tag is missing.");
+        Version version = ParseReleaseVersion(tagName);
+        List<ReleaseAsset> assets = [];
+        foreach (JsonElement asset in root.GetProperty("assets").EnumerateArray())
+        {
+            string name = asset.GetProperty("name").GetString() ?? string.Empty;
+            string url = asset.GetProperty("browser_download_url").GetString() ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(name) && Uri.TryCreate(url, UriKind.Absolute, out Uri? downloadUrl))
+            {
+                assets.Add(new ReleaseAsset(name, downloadUrl));
+            }
+        }
+
+        Version normalizedCurrentVersion = NormalizeVersion(currentVersion);
+        ReleaseInfo release = new(tagName, version, assets);
+        return new UpdateCheckResult(normalizedCurrentVersion, release, version > normalizedCurrentVersion);
+    }
+
+    public async Task<string> DownloadWindowsExeAsync(ReleaseInfo release, string downloadDirectory, CancellationToken cancellationToken = default)
+    {
+        ReleaseAsset exe = release.FindAsset("CodexProviderSync.exe");
+        ReleaseAsset checksum = release.FindAsset("CodexProviderSync.exe.sha256");
+        Directory.CreateDirectory(downloadDirectory);
+
+        string finalPath = Path.Combine(downloadDirectory, $"CodexProviderSync-{release.Version}.exe");
+        string temporaryPath = finalPath + ".download";
+        try
+        {
+            string checksumText = await _httpClient.GetStringAsync(checksum.DownloadUrl, cancellationToken);
+            string expectedHash = ParseSha256(checksumText, "CodexProviderSync.exe");
+
+            using HttpResponseMessage response = await _httpClient.GetAsync(exe.DownloadUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            await using (Stream source = await response.Content.ReadAsStreamAsync(cancellationToken))
+            await using (FileStream destination = new(temporaryPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true))
+            {
+                await source.CopyToAsync(destination, cancellationToken);
+                await destination.FlushAsync(cancellationToken);
+            }
+
+            string actualHash = await CalculateSha256Async(temporaryPath, cancellationToken);
+            if (!CryptographicOperations.FixedTimeEquals(Convert.FromHexString(expectedHash), Convert.FromHexString(actualHash)))
+            {
+                throw new InvalidDataException("The downloaded update does not match the published SHA-256 checksum.");
+            }
+
+            File.Move(temporaryPath, finalPath, overwrite: true);
+            return finalPath;
+        }
+        catch
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+
+            throw;
+        }
+    }
+
+    internal static Version ParseReleaseVersion(string tagName)
+    {
+        string value = tagName.Trim();
+        if (value.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+        {
+            value = value[1..];
+        }
+
+        if (!Version.TryParse(value, out Version? version))
+        {
+            throw new InvalidDataException($"Release tag '{tagName}' is not a supported version.");
+        }
+
+        return version;
+    }
+
+    public static Version NormalizeVersion(Version version) => new(version.Major, version.Minor, Math.Max(version.Build, 0));
+
+    internal static string ParseSha256(string checksumText, string expectedFileName)
+    {
+        string? line = checksumText
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault(value => value.EndsWith(expectedFileName, StringComparison.Ordinal));
+        if (line is null)
+        {
+            throw new InvalidDataException($"Checksum file does not contain {expectedFileName}.");
+        }
+
+        string hash = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)[0];
+        if (hash.Length != 64 || !hash.All(Uri.IsHexDigit))
+        {
+            throw new InvalidDataException("Published SHA-256 checksum is invalid.");
+        }
+
+        return hash.ToLowerInvariant();
+    }
+
+    private static async Task<string> CalculateSha256Async(string path, CancellationToken cancellationToken)
+    {
+        await using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        byte[] hash = await SHA256.HashDataAsync(stream, cancellationToken);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}
+
+public sealed record ReleaseAsset(string Name, Uri DownloadUrl);
+
+public sealed record ReleaseInfo(string TagName, Version Version, IReadOnlyList<ReleaseAsset> Assets)
+{
+    public ReleaseAsset FindAsset(string name) => Assets.FirstOrDefault(asset => string.Equals(asset.Name, name, StringComparison.Ordinal))
+        ?? throw new InvalidDataException($"Release {TagName} does not contain {name}.");
+}
+
+public sealed record UpdateCheckResult(Version CurrentVersion, ReleaseInfo LatestRelease, bool IsUpdateAvailable);


### PR DESCRIPTION
## 变更

- GUI 增加检查更新与确认更新入口。
- 下载 GitHub Release EXE 并校验 SHA-256。
- 通过临时更新器替换旧 EXE 后自动重启。
- 补充更新逻辑测试与使用说明。

## 验证

- dotnet test（47/47）
- Windows 单文件发布构建
- npm test（41/41）