### PR TITLE
perf: replace equal-length provider IDs in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ codex-provider prune-backups --keep 5
 - `restore <backup-dir>`：从备份恢复，支持 `--no-config`、`--no-db`、`--no-sessions`。
 - `prune-backups --keep <n>`：只清理本工具创建的旧备份。
 
+备注：频繁切换时，建议使用统一的 6 字符 ASCII provider ID，例如将逻辑名称 `provider_a` 配置为 `prov_a`。内置的 `openai` ID 正好是 6 个字符，因此统一为 6 字符相对最通用。会话文件很多或体积很大时，不同长度的 ID 需要重写整个 rollout，可能产生巨量磁盘写入；相同长度则可原地替换，无法识别时仍自动回退到原有的完整重写。
+
 ## 能力边界
 
 本工具只修复“历史会话可见性”相关 metadata，不修改会话内容。

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -115,6 +115,8 @@ Clean old managed backups manually:
 codex-provider prune-backups --keep 5
 ```
 
+Note: When switching frequently, we recommend consistent six-character ASCII provider IDs, for example configuring logical provider `provider_a` as `prov_a`. The built-in `openai` ID is six characters, making six-character IDs the most broadly compatible choice. With many or large session files, different-length IDs require rewriting entire rollouts and can cause massive disk writes; equal-length IDs can be replaced in place, while unrecognized cases still fall back to the existing full rewrite.
+
 ## AI Quick Run
 
 If you want an AI assistant to handle this in one shot, copy this prompt:

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -530,6 +530,62 @@ async function rewriteFirstLine(filePath, nextFirstLine, separator) {
   }
 }
 
+function getInPlaceProviderReplacement(change) {
+  if (typeof change.originalFirstLine !== "string"
+      || typeof change.originalProvider !== "string"
+      || typeof change.updatedProvider !== "string") {
+    return null;
+  }
+
+  const originalProvider = Buffer.from(change.originalProvider, "utf8");
+  const updatedProvider = Buffer.from(change.updatedProvider, "utf8");
+  if (originalProvider.length === 0 || originalProvider.length !== updatedProvider.length) {
+    return null;
+  }
+
+  const providerFieldPattern = /"model_provider"\s*:\s*"([^"\\]*)"/g;
+  let fieldMatch;
+  while ((fieldMatch = providerFieldPattern.exec(change.originalFirstLine)) !== null) {
+    if (fieldMatch[1] !== change.originalProvider) {
+      continue;
+    }
+
+    const valueOffset = fieldMatch.index + fieldMatch[0].lastIndexOf(change.originalProvider);
+    return {
+      byteOffset: Buffer.byteLength(change.originalFirstLine.slice(0, valueOffset), "utf8"),
+      replacement: updatedProvider
+    };
+  }
+
+  return null;
+}
+
+async function tryRewriteProviderInPlace(change, replacement) {
+  let handle;
+  try {
+    handle = await fsp.open(change.path, "r+");
+    const stat = await handle.stat();
+    if (!snapshotMatches(change, { size: stat.size, mtimeMs: stat.mtimeMs })) {
+      return false;
+    }
+
+    const { bytesWritten } = await handle.write(
+      replacement.replacement,
+      0,
+      replacement.replacement.length,
+      replacement.byteOffset
+    );
+    if (bytesWritten !== replacement.replacement.length) {
+      throw new Error(`Unable to rewrite provider bytes in rollout file: ${change.path}`);
+    }
+    return true;
+  } catch (error) {
+    throw wrapRolloutFileBusyError(error, change.path, "rewrite");
+  } finally {
+    await handle?.close();
+  }
+}
+
 async function tryRewriteCollectedFirstLine(change) {
   const beforeSnapshot = await getFileSnapshot(change.path);
   if (!snapshotMatches(change, beforeSnapshot)) {
@@ -539,6 +595,11 @@ async function tryRewriteCollectedFirstLine(change) {
   const current = await readFirstLineRecord(change.path);
   if (current.firstLine !== change.originalFirstLine || current.offset !== change.originalOffset) {
     return false;
+  }
+
+  const inPlaceReplacement = getInPlaceProviderReplacement(change);
+  if (inPlaceReplacement) {
+    return tryRewriteProviderInPlace(change, inPlaceReplacement);
   }
 
   const tmpPath = `${change.path}.provider-sync.${process.pid}.${Date.now()}.tmp`;
@@ -695,6 +756,7 @@ export async function collectSessionChanges(codexHome, targetProvider, options =
           originalSize: snapshot.size,
           originalMtimeMs: snapshot.mtimeMs,
           originalProvider: currentProvider,
+          updatedProvider: targetProvider,
           updatedFirstLine: JSON.stringify(parsed)
         });
       }

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -265,7 +265,10 @@ function parseSessionMetaRecord(firstLine) {
 }
 
 function isValidWindowsRewriteResult(result) {
-  return result === "APPLIED" || result === "SKIP_BUSY" || result === "SKIP_CHANGED";
+  return result === "APPLIED"
+    || result === "APPLIED_IN_PLACE"
+    || result === "SKIP_BUSY"
+    || result === "SKIP_CHANGED";
 }
 
 function parseWindowsRewriteResults(stdout, changes) {
@@ -374,6 +377,14 @@ async function invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatc
         $separator = [string]$change.originalSeparator
         $sourceOffset = [int64]$change.originalOffset
         $headerOnly = $sourceOffset -ge [int64]$change.originalSize
+
+        if ($null -ne $change.inPlaceByteOffset -and -not [string]::IsNullOrEmpty([string]$change.inPlaceReplacementBase64)) {
+          $replacementBytes = [Convert]::FromBase64String([string]$change.inPlaceReplacementBase64)
+          $source.Seek([int64]$change.inPlaceByteOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
+          $source.Write($replacementBytes, 0, $replacementBytes.Length)
+          $source.Flush()
+          return "APPLIED_IN_PLACE"
+        }
       } else {
         $record = Read-FirstLineRecord $source
         $separator = [string]$change.separator
@@ -441,12 +452,18 @@ async function invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatc
 `.trim();
 
   try {
+    const manifestChanges = changes.map((change) => {
+      const replacement = requireOriginalMatch ? getInPlaceProviderReplacement(change) : null;
+      return {
+        ...change,
+        requireOriginalMatch,
+        inPlaceByteOffset: replacement?.byteOffset ?? null,
+        inPlaceReplacementBase64: replacement?.replacement.toString("base64") ?? null
+      };
+    });
     await fsp.writeFile(
       manifestPath,
-      JSON.stringify(changes.map((change) => ({
-        ...change,
-        requireOriginalMatch
-      }))),
+      JSON.stringify(manifestChanges),
       "utf8"
     );
 
@@ -537,20 +554,22 @@ function getInPlaceProviderReplacement(change) {
     return null;
   }
 
-  const originalProvider = Buffer.from(change.originalProvider, "utf8");
-  const updatedProvider = Buffer.from(change.updatedProvider, "utf8");
+  const originalProviderJson = JSON.stringify(change.originalProvider);
+  const updatedProviderJson = JSON.stringify(change.updatedProvider);
+  const originalProvider = Buffer.from(originalProviderJson, "utf8");
+  const updatedProvider = Buffer.from(updatedProviderJson, "utf8");
   if (originalProvider.length === 0 || originalProvider.length !== updatedProvider.length) {
     return null;
   }
 
-  const providerFieldPattern = /"model_provider"\s*:\s*"([^"\\]*)"/g;
+  const providerFieldPattern = /"model_provider"\s*:\s*/g;
   let fieldMatch;
   while ((fieldMatch = providerFieldPattern.exec(change.originalFirstLine)) !== null) {
-    if (fieldMatch[1] !== change.originalProvider) {
+    const valueOffset = fieldMatch.index + fieldMatch[0].length;
+    if (!change.originalFirstLine.startsWith(originalProviderJson, valueOffset)) {
       continue;
     }
 
-    const valueOffset = fieldMatch.index + fieldMatch[0].lastIndexOf(change.originalProvider);
     return {
       byteOffset: Buffer.byteLength(change.originalFirstLine.slice(0, valueOffset), "utf8"),
       replacement: updatedProvider
@@ -589,17 +608,19 @@ async function tryRewriteProviderInPlace(change, replacement) {
 async function tryRewriteCollectedFirstLine(change) {
   const beforeSnapshot = await getFileSnapshot(change.path);
   if (!snapshotMatches(change, beforeSnapshot)) {
-    return false;
+    return "SKIP_CHANGED";
   }
 
   const current = await readFirstLineRecord(change.path);
   if (current.firstLine !== change.originalFirstLine || current.offset !== change.originalOffset) {
-    return false;
+    return "SKIP_CHANGED";
   }
 
   const inPlaceReplacement = getInPlaceProviderReplacement(change);
   if (inPlaceReplacement) {
-    return tryRewriteProviderInPlace(change, inPlaceReplacement);
+    return await tryRewriteProviderInPlace(change, inPlaceReplacement)
+      ? "APPLIED_IN_PLACE"
+      : "SKIP_CHANGED";
   }
 
   const tmpPath = `${change.path}.provider-sync.${process.pid}.${Date.now()}.tmp`;
@@ -630,11 +651,11 @@ async function tryRewriteCollectedFirstLine(change) {
     const afterSnapshot = await getFileSnapshot(change.path);
     if (!snapshotMatches(change, afterSnapshot)) {
       await fsp.rm(tmpPath, { force: true });
-      return false;
+      return "SKIP_CHANGED";
     }
 
     await fsp.rename(tmpPath, change.path);
-    return true;
+    return "APPLIED";
   } catch (error) {
     await fsp.rm(tmpPath, { force: true });
     throw wrapRolloutFileBusyError(error, change.path, "rewrite");
@@ -771,27 +792,26 @@ export async function applySessionChanges(changes) {
   const skippedPaths = [];
   const appliedPaths = [];
   let appliedChanges = 0;
+  let inPlaceChanges = 0;
+  let results;
 
   if (process.platform === "win32") {
-    const results = await invokeWindowsExclusiveRewriteBatch(normalizedChanges, { requireOriginalMatch: true });
-    for (let index = 0; index < normalizedChanges.length; index += 1) {
-      if (results[index] === "APPLIED") {
-        appliedChanges += 1;
-        appliedPaths.push(normalizedChanges[index].path);
-        await restoreOriginalMtime(normalizedChanges[index].path, normalizedChanges[index].originalMtimeMs);
-      } else {
-        skippedPaths.push(normalizedChanges[index].path);
-      }
-    }
+    results = await invokeWindowsExclusiveRewriteBatch(normalizedChanges, { requireOriginalMatch: true });
   } else {
+    results = [];
     for (const change of normalizedChanges) {
-      if (await tryRewriteCollectedFirstLine(change)) {
-        appliedChanges += 1;
-        appliedPaths.push(change.path);
-        await restoreOriginalMtime(change.path, change.originalMtimeMs);
-      } else {
-        skippedPaths.push(change.path);
-      }
+      results.push(await tryRewriteCollectedFirstLine(change));
+    }
+  }
+
+  for (let index = 0; index < normalizedChanges.length; index += 1) {
+    if (results[index] === "APPLIED" || results[index] === "APPLIED_IN_PLACE") {
+      appliedChanges += 1;
+      inPlaceChanges += results[index] === "APPLIED_IN_PLACE" ? 1 : 0;
+      appliedPaths.push(normalizedChanges[index].path);
+      await restoreOriginalMtime(normalizedChanges[index].path, normalizedChanges[index].originalMtimeMs);
+    } else {
+      skippedPaths.push(normalizedChanges[index].path);
     }
   }
 
@@ -799,6 +819,7 @@ export async function applySessionChanges(changes) {
   skippedPaths.sort((left, right) => left.localeCompare(right));
   return {
     appliedChanges,
+    inPlaceChanges,
     appliedPaths,
     skippedPaths
   };

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -547,11 +547,20 @@ async function invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatc
         $headerOnly = $sourceOffset -ge [int64]$change.originalSize
 
         if ($null -ne $change.inPlaceByteOffset -and -not [string]::IsNullOrEmpty([string]$change.inPlaceReplacementBase64)) {
+          $originalBytes = [Convert]::FromBase64String([string]$change.inPlaceOriginalBase64)
           $replacementBytes = [Convert]::FromBase64String([string]$change.inPlaceReplacementBase64)
-          $source.Seek([int64]$change.inPlaceByteOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
-          $source.Write($replacementBytes, 0, $replacementBytes.Length)
-          $source.Flush()
-          return "APPLIED_IN_PLACE"
+          try {
+            $source.Seek([int64]$change.inPlaceByteOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
+            $source.Write($replacementBytes, 0, $replacementBytes.Length)
+            $source.Flush()
+            return "APPLIED_IN_PLACE"
+          } catch {
+            $source.Seek([int64]$change.inPlaceByteOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
+            $source.Write($originalBytes, 0, $originalBytes.Length)
+            $source.Flush()
+            # The original bytes are restored; continue into the safe
+            # full-file rewrite below.
+          }
         }
       } else {
         $record = Read-FirstLineRecord $source
@@ -626,6 +635,7 @@ async function invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatc
         ...change,
         requireOriginalMatch,
         inPlaceByteOffset: replacement?.byteOffset ?? null,
+        inPlaceOriginalBase64: replacement?.original.toString("base64") ?? null,
         inPlaceReplacementBase64: replacement?.replacement.toString("base64") ?? null
       };
     });
@@ -742,6 +752,7 @@ function getInPlaceProviderReplacement(change) {
 
     return {
       byteOffset: Buffer.byteLength(change.originalFirstLine.slice(0, valueOffset), "utf8"),
+      original: originalProvider,
       replacement: updatedProvider
     };
   }
@@ -751,24 +762,55 @@ function getInPlaceProviderReplacement(change) {
 
 async function tryRewriteProviderInPlace(change, replacement) {
   let handle;
+  let writeStarted = false;
   try {
     handle = await fsp.open(change.path, "r+");
     const stat = await handle.stat();
     if (!snapshotMatches(change, { size: stat.size, mtimeMs: stat.mtimeMs })) {
-      return false;
+      return "SKIP_CHANGED";
     }
 
-    const { bytesWritten } = await handle.write(
-      replacement.replacement,
-      0,
-      replacement.replacement.length,
-      replacement.byteOffset
-    );
-    if (bytesWritten !== replacement.replacement.length) {
-      throw new Error(`Unable to rewrite provider bytes in rollout file: ${change.path}`);
+    let totalWritten = 0;
+    writeStarted = true;
+    while (totalWritten < replacement.replacement.length) {
+      const { bytesWritten } = await handle.write(
+        replacement.replacement,
+        totalWritten,
+        replacement.replacement.length - totalWritten,
+        replacement.byteOffset + totalWritten
+      );
+      if (bytesWritten <= 0) {
+        throw new Error(`Unable to rewrite provider bytes in rollout file: ${change.path}`);
+      }
+      totalWritten += bytesWritten;
     }
-    return true;
+    await handle.sync();
+    return "APPLIED_IN_PLACE";
   } catch (error) {
+    if (handle && writeStarted) {
+      try {
+        let totalRestored = 0;
+        while (totalRestored < replacement.original.length) {
+          const { bytesWritten } = await handle.write(
+            replacement.original,
+            totalRestored,
+            replacement.original.length - totalRestored,
+            replacement.byteOffset + totalRestored
+          );
+          if (bytesWritten <= 0) {
+            throw new Error(`Unable to restore provider bytes in rollout file: ${change.path}`);
+          }
+          totalRestored += bytesWritten;
+        }
+        await handle.sync();
+        return "FALLBACK";
+      } catch (restoreError) {
+        throw new AggregateError(
+          [error, restoreError],
+          `Unable to restore provider bytes after an in-place rewrite failure: ${change.path}`
+        );
+      }
+    }
     throw wrapRolloutFileBusyError(error, change.path, "rewrite");
   } finally {
     await handle?.close();
@@ -788,9 +830,10 @@ async function tryRewriteCollectedFirstLine(change) {
 
   const inPlaceReplacement = getInPlaceProviderReplacement(change);
   if (inPlaceReplacement) {
-    return await tryRewriteProviderInPlace(change, inPlaceReplacement)
-      ? "APPLIED_IN_PLACE"
-      : "SKIP_CHANGED";
+    const inPlaceResult = await tryRewriteProviderInPlace(change, inPlaceReplacement);
+    if (inPlaceResult !== "FALLBACK") {
+      return inPlaceResult;
+    }
   }
 
   const tmpPath = `${change.path}.provider-sync.${process.pid}.${Date.now()}.tmp`;

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -884,10 +884,6 @@ test("applySessionChanges preserves large UTF-8 session metadata", async () => {
 });
 
 test("applySessionChanges replaces equal-length provider IDs in place", async () => {
-  if (process.platform === "win32") {
-    return;
-  }
-
   const { codexHome } = await makeTempCodexHome();
   const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-in-place.jsonl");
   await writeRollout(sessionPath, "thread-in-place", "openai");
@@ -905,12 +901,29 @@ test("applySessionChanges replaces equal-length provider IDs in place", async ()
   const rollout = await fs.readFile(sessionPath, "utf8");
 
   assert.equal(result.appliedChanges, 1);
-  assert.equal(after.ino, before.ino);
+  assert.equal(result.inPlaceChanges, 1);
+  if (process.platform !== "win32") {
+    assert.equal(after.ino, before.ino);
+  }
   assert.equal(Math.round(after.mtimeMs), originalTime.getTime());
   assert.equal(
     rollout,
     original.replace('"model_provider" : "openai"', '"model_provider" : "prov_a"')
   );
+});
+
+test("applySessionChanges falls back when equal-length provider IDs have different JSON byte lengths", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-escaped-provider.jsonl");
+  await writeRollout(sessionPath, "thread-escaped-provider", "openai");
+
+  const { changes } = await collectSessionChanges(codexHome, 'bad"id');
+  const result = await applySessionChanges(changes);
+  const [firstLine] = (await fs.readFile(sessionPath, "utf8")).split(/\r?\n/);
+
+  assert.equal(result.appliedChanges, 1);
+  assert.equal(result.inPlaceChanges, 0);
+  assert.equal(JSON.parse(firstLine).payload.model_provider, 'bad"id');
 });
 
 test("applySessionChanges restores original rollout mtime", async () => {

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -883,6 +883,36 @@ test("applySessionChanges preserves large UTF-8 session metadata", async () => {
   assert.match(rollout, /"large_blob":"数据块数据块/);
 });
 
+test("applySessionChanges replaces equal-length provider IDs in place", async () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  const { codexHome } = await makeTempCodexHome();
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-in-place.jsonl");
+  await writeRollout(sessionPath, "thread-in-place", "openai");
+  const original = (await fs.readFile(sessionPath, "utf8"))
+    .replace('"cwd":"C:\\\\AITemp"', '"cwd":"中文路径"')
+    .replace('"model_provider":"openai"', '"model_provider" : "openai"');
+  await fs.writeFile(sessionPath, original, "utf8");
+  const originalTime = new Date("2026-01-02T03:04:05.000Z");
+  await fs.utimes(sessionPath, originalTime, originalTime);
+
+  const before = await fs.stat(sessionPath);
+  const { changes } = await collectSessionChanges(codexHome, "prov_a");
+  const result = await applySessionChanges(changes);
+  const after = await fs.stat(sessionPath);
+  const rollout = await fs.readFile(sessionPath, "utf8");
+
+  assert.equal(result.appliedChanges, 1);
+  assert.equal(after.ino, before.ino);
+  assert.equal(Math.round(after.mtimeMs), originalTime.getTime());
+  assert.equal(
+    rollout,
+    original.replace('"model_provider" : "openai"', '"model_provider" : "prov_a"')
+  );
+});
+
 test("applySessionChanges restores original rollout mtime", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"');


### PR DESCRIPTION
## Summary

- replace equal-length `model_provider` values in place when the field can be located in rollout metadata
- retain the existing full rewrite as a fallback for different-length or unrecognized provider IDs
- recommend consistent six-character ASCII provider IDs to reduce disk writes

## Motivation

Provider synchronization currently rewrites each changed rollout file. With many or large session files, changing only `model_provider` can still generate tens of gigabytes of disk writes.

In my setup, a provider switch appeared to hang for a long time. Investigation showed that my rollout files totaled about 53 GB. Because the old and new provider IDs had different lengths, the affected rollout data was read and fully rewritten. That made the switch take a long time, while writing roughly a full dataset again creates substantial unnecessary SSD wear and reduces drive lifespan when provider switches are repeated.

Equal-length provider IDs allow the tool to update only the provider bytes in place, avoiding unnecessary copies of the rollout body.

The built-in `openai` provider ID is six characters, so standardizing provider IDs to six ASCII characters is the most broadly compatible choice.

## Compatibility

The existing full rewrite path remains unchanged and is used whenever the in-place replacement is not applicable. Existing file-change detection, mtime restoration, backup, and restore behavior are preserved.

## Tests

- verify equal-length replacement preserves the rollout inode, content, UTF-8 metadata, and original mtime
- retain existing coverage for different-length rewrites and backup/restore behavior
- `npm test`: 42 tests passed