### PR TITLE
Sync all existing Codex state databases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,10 @@ For normal Windows users, prefer the GUI app when it is available. Use the CLI w
 The tool works by updating both:
 
 - rollout metadata under `~/.codex/sessions` and `~/.codex/archived_sessions`
-- SQLite thread metadata in the detected Codex state database, normally
-  `~/.codex/sqlite/state_5.sqlite` with legacy fallback to
-  `~/.codex/state_5.sqlite`
+- SQLite thread metadata in every existing Codex state database. The current
+  location is normally `~/.codex/sqlite/state_5.sqlite`, while some Desktop
+  versions may also keep using the legacy `~/.codex/state_5.sqlite`; when both
+  exist, sync updates and backs up both.
 
 Do not solve this by manually editing rollout files only unless the user explicitly asks for manual intervention.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ codex-provider sync
 
 CLI 需要 Node.js `16+`。Node 24+ 会优先使用内置 `node:sqlite`；旧版 Node 会使用可选依赖 `better-sqlite3`。
 
+当 `~/.codex/sqlite/state_5.sqlite` 与旧路径 `~/.codex/state_5.sqlite` 同时存在时，同步和备份会同时处理两个数据库，避免 Codex Desktop 重新读到旧的 provider 元数据。
+
 更多 CLI 常用命令：
 
 ```bash

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -71,7 +71,7 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
-    public async Task RunSync_UpdatesLegacyRootSqliteDatabase_WhenSqliteDirStateIsStale()
+    public async Task RunSync_UpdatesAndBacksUpBothSqliteDatabases_WhenBothLocationsExist()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
         await fixture.WriteConfigAsync("model_provider = \"openai\"");
@@ -92,11 +92,16 @@ public sealed class CoreIntegrationTests
         CodexSyncService service = new();
         SyncResult syncResult = await service.RunSyncAsync(fixture.CodexHome);
 
-        Assert.Equal(2, syncResult.SqliteRowsUpdated);
+        Assert.Equal(3, syncResult.SqliteRowsUpdated);
         BackupMetadataFile backupMetadata = JsonSerializer.Deserialize<BackupMetadataFile>(
             await File.ReadAllTextAsync(Path.Combine(syncResult.BackupDir, "metadata.json")),
             new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })!;
-        Assert.Equal([AppConstants.DbFileBasename], backupMetadata.DbFiles);
+        Assert.Equal(
+        [
+            Path.Combine(AppConstants.SqliteDirBasename, AppConstants.DbFileBasename),
+            AppConstants.DbFileBasename
+        ],
+            backupMetadata.DbFiles);
 
         await using (SqliteConnection connection = fixture.OpenLegacySqliteConnection())
         {
@@ -129,8 +134,21 @@ public sealed class CoreIntegrationTests
                 rows.Add((reader.GetString(0), reader.GetString(1)));
             }
 
-            Assert.Equal([("thread-active-a", "dal")], rows);
+            Assert.Equal([("thread-active-a", "openai")], rows);
         }
+
+        await service.RunRestoreAsync(fixture.CodexHome, syncResult.BackupDir);
+
+        await using SqliteConnection restoredSqliteDir = fixture.OpenSqliteConnection();
+        await using SqliteConnection restoredLegacy = fixture.OpenLegacySqliteConnection();
+        await restoredSqliteDir.OpenAsync();
+        await restoredLegacy.OpenAsync();
+        SqliteCommand sqliteDirProvider = restoredSqliteDir.CreateCommand();
+        sqliteDirProvider.CommandText = "SELECT model_provider FROM threads WHERE id = 'thread-active-a'";
+        Assert.Equal("dal", await sqliteDirProvider.ExecuteScalarAsync());
+        SqliteCommand legacyProviders = restoredLegacy.CreateCommand();
+        legacyProviders.CommandText = "SELECT COUNT(*) FROM threads WHERE model_provider = 'dal'";
+        Assert.Equal(2L, Convert.ToInt64(await legacyProviders.ExecuteScalarAsync()));
     }
 
     [Fact]

--- a/desktop/CodexProviderSync.Core/BackupService.cs
+++ b/desktop/CodexProviderSync.Core/BackupService.cs
@@ -26,8 +26,8 @@ public sealed class BackupService
         Directory.CreateDirectory(dbDir);
 
         List<string> copiedDbFiles = [];
-        StateDbLocation? stateDb = _sqliteStateService.DetectStateDb(codexHome);
-        if (stateDb is not null)
+        IReadOnlyList<StateDbLocation> stateDbs = _sqliteStateService.ExistingStateDbs(codexHome);
+        foreach (StateDbLocation stateDb in stateDbs)
         {
             foreach (string suffix in new[] { string.Empty, "-shm", "-wal" })
             {

--- a/desktop/CodexProviderSync.Core/SqliteStateService.cs
+++ b/desktop/CodexProviderSync.Core/SqliteStateService.cs
@@ -98,6 +98,13 @@ public sealed class SqliteStateService
         return DetectStateDb(codexHome)?.Path;
     }
 
+    public IReadOnlyList<StateDbLocation> ExistingStateDbs(string codexHome)
+    {
+        return StateDbCandidates(codexHome)
+            .Where(static candidate => File.Exists(candidate.Path))
+            .ToList();
+    }
+
     public async Task<ProviderCounts?> ReadSqliteProviderCountsAsync(string codexHome)
     {
         string? dbPath = ExistingStateDbPath(codexHome);
@@ -233,27 +240,30 @@ public sealed class SqliteStateService
 
     public async Task<bool> AssertSqliteWritableAsync(string codexHome, int? busyTimeoutMs = null)
     {
-        string? dbPath = ExistingStateDbPath(codexHome);
-        if (dbPath is null)
+        IReadOnlyList<StateDbLocation> databases = ExistingStateDbs(codexHome);
+        if (databases.Count == 0)
         {
             return false;
         }
 
-        await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
-        try
+        foreach (StateDbLocation database in databases)
         {
-            await connection.OpenAsync();
-            await SetBusyTimeoutAsync(connection, busyTimeoutMs);
-            await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
-            await ExecuteNonQueryAsync(connection, "ROLLBACK");
-            return true;
+            await using SqliteConnection connection = OpenConnection(database.Path, SqliteOpenMode.ReadWriteCreate);
+            try
+            {
+                await connection.OpenAsync();
+                await SetBusyTimeoutAsync(connection, busyTimeoutMs);
+                await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
+                await ExecuteNonQueryAsync(connection, "ROLLBACK");
+            }
+            catch (Exception error)
+            {
+                string action = $"update session provider metadata in {database.RelativePath}";
+                throw WrapSqliteMalformedError(WrapSqliteBusyError(error, action), action);
+            }
         }
-        catch (Exception error)
-        {
-            throw WrapSqliteMalformedError(
-                WrapSqliteBusyError(error, "update session provider metadata"),
-                "update session provider metadata");
-        }
+
+        return true;
     }
 
     public async Task<(int UpdatedRows, int ProviderRowsUpdated, int UserEventRowsUpdated, int CwdRowsUpdated, bool DatabasePresent)> UpdateSqliteProviderAsync(
@@ -264,8 +274,8 @@ public sealed class SqliteStateService
         IReadOnlyCollection<string>? userEventThreadIds = null,
         IReadOnlyDictionary<string, string>? threadCwdsById = null)
     {
-        string? dbPath = ExistingStateDbPath(codexHome);
-        if (dbPath is null)
+        IReadOnlyList<StateDbLocation> databases = ExistingStateDbs(codexHome);
+        if (databases.Count == 0)
         {
             if (afterUpdate is not null)
             {
@@ -275,61 +285,70 @@ public sealed class SqliteStateService
             return (0, 0, 0, 0, false);
         }
 
-        await using SqliteConnection connection = OpenConnection(dbPath, SqliteOpenMode.ReadWriteCreate);
-        bool transactionOpen = false;
+        List<(SqliteConnection Connection, bool TransactionOpen)> openDatabases = [];
         try
         {
-            await connection.OpenAsync();
-            await SetBusyTimeoutAsync(connection, busyTimeoutMs);
-            await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
-            transactionOpen = true;
-
-            await using SqliteCommand command = connection.CreateCommand();
-            command.CommandText = """
-                UPDATE threads
-                SET model_provider = $provider
-                WHERE COALESCE(model_provider, '') <> $provider
-                """;
-            command.Parameters.AddWithValue("$provider", targetProvider);
-            int providerRowsUpdated = await command.ExecuteNonQueryAsync();
-            int userEventRowsUpdated = 0;
-            if (userEventThreadIds?.Count > 0 && await TableHasColumnAsync(connection, "threads", "has_user_event"))
+            foreach (StateDbLocation database in databases)
             {
-                await using SqliteCommand userEventCommand = connection.CreateCommand();
-                userEventCommand.CommandText = """
-                    UPDATE threads
-                    SET has_user_event = 1
-                    WHERE id = $id AND COALESCE(has_user_event, 0) <> 1
-                    """;
-                SqliteParameter idParameter = userEventCommand.Parameters.Add("$id", SqliteType.Text);
-                foreach (string threadId in userEventThreadIds)
-                {
-                    idParameter.Value = threadId;
-                    userEventRowsUpdated += await userEventCommand.ExecuteNonQueryAsync();
-                }
+                SqliteConnection connection = OpenConnection(database.Path, SqliteOpenMode.ReadWriteCreate);
+                openDatabases.Add((connection, false));
+                await connection.OpenAsync();
+                await SetBusyTimeoutAsync(connection, busyTimeoutMs);
+                await ExecuteNonQueryAsync(connection, "BEGIN IMMEDIATE");
+                openDatabases[^1] = (connection, true);
             }
 
+            int providerRowsUpdated = 0;
+            int userEventRowsUpdated = 0;
             int cwdRowsUpdated = 0;
-            if (threadCwdsById?.Count > 0 && await TableHasColumnAsync(connection, "threads", "cwd"))
+            foreach ((SqliteConnection connection, _) in openDatabases)
             {
-                await using SqliteCommand cwdCommand = connection.CreateCommand();
-                cwdCommand.CommandText = """
+                await using SqliteCommand command = connection.CreateCommand();
+                command.CommandText = """
                     UPDATE threads
-                    SET cwd = $cwd
-                    WHERE id = $id AND COALESCE(cwd, '') <> $cwd
+                    SET model_provider = $provider
+                    WHERE COALESCE(model_provider, '') <> $provider
                     """;
-                SqliteParameter cwdIdParameter = cwdCommand.Parameters.Add("$id", SqliteType.Text);
-                SqliteParameter cwdParameter = cwdCommand.Parameters.Add("$cwd", SqliteType.Text);
-                foreach ((string threadId, string cwd) in threadCwdsById)
-                {
-                    if (string.IsNullOrWhiteSpace(threadId) || string.IsNullOrWhiteSpace(cwd))
-                    {
-                        continue;
-                    }
+                command.Parameters.AddWithValue("$provider", targetProvider);
+                providerRowsUpdated += await command.ExecuteNonQueryAsync();
 
-                    cwdIdParameter.Value = threadId;
-                    cwdParameter.Value = cwd;
-                    cwdRowsUpdated += await cwdCommand.ExecuteNonQueryAsync();
+                if (userEventThreadIds?.Count > 0 && await TableHasColumnAsync(connection, "threads", "has_user_event"))
+                {
+                    await using SqliteCommand userEventCommand = connection.CreateCommand();
+                    userEventCommand.CommandText = """
+                        UPDATE threads
+                        SET has_user_event = 1
+                        WHERE id = $id AND COALESCE(has_user_event, 0) <> 1
+                        """;
+                    SqliteParameter idParameter = userEventCommand.Parameters.Add("$id", SqliteType.Text);
+                    foreach (string threadId in userEventThreadIds)
+                    {
+                        idParameter.Value = threadId;
+                        userEventRowsUpdated += await userEventCommand.ExecuteNonQueryAsync();
+                    }
+                }
+
+                if (threadCwdsById?.Count > 0 && await TableHasColumnAsync(connection, "threads", "cwd"))
+                {
+                    await using SqliteCommand cwdCommand = connection.CreateCommand();
+                    cwdCommand.CommandText = """
+                        UPDATE threads
+                        SET cwd = $cwd
+                        WHERE id = $id AND COALESCE(cwd, '') <> $cwd
+                        """;
+                    SqliteParameter cwdIdParameter = cwdCommand.Parameters.Add("$id", SqliteType.Text);
+                    SqliteParameter cwdParameter = cwdCommand.Parameters.Add("$cwd", SqliteType.Text);
+                    foreach ((string threadId, string cwd) in threadCwdsById)
+                    {
+                        if (string.IsNullOrWhiteSpace(threadId) || string.IsNullOrWhiteSpace(cwd))
+                        {
+                            continue;
+                        }
+
+                        cwdIdParameter.Value = threadId;
+                        cwdParameter.Value = cwd;
+                        cwdRowsUpdated += await cwdCommand.ExecuteNonQueryAsync();
+                    }
                 }
             }
 
@@ -340,27 +359,41 @@ public sealed class SqliteStateService
                 await afterUpdate((updatedRows, providerRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true));
             }
 
-            await ExecuteNonQueryAsync(connection, "COMMIT");
-            transactionOpen = false;
+            for (int index = 0; index < openDatabases.Count; index += 1)
+            {
+                (SqliteConnection connection, _) = openDatabases[index];
+                await ExecuteNonQueryAsync(connection, "COMMIT");
+                openDatabases[index] = (connection, false);
+            }
             return (updatedRows, providerRowsUpdated, userEventRowsUpdated, cwdRowsUpdated, true);
         }
         catch (Exception error)
         {
-            if (transactionOpen)
+            foreach ((SqliteConnection connection, bool transactionOpen) in openDatabases)
             {
-                try
+                if (transactionOpen)
                 {
-                    await ExecuteNonQueryAsync(connection, "ROLLBACK");
-                }
-                catch
-                {
-                    // Ignore rollback failures and surface the original error.
+                    try
+                    {
+                        await ExecuteNonQueryAsync(connection, "ROLLBACK");
+                    }
+                    catch
+                    {
+                        // Ignore rollback failures and surface the original error.
+                    }
                 }
             }
 
             throw WrapSqliteMalformedError(
                 WrapSqliteBusyError(error, "update session provider metadata"),
                 "update session provider metadata");
+        }
+        finally
+        {
+            foreach ((SqliteConnection connection, _) in openDatabases)
+            {
+                await connection.DisposeAsync();
+            }
         }
     }
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -30,6 +30,7 @@ Typical symptom:
 - the Codex state database, usually `~/.codex/sqlite/state_5.sqlite`
 
 Older Codex layouts may still use `~/.codex/state_5.sqlite`; the tool detects the active location and reports it in `codex-provider status`.
+If both database locations exist, sync and backup operations cover both so Codex Desktop cannot switch back to stale provider metadata.
 
 ## GUI For Windows
 

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -42,6 +42,8 @@ codex-provider sync
 
 CLI 需要 Node.js `16+`。Node 24+ 会优先使用内置 `node:sqlite`；旧版 Node 会使用可选依赖 `better-sqlite3`。
 
+当 `~/.codex/sqlite/state_5.sqlite` 与旧路径 `~/.codex/state_5.sqlite` 同时存在时，同步和备份会同时处理两个数据库，避免 Codex Desktop 重新读到旧的 provider 元数据。
+
 更多 CLI 常用命令：
 
 ```bash

--- a/src/backup.js
+++ b/src/backup.js
@@ -10,7 +10,7 @@ import {
   GLOBAL_STATE_FILE_BASENAME
 } from "./constants.js";
 import { assertSessionFilesWritable, restoreSessionChanges } from "./session-files.js";
-import { assertSqliteWritable, detectStateDb } from "./sqlite-state.js";
+import { assertSqliteWritable, existingStateDbs } from "./sqlite-state.js";
 
 function timestampSlug(date = new Date()) {
   return date.toISOString().replaceAll(":", "").replaceAll("-", "").replace(".", "");
@@ -70,8 +70,8 @@ export async function createBackup({
   await fs.mkdir(dbDir, { recursive: true });
 
   const copiedDbFiles = [];
-  const stateDb = await detectStateDb(codexHome);
-  if (stateDb) {
+  const stateDbs = await existingStateDbs(codexHome);
+  for (const stateDb of stateDbs) {
     for (const suffix of ["", "-shm", "-wal"]) {
       const relativePath = dbBackupRelativePath(codexHome, stateDb.path, suffix);
       const copied = await copyIfPresent(`${stateDb.path}${suffix}`, path.join(dbDir, relativePath));

--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -158,6 +158,19 @@ export async function existingStateDbPath(codexHome) {
   return (await detectStateDb(codexHome))?.path ?? null;
 }
 
+export async function existingStateDbs(codexHome) {
+  const databases = [];
+  for (const candidate of stateDbCandidates(codexHome)) {
+    try {
+      await fs.access(candidate.path);
+      databases.push(candidate);
+    } catch {
+      // Try the next known Codex state DB location.
+    }
+  }
+  return databases;
+}
+
 function tableHasColumn(db, tableName, columnName) {
   return db
     .prepare(`PRAGMA table_info(${JSON.stringify(tableName)})`)
@@ -308,26 +321,28 @@ export async function readSqliteRepairStats(codexHome, options = {}) {
 }
 
 export async function assertSqliteWritable(codexHome, options = {}) {
-  const dbPath = await existingStateDbPath(codexHome);
-  if (!dbPath) {
+  const databases = await existingStateDbs(codexHome);
+  if (databases.length === 0) {
     return { databasePresent: false };
   }
 
-  let db;
-  try {
-    db = await openDatabase(dbPath);
-    setBusyTimeout(db, options.busyTimeoutMs);
-    db.exec("BEGIN IMMEDIATE");
-    db.exec("ROLLBACK");
-    return { databasePresent: true };
-  } catch (error) {
-    throw wrapSqliteMalformedError(
-      wrapSqliteBusyError(error, "update session provider metadata"),
-      "update session provider metadata"
-    );
-  } finally {
-    db?.close();
+  for (const database of databases) {
+    let db;
+    try {
+      db = await openDatabase(database.path);
+      setBusyTimeout(db, options.busyTimeoutMs);
+      db.exec("BEGIN IMMEDIATE");
+      db.exec("ROLLBACK");
+    } catch (error) {
+      throw wrapSqliteMalformedError(
+        wrapSqliteBusyError(error, `update session provider metadata in ${database.relativePath}`),
+        `update session provider metadata in ${database.relativePath}`
+      );
+    } finally {
+      db?.close();
+    }
   }
+  return { databasePresent: true };
 }
 
 export async function updateSqliteProvider(codexHome, targetProvider, afterUpdateOrOptions, maybeOptions) {
@@ -336,8 +351,8 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
     ? (maybeOptions ?? {})
     : (afterUpdateOrOptions ?? {});
 
-  const dbPath = await existingStateDbPath(codexHome);
-  if (!dbPath) {
+  const databases = await existingStateDbs(codexHome);
+  if (databases.length === 0) {
     if (afterUpdate) {
       await afterUpdate({
         updatedRows: 0,
@@ -356,67 +371,76 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
     };
   }
 
-  let db;
-  let transactionOpen = false;
+  const openDatabases = [];
   try {
-    db = await openDatabase(dbPath);
-    setBusyTimeout(db, options.busyTimeoutMs);
-    db.exec("BEGIN IMMEDIATE");
-    transactionOpen = true;
-    const stmt = db.prepare(`
-      UPDATE threads
-      SET model_provider = ?
-      WHERE COALESCE(model_provider, '') <> ?
-    `);
-    const result = stmt.run(targetProvider, targetProvider);
+    for (const database of databases) {
+      const db = await openDatabase(database.path);
+      const openDatabaseEntry = { ...database, db, transactionOpen: false };
+      openDatabases.push(openDatabaseEntry);
+      setBusyTimeout(db, options.busyTimeoutMs);
+      db.exec("BEGIN IMMEDIATE");
+      openDatabaseEntry.transactionOpen = true;
+    }
+
+    let providerRowsUpdated = 0;
     let userEventUpdatedRows = 0;
-    if (tableHasColumn(db, "threads", "has_user_event") && options.userEventThreadIds?.size) {
-      const userEventStmt = db.prepare(`
-        UPDATE threads
-        SET has_user_event = 1
-        WHERE id = ? AND COALESCE(has_user_event, 0) <> 1
-      `);
-      for (const threadId of options.userEventThreadIds) {
-        userEventUpdatedRows += userEventStmt.run(threadId).changes ?? 0;
-      }
-    }
     let cwdUpdatedRows = 0;
-    if (tableHasColumn(db, "threads", "cwd") && options.threadCwdById?.size) {
-      const cwdStmt = db.prepare(`
+    for (const { db } of openDatabases) {
+      const stmt = db.prepare(`
         UPDATE threads
-        SET cwd = ?
-        WHERE id = ? AND COALESCE(cwd, '') <> ?
+        SET model_provider = ?
+        WHERE COALESCE(model_provider, '') <> ?
       `);
-      for (const [threadId, cwd] of options.threadCwdById) {
-        if (typeof threadId !== "string" || !threadId || typeof cwd !== "string" || !cwd.trim()) {
-          continue;
+      providerRowsUpdated += stmt.run(targetProvider, targetProvider).changes ?? 0;
+      if (tableHasColumn(db, "threads", "has_user_event") && options.userEventThreadIds?.size) {
+        const userEventStmt = db.prepare(`
+          UPDATE threads
+          SET has_user_event = 1
+          WHERE id = ? AND COALESCE(has_user_event, 0) <> 1
+        `);
+        for (const threadId of options.userEventThreadIds) {
+          userEventUpdatedRows += userEventStmt.run(threadId).changes ?? 0;
         }
-        cwdUpdatedRows += cwdStmt.run(cwd, threadId, cwd).changes ?? 0;
+      }
+      if (tableHasColumn(db, "threads", "cwd") && options.threadCwdById?.size) {
+        const cwdStmt = db.prepare(`
+          UPDATE threads
+          SET cwd = ?
+          WHERE id = ? AND COALESCE(cwd, '') <> ?
+        `);
+        for (const [threadId, cwd] of options.threadCwdById) {
+          if (typeof threadId !== "string" || !threadId || typeof cwd !== "string" || !cwd.trim()) {
+            continue;
+          }
+          cwdUpdatedRows += cwdStmt.run(cwd, threadId, cwd).changes ?? 0;
+        }
       }
     }
-    const updatedRows = (result.changes ?? 0) + userEventUpdatedRows + cwdUpdatedRows;
+    const updatedRows = providerRowsUpdated + userEventUpdatedRows + cwdUpdatedRows;
     if (afterUpdate) {
       await afterUpdate({
         updatedRows,
-        providerRowsUpdated: result.changes ?? 0,
+        providerRowsUpdated,
         userEventRowsUpdated: userEventUpdatedRows,
         cwdRowsUpdated: cwdUpdatedRows,
         databasePresent: true
       });
     }
-    db.exec("COMMIT");
-    transactionOpen = false;
+    for (const database of openDatabases) {
+      database.db.exec("COMMIT");
+      database.transactionOpen = false;
+    }
     return {
       updatedRows,
-      providerRowsUpdated: result.changes ?? 0,
+      providerRowsUpdated,
       userEventRowsUpdated: userEventUpdatedRows,
       cwdRowsUpdated: cwdUpdatedRows,
       databasePresent: true
     };
   } catch (error) {
-    if (transactionOpen) {
+    for (const database of openDatabases.filter((entry) => entry.transactionOpen)) {
       try {
-        db.exec("ROLLBACK");
+        database.db.exec("ROLLBACK");
       } catch {
         // Ignore rollback failures and surface the original error.
       }
@@ -426,6 +450,8 @@ export async function updateSqliteProvider(codexHome, targetProvider, afterUpdat
       "update session provider metadata"
     );
   } finally {
-    db?.close();
+    for (const database of openDatabases) {
+      database.db.close();
+    }
   }
 }

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -322,7 +322,7 @@ test("runSync rewrites rollout files and sqlite, then restore reverts both", asy
   assert.match(restoredArchived, /"model_provider":"newapi"/);
 });
 
-test("runSync updates legacy root sqlite database when sqlite-dir state is stale", async () => {
+test("runSync updates and backs up both sqlite databases when both locations exist", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"');
   const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-active-a.jsonl");
@@ -339,9 +339,12 @@ test("runSync updates legacy root sqlite database when sqlite-dir state is stale
 
   const syncResult = await runSync({ codexHome });
 
-  assert.equal(syncResult.sqliteRowsUpdated, 2);
+  assert.equal(syncResult.sqliteRowsUpdated, 3);
   const backupMetadata = JSON.parse(await fs.readFile(path.join(syncResult.backupDir, "metadata.json"), "utf8"));
-  assert.deepEqual(backupMetadata.dbFiles, [DB_FILE_BASENAME]);
+  assert.deepEqual(
+    backupMetadata.dbFiles.map((fileName) => fileName.replaceAll("\\", "/")),
+    ["sqlite/state_5.sqlite", DB_FILE_BASENAME]
+  );
 
   const legacyDb = await openDatabase(legacyStateDbPath(codexHome));
   try {
@@ -361,11 +364,26 @@ test("runSync updates legacy root sqlite database when sqlite-dir state is stale
     assert.deepEqual(
       staleDb.prepare("SELECT id, model_provider FROM threads ORDER BY id").all().map((row) => ({ ...row })),
       [
-        { id: "thread-active-a", model_provider: "dal" }
+        { id: "thread-active-a", model_provider: "openai" }
       ]
     );
   } finally {
     staleDb.close();
+  }
+
+  await runRestore({ codexHome, backupDir: syncResult.backupDir });
+
+  const restoredSqliteDirDb = await openDatabase(stateDbPath(codexHome));
+  const restoredLegacyDb = await openDatabase(legacyStateDbPath(codexHome));
+  try {
+    assert.equal(restoredSqliteDirDb.prepare("SELECT model_provider FROM threads WHERE id = ?").get("thread-active-a").model_provider, "dal");
+    assert.deepEqual(
+      restoredLegacyDb.prepare("SELECT model_provider FROM threads ORDER BY id").all().map((row) => row.model_provider),
+      ["dal", "dal"]
+    );
+  } finally {
+    restoredSqliteDirDb.close();
+    restoredLegacyDb.close();
   }
 });
 
@@ -751,7 +769,7 @@ test("runSwitch rejects unknown custom providers", async () => {
   );
 });
 
-test("runSync leaves rollout files and sqlite untouched when sqlite is locked", async () => {
+test("runSync leaves rollout files and both sqlite databases untouched when either database is locked", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"');
   const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-a.jsonl");
@@ -759,8 +777,11 @@ test("runSync leaves rollout files and sqlite untouched when sqlite is locked", 
   await writeStateDb(codexHome, [
     { id: "thread-a", model_provider: "apigather", archived: false }
   ]);
+  await writeLegacyStateDb(codexHome, [
+    { id: "thread-a", model_provider: "apigather", archived: false }
+  ]);
 
-  const lockDb = await openDatabase(stateDbPath(codexHome));
+  const lockDb = await openDatabase(legacyStateDbPath(codexHome));
   try {
     lockDb.exec("BEGIN IMMEDIATE");
     await assert.rejects(
@@ -780,13 +801,19 @@ test("runSync leaves rollout files and sqlite untouched when sqlite is locked", 
   assert.match(rollout, /"model_provider":"apigather"/);
 
   const db = await openDatabase(stateDbPath(codexHome));
+  const legacyDb = await openDatabase(legacyStateDbPath(codexHome));
   try {
     const row = db
       .prepare("SELECT model_provider FROM threads WHERE id = ?")
       .get("thread-a");
     assert.equal(row.model_provider, "apigather");
+    assert.equal(
+      legacyDb.prepare("SELECT model_provider FROM threads WHERE id = ?").get("thread-a").model_provider,
+      "apigather"
+    );
   } finally {
     db.close();
+    legacyDb.close();
   }
 });
 


### PR DESCRIPTION
## Summary

- update provider metadata in every existing Codex state database instead of only the heuristically selected active database
- check writability for both `~/.codex/sqlite/state_5.sqlite` and `~/.codex/state_5.sqlite` before changing rollout metadata
- back up and restore both database locations when both exist
- keep the existing active-database selection for status and diagnostics

## Environment

- Windows 11 Pro, version `10.0.26200` (build `26200`)
- Codex Desktop `26.707.8479.0` (`OpenAI.Codex_26.707.8479.0_x64__2p2nqsd0c76g0`)

## Why

v0.2.9 / #48 improved active database detection, but sync still writes only the single database returned by that heuristic. After updating the database by v0.2.9 tool, the desktop history records briefly appeared and then disappeared.

Codex supports an independent SQLite home through `sqlite_home` / `CODEX_SQLITE_HOME`; otherwise it defaults to `CODEX_HOME`. Consequently, different Codex versions, surfaces, or launch configurations can select different paths:

- `CODEX_HOME=~/.codex` → `~/.codex/state_5.sqlite`
- `sqlite_home=~/.codex/sqlite` → `~/.codex/sqlite/state_5.sqlite`

A sync tool cannot reliably predict which existing database a later Desktop or app-server launch will select. Updating only the database that currently looks most active can therefore leave stale provider metadata in the other known location.

Observed locally before manual repair:

- `~/.codex/sqlite/state_5.sqlite`: 262 threads using `custom`
- `~/.codex/state_5.sqlite`: 316 threads using `OpenAI`, 1 using `custom`

The current Desktop app-server was actively writing the legacy-root database, while the sqlite-dir database appeared to be left by another version or configuration. After both databases were synchronized to `custom`, Desktop history remained visible instead of appearing briefly and disappearing again.

The Codex CLI/app-server and SQLite state implementation are public, but the complete Codex Desktop UI implementation is not available in the public `openai/codex` repository. Therefore the exact UI-side mechanism behind the brief appearance and subsequent disappearance cannot currently be established from source. Synchronizing only the heuristically selected database did not resolve the issue in this environment, while synchronizing both existing databases did.

This is related to the behavior reported in #28 and complements the active-database detection added by #48.

## Safety

- all existing databases are opened and `BEGIN IMMEDIATE` is acquired before rollout changes are applied
- if either database is locked or malformed, sync fails before rewriting rollout files
- row counts aggregate updates across both databases
- backups contain both database paths and restore restores both

## Tests

- `npm test` — 41 passed
- `dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj -c Release --no-restore` — 43 passed