### PR TITLE
feat: add CLI history import/export with selective browse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Use `codex-provider export <archive-path>` when:
 - the user asks for a portable backup/archive of sessions and SQLite thread metadata
 - use `codex-provider export --select` when the user wants to preview and choose specific conversations
 - use `codex-provider export <archive-path> --ids <id[,id]>` for automated partial exports
+- in the export TUI, `Tab` shows/hides archived items and `Delete` toggles the highlighted conversation between active and archived state
 
 Use `codex-provider import <archive-path>` when:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ Use `codex-provider export <archive-path>` when:
 
 - the user wants to move Codex conversation history to another device
 - the user asks for a portable backup/archive of sessions and SQLite thread metadata
+- use `codex-provider export --select` when the user wants to preview and choose specific conversations
+- use `codex-provider export <archive-path> --ids <id[,id]>` for automated partial exports
 
 Use `codex-provider import <archive-path>` when:
 
@@ -144,6 +146,8 @@ codex-provider sync --keep 5
 codex-provider sync --provider openai
 codex-provider switch apigather
 codex-provider export codex-history.tgz
+codex-provider export --select
+codex-provider export selected-history.tgz --ids thread-a,thread-b
 codex-provider import codex-history.tgz
 codex-provider import codex-history.tgz --provider openai --conflict ask
 codex-provider prune-backups --keep 5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,18 @@ Use `codex-provider restore <backup-dir>` when:
 - the user wants to roll back a previous sync
 - the user synced to the wrong provider
 
+Use `codex-provider export <archive-path>` when:
+
+- the user wants to move Codex conversation history to another device
+- the user asks for a portable backup/archive of sessions and SQLite thread metadata
+
+Use `codex-provider import <archive-path>` when:
+
+- the user has an archive created by `codex-provider export`
+- the user wants to restore/migrate conversations onto this device
+- default to interactive conflict handling in a terminal, or pass
+  `--conflict skip|overwrite|fail` for automation
+
 Use `codex-provider status` only when:
 
 - the user asks for inspection only
@@ -131,6 +143,9 @@ codex-provider sync
 codex-provider sync --keep 5
 codex-provider sync --provider openai
 codex-provider switch apigather
+codex-provider export codex-history.tgz
+codex-provider import codex-history.tgz
+codex-provider import codex-history.tgz --provider openai --conflict ask
 codex-provider prune-backups --keep 5
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\20260319T042708906Z
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Use `codex-provider export <archive-path>` when:
 - the user asks for a portable backup/archive of sessions and SQLite thread metadata
 - use `codex-provider export --select` when the user wants to preview and choose specific conversations
 - use `codex-provider export <archive-path> --ids <id[,id]>` for automated partial exports
-- in the export TUI, `Tab` shows/hides archived items and `Delete` toggles the highlighted conversation between active and archived state
+- in the export TUI, `Ctrl+P` expands an inline preview, `Ctrl+T` opens transcript details, `Tab` shows/hides archived items, and `Delete` toggles the highlighted conversation between active and archived state
 
 Use `codex-provider import <archive-path>` when:
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ codex-provider status
 codex-provider sync
 codex-provider sync --provider openai
 codex-provider switch apigather
+codex-provider export
+codex-provider import codex-history.tgz
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\<timestamp>
 codex-provider prune-backups --keep 5
 ```
@@ -60,14 +62,53 @@ codex-provider prune-backups --keep 5
 - `status`：只检查当前 provider、rollout、SQLite、项目可见性诊断。
 - `sync`：不切换登录状态，只把历史会话 metadata 同步到当前 provider。
 - `switch <provider-id>`：修改 `config.toml` 根级 `model_provider`，然后执行同步。
+- `export <archive-path>`：导出 `sessions`、`archived_sessions` 和检测到的 SQLite 会话 metadata，便于迁移到另一台设备。
+- `import <archive-path>`：导入导出的历史包，默认把导入记录对齐到目标设备当前 provider。
 - `restore <backup-dir>`：从备份恢复，支持 `--no-config`、`--no-db`、`--no-sessions`。
 - `prune-backups --keep <n>`：只清理本工具创建的旧备份。
+
+## 对话记录迁移
+
+在源设备导出：
+
+```bash
+codex-provider export
+```
+
+不传路径时会在当前 terminal 所在目录生成 `codex-history_YYYYMMDD_HHMMSS.tgz`。也可以显式指定文件名：
+
+```bash
+codex-provider export codex-history.tgz
+```
+
+把 `codex-history.tgz` 复制到目标设备后导入：
+
+```bash
+codex-provider import codex-history.tgz
+```
+
+常用选项：
+
+```bash
+codex-provider import codex-history.tgz --provider openai --conflict ask
+codex-provider import codex-history.tgz --conflict skip
+codex-provider import codex-history.tgz --dry-run
+```
+
+导入说明：
+
+- 默认导入到目标设备当前 `model_provider`，也可以用 `--provider <id>` 指定。
+- 如果发现同一个 thread id 已存在，交互式终端默认会展示本地/导入记录并让你选择保留哪一个。
+- 非交互环境遇到冲突时需要显式传 `--conflict skip`、`--conflict overwrite` 或 `--conflict fail`。
+- 导入前会创建 managed backup，并继续使用 `--keep <n>` 控制备份保留数量。
+- 迁移包不包含 `auth.json`、`config.toml`、日志、缓存或旧备份。
 
 ## 能力边界
 
 本工具只修复“历史会话可见性”相关 metadata，不修改会话内容。
 
 - 不处理登录、认证、`auth.json` 或第三方切号工具。
+- 不导入/导出登录状态或 provider 配置；新设备仍需自己完成登录和配置。
 - 不修改消息历史、会话标题、对话内容。
 - 不修改 `updated_at`，不通过改变历史排序来修复 Desktop 显示。
 - 不把旧会话里的 `encrypted_content` 重新加密到另一个 provider / account。

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ codex-provider sync
 codex-provider sync --provider openai
 codex-provider switch apigather
 codex-provider export
+codex-provider export --select
+codex-provider export selected-history.tgz --ids thread-a,thread-b
 codex-provider import codex-history.tgz
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\<timestamp>
 codex-provider prune-backups --keep 5
@@ -62,7 +64,7 @@ codex-provider prune-backups --keep 5
 - `status`：只检查当前 provider、rollout、SQLite、项目可见性诊断。
 - `sync`：不切换登录状态，只把历史会话 metadata 同步到当前 provider。
 - `switch <provider-id>`：修改 `config.toml` 根级 `model_provider`，然后执行同步。
-- `export <archive-path>`：导出 `sessions`、`archived_sessions` 和检测到的 SQLite 会话 metadata，便于迁移到另一台设备。
+- `export [archive-path]`：导出 `sessions`、`archived_sessions` 和检测到的 SQLite 会话 metadata，便于迁移到另一台设备；支持 `--select` 预览选择和 `--ids` 指定 thread id。
 - `import <archive-path>`：导入导出的历史包，默认把导入记录对齐到目标设备当前 provider。
 - `restore <backup-dir>`：从备份恢复，支持 `--no-config`、`--no-db`、`--no-sessions`。
 - `prune-backups --keep <n>`：只清理本工具创建的旧备份。
@@ -79,6 +81,20 @@ codex-provider export
 
 ```bash
 codex-provider export codex-history.tgz
+```
+
+如果只想迁移部分对话，可以先预览再手动选择：
+
+```bash
+codex-provider export --select
+```
+
+交互里会按列表展示 thread id、active/archived、provider、时间、首条用户消息预览、cwd 和 rollout 路径。直接输入文字可搜索，`↑/↓` 浏览，`Space` 选择/取消，`←/→` 或 `PageUp/PageDown` 翻页，`Enter` 导出，`Esc` 退出。
+
+自动化场景可以直接指定 thread id：
+
+```bash
+codex-provider export selected-history.tgz --ids thread-a,thread-b
 ```
 
 把 `codex-history.tgz` 复制到目标设备后导入：
@@ -98,6 +114,7 @@ codex-provider import codex-history.tgz --dry-run
 导入说明：
 
 - 默认导入到目标设备当前 `model_provider`，也可以用 `--provider <id>` 指定。
+- 如果导出时只选择了部分对话，导入时也只会增量合并这些记录。
 - 如果发现同一个 thread id 已存在，交互式终端默认会展示本地/导入记录并让你选择保留哪一个。
 - 非交互环境遇到冲突时需要显式传 `--conflict skip`、`--conflict overwrite` 或 `--conflict fail`。
 - 导入前会创建 managed backup，并继续使用 `--keep <n>` 控制备份保留数量。

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ codex-provider export codex-history.tgz
 codex-provider export --select
 ```
 
-交互里会按列表展示 thread id、active/archived、provider、时间、首条用户消息预览、cwd 和 rollout 路径。直接输入文字可搜索，`↑/↓` 浏览，`Space` 选择/取消，`←/→` 或 `PageUp/PageDown` 翻页，`Enter` 导出，`Esc` 退出。
+交互里会按列表展示 thread id、active/archived、provider、时间、首条用户消息预览、cwd 和 rollout 路径。直接输入文字可搜索，`↑/↓` 浏览，`Space` 选择/取消，`←/→` 或 `PageUp/PageDown` 翻页，`Tab` 显示/隐藏 archived 条目，`Delete` 将当前条目在 active/archived 间切换，`Enter` 导出，`Esc` 退出。
 
 自动化场景可以直接指定 thread id：
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ codex-provider export codex-history.tgz
 codex-provider export --select
 ```
 
-交互里会按列表展示 thread id、active/archived、provider、时间、首条用户消息预览、cwd 和 rollout 路径。直接输入文字可搜索，`↑/↓` 浏览，`Space` 选择/取消，`←/→` 或 `PageUp/PageDown` 翻页，`Tab` 显示/隐藏 archived 条目，`Delete` 将当前条目在 active/archived 间切换，`Enter` 导出，`Esc` 退出。
+交互里会按列表展示 thread id、active/archived、provider、时间、rename 标题或首条用户消息预览、cwd 和 rollout 路径。直接输入文字可搜索，`↑/↓` 浏览，`Space` 选择/取消，`←/→` 或 `PageUp/PageDown` 翻页，`Ctrl+P` 原地展开预览，`Ctrl+T` 查看 transcript 详情，`Tab` 显示/隐藏 archived 条目，`Delete` 将当前条目在 active/archived 间切换，`Enter` 导出，`Esc` 退出。
 
 自动化场景可以直接指定 thread id：
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -127,6 +127,20 @@ Without an explicit path, export writes `codex-history_YYYYMMDD_HHMMSS.tgz` in t
 codex-provider export codex-history.tgz
 ```
 
+To migrate only selected conversations, preview first and choose by number:
+
+```bash
+codex-provider export --select
+```
+
+The browser shows thread id, active/archived state, provider, timestamp, first user message preview, cwd, and rollout path. Type to search, use `Up/Down` to browse, `Space` to toggle selection, `Left/Right` or `PageUp/PageDown` to page, `Enter` to export, and `Esc` to exit.
+
+For automation, pass thread ids directly:
+
+```bash
+codex-provider export selected-history.tgz --ids thread-a,thread-b
+```
+
 Import that archive on another device:
 
 ```bash
@@ -190,9 +204,12 @@ Quick mapping:
 - `codex-provider export [archive-path]`
   - exports `sessions`, `archived_sessions`, and detected SQLite thread metadata to a `.tgz` archive
   - defaults to `codex-history_YYYYMMDD_HHMMSS.tgz` in the current terminal directory
+  - `--select` previews conversations and interactively chooses what to export
+  - `--ids <id[,id]>` exports only specific thread ids
   - use `--overwrite` to replace an existing archive file
 - `codex-provider import <archive-path>`
   - imports a history archive on another device
+  - incrementally merges only the records present in the archive
   - defaults imported records to the destination current provider
   - `--provider <id>` overrides the import provider
   - `--conflict ask|skip|overwrite|fail` controls same-thread conflicts
@@ -217,6 +234,8 @@ codex-provider sync --provider openai
 codex-provider switch openai
 codex-provider switch apigather
 codex-provider export
+codex-provider export --select
+codex-provider export selected-history.tgz --ids thread-a,thread-b
 codex-provider import codex-history.tgz
 codex-provider import codex-history.tgz --provider openai --conflict ask
 codex-provider prune-backups --keep 5

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -133,7 +133,7 @@ To migrate only selected conversations, preview first and choose by number:
 codex-provider export --select
 ```
 
-The browser shows thread id, active/archived state, provider, timestamp, first user message preview, cwd, and rollout path. Type to search, use `Up/Down` to browse, `Space` to toggle selection, `Left/Right` or `PageUp/PageDown` to page, `Enter` to export, and `Esc` to exit.
+The browser shows thread id, active/archived state, provider, timestamp, first user message preview, cwd, and rollout path. Type to search, use `Up/Down` to browse, `Space` to toggle selection, `Left/Right` or `PageUp/PageDown` to page, `Tab` to show/hide archived items, `Delete` to toggle the current item between active/archived, `Enter` to export, and `Esc` to exit.
 
 For automation, pass thread ids directly:
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -115,6 +115,32 @@ Clean old managed backups manually:
 codex-provider prune-backups --keep 5
 ```
 
+Export history from one device:
+
+```bash
+codex-provider export
+```
+
+Without an explicit path, export writes `codex-history_YYYYMMDD_HHMMSS.tgz` in the current terminal directory. You can still choose a file name explicitly:
+
+```bash
+codex-provider export codex-history.tgz
+```
+
+Import that archive on another device:
+
+```bash
+codex-provider import codex-history.tgz
+```
+
+Common import options:
+
+```bash
+codex-provider import codex-history.tgz --provider openai --conflict ask
+codex-provider import codex-history.tgz --conflict skip
+codex-provider import codex-history.tgz --dry-run
+```
+
 ## AI Quick Run
 
 If you want an AI assistant to handle this in one shot, copy this prompt:
@@ -161,6 +187,16 @@ Quick mapping:
   - updates root `model_provider` in `config.toml`
   - immediately runs a sync
   - `--keep <n>` overrides how many managed backups are retained after the run
+- `codex-provider export [archive-path]`
+  - exports `sessions`, `archived_sessions`, and detected SQLite thread metadata to a `.tgz` archive
+  - defaults to `codex-history_YYYYMMDD_HHMMSS.tgz` in the current terminal directory
+  - use `--overwrite` to replace an existing archive file
+- `codex-provider import <archive-path>`
+  - imports a history archive on another device
+  - defaults imported records to the destination current provider
+  - `--provider <id>` overrides the import provider
+  - `--conflict ask|skip|overwrite|fail` controls same-thread conflicts
+  - `--dry-run` reports the plan without writing
 - `codex-provider prune-backups`
   - manually removes older managed backups and keeps the newest `n`
 - `codex-provider restore <backup-dir>`
@@ -180,6 +216,9 @@ codex-provider sync --keep 5
 codex-provider sync --provider openai
 codex-provider switch openai
 codex-provider switch apigather
+codex-provider export
+codex-provider import codex-history.tgz
+codex-provider import codex-history.tgz --provider openai --conflict ask
 codex-provider prune-backups --keep 5
 codex-provider install-windows-launcher
 codex-provider install-windows-launcher --dir D:\Tools
@@ -193,7 +232,7 @@ codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\20260319T
 
 ## Safety
 
-Before each sync, the tool creates a backup under:
+Before each sync/import, the tool creates a backup under:
 
 ```text
 ~/.codex/backups_state/provider-sync/<timestamp>
@@ -207,6 +246,8 @@ It also uses:
 
 - It does not replace official `codex`.
 - It does not manage `auth.json` or third-party login tools.
+- History archives do not include `auth.json`, `config.toml`, logs, caches, or old backups.
+- Import does not log you in or configure providers on the new device.
 - It does not rewrite message history, titles, cwd, or timestamps.
 - It keeps the newest 5 managed backups by default; GUI retention settings or CLI `--keep <n>` can override that.
 - Manual cleanup and auto-prune only touch backups created by this tool inside `backups_state/provider-sync`.

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -133,7 +133,7 @@ To migrate only selected conversations, preview first and choose by number:
 codex-provider export --select
 ```
 
-The browser shows thread id, active/archived state, provider, timestamp, first user message preview, cwd, and rollout path. Type to search, use `Up/Down` to browse, `Space` to toggle selection, `Left/Right` or `PageUp/PageDown` to page, `Tab` to show/hide archived items, `Delete` to toggle the current item between active/archived, `Enter` to export, and `Esc` to exit.
+The browser shows thread id, active/archived state, provider, timestamp, renamed title or first user message preview, cwd, and rollout path. Type to search, use `Up/Down` to browse, `Space` to toggle selection, `Left/Right` or `PageUp/PageDown` to page, `Ctrl+P` to expand an inline preview, `Ctrl+T` to open the transcript view, `Tab` to show/hide archived items, `Delete` to toggle the current item between active/archived, `Enter` to export, and `Esc` to exit.
 
 For automation, pass thread ids directly:
 

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -87,7 +87,7 @@ codex-provider export codex-history.tgz
 codex-provider export --select
 ```
 
-交互里会按列表展示 thread id、active/archived、provider、时间、首条用户消息预览、cwd 和 rollout 路径。直接输入文字可搜索，`↑/↓` 浏览，`Space` 选择/取消，`←/→` 或 `PageUp/PageDown` 翻页，`Tab` 显示/隐藏 archived 条目，`Delete` 将当前条目在 active/archived 间切换，`Enter` 导出，`Esc` 退出。
+交互里会按列表展示 thread id、active/archived、provider、时间、rename 标题或首条用户消息预览、cwd 和 rollout 路径。直接输入文字可搜索，`↑/↓` 浏览，`Space` 选择/取消，`←/→` 或 `PageUp/PageDown` 翻页，`Ctrl+P` 原地展开预览，`Ctrl+T` 查看 transcript 详情，`Tab` 显示/隐藏 archived 条目，`Delete` 将当前条目在 active/archived 间切换，`Enter` 导出，`Esc` 退出。
 
 自动化场景可以直接指定 thread id：
 

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -50,6 +50,8 @@ codex-provider sync
 codex-provider sync --provider openai
 codex-provider switch apigather
 codex-provider export
+codex-provider export --select
+codex-provider export selected-history.tgz --ids thread-a,thread-b
 codex-provider import codex-history.tgz
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\<timestamp>
 codex-provider prune-backups --keep 5
@@ -60,7 +62,7 @@ codex-provider prune-backups --keep 5
 - `status`：只检查当前 provider、rollout、SQLite、项目可见性诊断。
 - `sync`：不切换登录状态，只把历史会话 metadata 同步到当前 provider。
 - `switch <provider-id>`：修改 `config.toml` 根级 `model_provider`，然后执行同步。
-- `export <archive-path>`：导出 `sessions`、`archived_sessions` 和检测到的 SQLite 会话 metadata，便于迁移到另一台设备。
+- `export [archive-path]`：导出 `sessions`、`archived_sessions` 和检测到的 SQLite 会话 metadata，便于迁移到另一台设备；支持 `--select` 预览选择和 `--ids` 指定 thread id。
 - `import <archive-path>`：导入导出的历史包，默认把导入记录对齐到目标设备当前 provider。
 - `restore <backup-dir>`：从备份恢复，支持 `--no-config`、`--no-db`、`--no-sessions`。
 - `prune-backups --keep <n>`：只清理本工具创建的旧备份。
@@ -77,6 +79,20 @@ codex-provider export
 
 ```bash
 codex-provider export codex-history.tgz
+```
+
+如果只想迁移部分对话，可以先预览再手动选择：
+
+```bash
+codex-provider export --select
+```
+
+交互里会按列表展示 thread id、active/archived、provider、时间、首条用户消息预览、cwd 和 rollout 路径。直接输入文字可搜索，`↑/↓` 浏览，`Space` 选择/取消，`←/→` 或 `PageUp/PageDown` 翻页，`Enter` 导出，`Esc` 退出。
+
+自动化场景可以直接指定 thread id：
+
+```bash
+codex-provider export selected-history.tgz --ids thread-a,thread-b
 ```
 
 把 `codex-history.tgz` 复制到目标设备后导入：
@@ -96,6 +112,7 @@ codex-provider import codex-history.tgz --dry-run
 导入说明：
 
 - 默认导入到目标设备当前 `model_provider`，也可以用 `--provider <id>` 指定。
+- 如果导出时只选择了部分对话，导入时也只会增量合并这些记录。
 - 如果发现同一个 thread id 已存在，交互式终端默认会展示本地/导入记录并让你选择保留哪一个。
 - 非交互环境遇到冲突时需要显式传 `--conflict skip`、`--conflict overwrite` 或 `--conflict fail`。
 - 导入前会创建 managed backup，并继续使用 `--keep <n>` 控制备份保留数量。

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -49,6 +49,8 @@ codex-provider status
 codex-provider sync
 codex-provider sync --provider openai
 codex-provider switch apigather
+codex-provider export
+codex-provider import codex-history.tgz
 codex-provider restore C:\Users\you\.codex\backups_state\provider-sync\<timestamp>
 codex-provider prune-backups --keep 5
 ```
@@ -58,14 +60,53 @@ codex-provider prune-backups --keep 5
 - `status`：只检查当前 provider、rollout、SQLite、项目可见性诊断。
 - `sync`：不切换登录状态，只把历史会话 metadata 同步到当前 provider。
 - `switch <provider-id>`：修改 `config.toml` 根级 `model_provider`，然后执行同步。
+- `export <archive-path>`：导出 `sessions`、`archived_sessions` 和检测到的 SQLite 会话 metadata，便于迁移到另一台设备。
+- `import <archive-path>`：导入导出的历史包，默认把导入记录对齐到目标设备当前 provider。
 - `restore <backup-dir>`：从备份恢复，支持 `--no-config`、`--no-db`、`--no-sessions`。
 - `prune-backups --keep <n>`：只清理本工具创建的旧备份。
+
+## 对话记录迁移
+
+在源设备导出：
+
+```bash
+codex-provider export
+```
+
+不传路径时会在当前 terminal 所在目录生成 `codex-history_YYYYMMDD_HHMMSS.tgz`。也可以显式指定文件名：
+
+```bash
+codex-provider export codex-history.tgz
+```
+
+把 `codex-history.tgz` 复制到目标设备后导入：
+
+```bash
+codex-provider import codex-history.tgz
+```
+
+常用选项：
+
+```bash
+codex-provider import codex-history.tgz --provider openai --conflict ask
+codex-provider import codex-history.tgz --conflict skip
+codex-provider import codex-history.tgz --dry-run
+```
+
+导入说明：
+
+- 默认导入到目标设备当前 `model_provider`，也可以用 `--provider <id>` 指定。
+- 如果发现同一个 thread id 已存在，交互式终端默认会展示本地/导入记录并让你选择保留哪一个。
+- 非交互环境遇到冲突时需要显式传 `--conflict skip`、`--conflict overwrite` 或 `--conflict fail`。
+- 导入前会创建 managed backup，并继续使用 `--keep <n>` 控制备份保留数量。
+- 迁移包不包含 `auth.json`、`config.toml`、日志、缓存或旧备份。
 
 ## 能力边界
 
 本工具只修复“历史会话可见性”相关 metadata，不修改会话内容。
 
 - 不处理登录、认证、`auth.json` 或第三方切号工具。
+- 不导入/导出登录状态或 provider 配置；新设备仍需自己完成登录和配置。
 - 不修改消息历史、会话标题、对话内容。
 - 不修改 `updated_at`，不通过改变历史排序来修复 Desktop 显示。
 - 不把旧会话里的 `encrypted_content` 重新加密到另一个 provider / account。

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -87,7 +87,7 @@ codex-provider export codex-history.tgz
 codex-provider export --select
 ```
 
-交互里会按列表展示 thread id、active/archived、provider、时间、首条用户消息预览、cwd 和 rollout 路径。直接输入文字可搜索，`↑/↓` 浏览，`Space` 选择/取消，`←/→` 或 `PageUp/PageDown` 翻页，`Enter` 导出，`Esc` 退出。
+交互里会按列表展示 thread id、active/archived、provider、时间、首条用户消息预览、cwd 和 rollout 路径。直接输入文字可搜索，`↑/↓` 浏览，`Space` 选择/取消，`←/→` 或 `PageUp/PageDown` 翻页，`Tab` 显示/隐藏 archived 条目，`Delete` 将当前条目在 active/archived 间切换，`Enter` 导出，`Esc` 退出。
 
 自动化场景可以直接指定 thread id：
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "codex-provider-sync",
       "version": "0.2.9",
       "license": "MIT",
+      "dependencies": {
+        "tar": "^6.2.1"
+      },
       "bin": {
         "codex-provider": "src/cli.js"
       },
@@ -162,6 +165,30 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "optional": true
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmmirror.com/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -219,6 +246,52 @@
       "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmmirror.com/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -415,6 +488,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmmirror.com/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -443,6 +533,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -466,6 +565,12 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "optional": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "license": "MIT",
   "optionalDependencies": {
     "better-sqlite3": "8.7.0"
+  },
+  "dependencies": {
+    "tar": "^6.2.1"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -395,6 +395,79 @@ function padVisible(value, width) {
   return `${text}${" ".repeat(width - length)}`;
 }
 
+function normalizeDisplayText(value) {
+  return String(value ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[\u0000-\u0009\u000b-\u001f\u007f]/g, " ")
+    .trim();
+}
+
+function wrapText(value, width, maxLines = Infinity) {
+  if (width <= 0 || maxLines <= 0) {
+    return [];
+  }
+  const paragraphs = normalizeDisplayText(value).split("\n");
+  const lines = [];
+  for (const paragraph of paragraphs) {
+    if (lines.length >= maxLines) {
+      break;
+    }
+    const words = paragraph.split(/(\s+)/).filter((part) => part.length > 0);
+    if (words.length === 0) {
+      lines.push("");
+      continue;
+    }
+    let current = "";
+    for (const word of words) {
+      if (lines.length >= maxLines) {
+        break;
+      }
+      if (/^\s+$/.test(word)) {
+        if (current && !current.endsWith(" ")) {
+          current += " ";
+        }
+        continue;
+      }
+      const candidate = current ? `${current}${word}` : word;
+      if (visibleLength(candidate) <= width) {
+        current = candidate;
+        continue;
+      }
+      if (current) {
+        lines.push(current.trimEnd());
+        current = "";
+        if (lines.length >= maxLines) {
+          break;
+        }
+      }
+      let chunk = "";
+      for (const char of Array.from(word)) {
+        const candidateChunk = `${chunk}${char}`;
+        if (visibleLength(candidateChunk) > width) {
+          if (chunk) {
+            lines.push(chunk);
+          }
+          chunk = char;
+          if (lines.length >= maxLines) {
+            break;
+          }
+        } else {
+          chunk = candidateChunk;
+        }
+      }
+      current = chunk;
+    }
+    if (current && lines.length < maxLines) {
+      lines.push(current.trimEnd());
+    }
+  }
+  if (lines.length > maxLines) {
+    return lines.slice(0, maxLines);
+  }
+  return lines;
+}
+
 const THEME = {
   reset: "\x1b[0m",
   dim: "\x1b[90m",
@@ -491,7 +564,7 @@ function formatExportBrowserRow(entry, { selected, active, odd, layout }) {
   const marker = selected ? "●" : "○";
   const pointer = active ? "›" : " ";
   const ageOrTime = entry.timestamp ? truncateText(entry.timestamp, layout.timeWidth) : "";
-  const title = entry.firstUserMessage || entry.threadId || entry.relativePath;
+  const title = entry.title || entry.firstUserMessage || entry.threadId || entry.relativePath;
   const plainLine = joinRowCells([
     padVisible(pointer, layout.gutterWidth),
     padVisible(marker, layout.checkWidth),
@@ -502,6 +575,57 @@ function formatExportBrowserRow(entry, { selected, active, odd, layout }) {
     formatCell(title, layout.titleWidth)
   ]);
   return colorRow(padVisible(plainLine, layout.width), { active, selected, odd });
+}
+
+function roleLabel(role) {
+  if (role === "user") {
+    return "You";
+  }
+  if (role === "assistant") {
+    return "Codex";
+  }
+  if (role === "system") {
+    return "System";
+  }
+  return "Msg";
+}
+
+function transcriptCacheItem(transcriptCache, key) {
+  return transcriptCache instanceof Map ? transcriptCache.get(key) : null;
+}
+
+function formatInlinePreviewRows(entry, { layout, transcriptCache, maxRows }) {
+  const cached = transcriptCacheItem(transcriptCache, entry.key);
+  const prefixWidth = Math.min(9, Math.max(5, Math.floor(layout.width * 0.14)));
+  const textWidth = Math.max(8, layout.width - prefixWidth - 3);
+  if (!cached) {
+    return [`${THEME.panel}${THEME.dim}${padVisible("  Loading preview...", layout.width)}${THEME.reset}`];
+  }
+  if (cached.error) {
+    return [`${THEME.panel}${THEME.warning}${padVisible(truncateText(`  ${cached.error}`, layout.width), layout.width)}${THEME.reset}`];
+  }
+  const messages = cached.messages ?? [];
+  if (messages.length === 0) {
+    return [`${THEME.panel}${THEME.dim}${padVisible("  No transcript messages found in rollout.", layout.width)}${THEME.reset}`];
+  }
+
+  const rows = [];
+  for (const message of messages.slice(0, 4)) {
+    if (rows.length >= maxRows) {
+      break;
+    }
+    const label = `${roleLabel(message.role)}:`;
+    const wrapped = wrapText(message.text, textWidth, Math.max(1, maxRows - rows.length));
+    for (let index = 0; index < wrapped.length && rows.length < maxRows; index += 1) {
+      const left = index === 0 ? label : "";
+      const line = `  ${formatCell(left, prefixWidth)} ${formatCell(wrapped[index], textWidth)}`;
+      rows.push(`${THEME.panel}${THEME.muted}${padVisible(line, layout.width)}${THEME.reset}`);
+    }
+  }
+  if (cached.truncated && rows.length < maxRows) {
+    rows.push(`${THEME.panel}${THEME.dim}${padVisible("  ... transcript is truncated", layout.width)}${THEME.reset}`);
+  }
+  return rows;
 }
 
 function formatExportBrowserHeader(layout) {
@@ -525,6 +649,8 @@ function renderExportBrowser({
   preview,
   filtered,
   selectedKeys,
+  transcriptCache,
+  expandedKey,
   cursor,
   scroll,
   query,
@@ -532,7 +658,7 @@ function renderExportBrowser({
   message
 }) {
   const layout = buildExportBrowserLayout();
-  const visible = filtered.slice(scroll, scroll + layout.bodyRows);
+  const visible = filtered.slice(scroll);
   const page = filtered.length === 0 ? 0 : Math.floor(scroll / layout.bodyRows) + 1;
   const pageCount = filtered.length === 0 ? 0 : Math.ceil(filtered.length / layout.bodyRows);
   const queryText = query ? `${THEME.accent}${truncateText(query, Math.max(1, layout.width - 18))}${THEME.reset}` : `${THEME.dim}(empty)${THEME.reset}`;
@@ -546,30 +672,111 @@ function renderExportBrowser({
     formatRule(layout.width)
   ];
 
-  for (let offset = 0; offset < layout.bodyRows; offset += 1) {
+  let renderedBodyRows = 0;
+  for (let offset = 0; renderedBodyRows < layout.bodyRows; offset += 1) {
     const entry = visible[offset];
     if (!entry) {
       const blank = " ".repeat(layout.width);
-      lines.push(`${offset % 2 ? THEME.panelAlt : THEME.panel}${blank}${THEME.reset}`);
+      lines.push(`${renderedBodyRows % 2 ? THEME.panelAlt : THEME.panel}${blank}${THEME.reset}`);
+      renderedBodyRows += 1;
       continue;
     }
     const active = scroll + offset === cursor;
     lines.push(formatExportBrowserRow(entry, {
       selected: selectedKeys.has(entry.key),
       active,
-      odd: offset % 2 === 1,
+      odd: renderedBodyRows % 2 === 1,
       layout
     }));
+    renderedBodyRows += 1;
+    if (entry.key === expandedKey && renderedBodyRows < layout.bodyRows) {
+      const previewRows = formatInlinePreviewRows(entry, {
+        layout,
+        transcriptCache,
+        maxRows: layout.bodyRows - renderedBodyRows
+      });
+      for (const previewRow of previewRows) {
+        if (renderedBodyRows >= layout.bodyRows) {
+          break;
+        }
+        lines.push(previewRow);
+        renderedBodyRows += 1;
+      }
+    }
   }
 
-  const footer = "↑/↓ browse  ←/→ PgUp/PgDn page  Space select  Tab archives  Delete archive/live  Ctrl+A all  Ctrl+N none  Enter export  Esc exit";
+  const footer = "↑/↓ browse  ←/→ PgUp/PgDn page  Space select  Ctrl+P preview  Ctrl+T transcript  Tab archives  Delete archive/live  Enter export  Esc exit";
   lines.push(formatRule(layout.width));
   lines.push(`${message ? THEME.warning : THEME.dim}${padVisible(truncateText(message || footer, layout.width), layout.width)}${THEME.reset}`);
   lines.push(`${THEME.dim}${padVisible(truncateText(preview.codexHome, layout.width), layout.width)}${THEME.reset}`);
   return `\x1b[?25l\x1b[H${lines.slice(0, layout.height).join("\n")}`;
 }
 
-async function chooseExportSelection(preview, { onToggleArchive } = {}) {
+function buildTranscriptLines(transcript, width) {
+  if (transcript?.error) {
+    return [transcript.error];
+  }
+  const messages = transcript?.messages ?? [];
+  if (messages.length === 0) {
+    return ["No transcript messages found in rollout."];
+  }
+  const labelWidth = Math.min(10, Math.max(6, Math.floor(width * 0.15)));
+  const textWidth = Math.max(12, width - labelWidth - 3);
+  const lines = [];
+  for (const message of messages) {
+    const label = `${roleLabel(message.role)}:`;
+    const wrapped = wrapText(message.text, textWidth, Infinity);
+    if (wrapped.length === 0) {
+      lines.push(`${formatCell(label, labelWidth)} `);
+      continue;
+    }
+    for (let index = 0; index < wrapped.length; index += 1) {
+      const left = index === 0 ? label : "";
+      lines.push(`${formatCell(left, labelWidth)} ${wrapped[index]}`);
+    }
+    lines.push("");
+  }
+  if (transcript.truncated) {
+    lines.push("... transcript is truncated");
+  }
+  return lines;
+}
+
+function renderTranscriptBrowser({ entry, transcript, scroll, message }) {
+  const layout = buildExportBrowserLayout();
+  const title = entry.title || entry.firstUserMessage || entry.threadId || entry.relativePath;
+  const meta = [
+    entry.scope === "archived_sessions" ? "archived" : "live",
+    entry.provider,
+    entry.timestamp,
+    entry.relativePath
+  ].filter(Boolean).join("  ");
+  const bodyRows = Math.max(3, layout.height - 5);
+  const transcriptLines = buildTranscriptLines(transcript, layout.width);
+  const maxScroll = Math.max(0, transcriptLines.length - bodyRows);
+  const safeScroll = Math.max(0, Math.min(scroll, maxScroll));
+  const lines = [
+    `${THEME.header}${padVisible(truncateText(title, layout.width), layout.width)}${THEME.reset}`,
+    `${THEME.dim}${padVisible(truncateText(meta, layout.width), layout.width)}${THEME.reset}`,
+    formatRule(layout.width)
+  ];
+  const visible = transcriptLines.slice(safeScroll, safeScroll + bodyRows);
+  for (let index = 0; index < bodyRows; index += 1) {
+    const text = visible[index] ?? "";
+    const color = transcript?.error ? THEME.warning : THEME.muted;
+    lines.push(`${index % 2 ? THEME.panelAlt : THEME.panel}${color}${padVisible(truncateText(text, layout.width), layout.width)}${THEME.reset}`);
+  }
+  const footer = `↑/↓ scroll  PgUp/PgDn page  Home/End  Ctrl+T/Esc back  ${safeScroll + 1}/${Math.max(1, transcriptLines.length)}`;
+  lines.push(formatRule(layout.width));
+  lines.push(`${message ? THEME.warning : THEME.dim}${padVisible(truncateText(message || footer, layout.width), layout.width)}${THEME.reset}`);
+  return {
+    text: `\x1b[?25l\x1b[H${lines.slice(0, layout.height).join("\n")}`,
+    scroll: safeScroll,
+    maxScroll
+  };
+}
+
+async function chooseExportSelection(preview, { onToggleArchive, onLoadTranscript } = {}) {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     throw new Error("Interactive export selection requires a terminal. Use --ids <thread-id[,thread-id]> for non-interactive exports.");
   }
@@ -580,10 +787,14 @@ async function chooseExportSelection(preview, { onToggleArchive } = {}) {
   readline.emitKeypressEvents(process.stdin);
   const previousRawMode = process.stdin.isRaw;
   const selectedKeys = new Set();
+  const transcriptCache = new Map();
   let query = "";
   let includeArchived = true;
   let cursor = 0;
   let scroll = 0;
+  let expandedKey = null;
+  let transcriptView = null;
+  let transcriptScroll = 0;
   let message = "";
   let busy = false;
 
@@ -612,12 +823,26 @@ async function chooseExportSelection(preview, { onToggleArchive } = {}) {
   }
 
   function render() {
+    if (transcriptView) {
+      const rendered = renderTranscriptBrowser({
+        entry: transcriptView.entry,
+        transcript: transcriptView.transcript,
+        scroll: transcriptScroll,
+        message
+      });
+      transcriptScroll = rendered.scroll;
+      process.stdout.write(rendered.text);
+      message = "";
+      return;
+    }
     const filtered = filteredEntries();
     clampView(filtered);
     process.stdout.write(renderExportBrowser({
       preview,
       filtered,
       selectedKeys,
+      transcriptCache,
+      expandedKey,
       cursor,
       scroll,
       query,
@@ -662,6 +887,71 @@ async function chooseExportSelection(preview, { onToggleArchive } = {}) {
       move(delta * bodyHeight());
     }
 
+    async function loadTranscriptForEntry(entry) {
+      if (!entry) {
+        return { error: "No conversation under cursor.", messages: [] };
+      }
+      if (transcriptCache.has(entry.key)) {
+        return transcriptCache.get(entry.key);
+      }
+      if (typeof onLoadTranscript !== "function") {
+        const unavailable = { error: "Transcript loading is not available.", messages: [] };
+        transcriptCache.set(entry.key, unavailable);
+        return unavailable;
+      }
+      try {
+        const transcript = await onLoadTranscript(entry);
+        transcriptCache.set(entry.key, transcript);
+        return transcript;
+      } catch (error) {
+        const failed = {
+          error: error instanceof Error ? error.message : String(error),
+          messages: []
+        };
+        transcriptCache.set(entry.key, failed);
+        return failed;
+      }
+    }
+
+    async function toggleInlinePreview() {
+      const entry = filteredEntries()[cursor];
+      if (!entry) {
+        message = "No conversation under cursor.";
+        render();
+        return;
+      }
+      if (expandedKey === entry.key) {
+        expandedKey = null;
+        render();
+        return;
+      }
+      expandedKey = entry.key;
+      if (!transcriptCache.has(entry.key)) {
+        busy = true;
+        render();
+        await loadTranscriptForEntry(entry);
+        busy = false;
+      }
+      render();
+    }
+
+    async function openTranscriptForCurrentEntry() {
+      const entry = filteredEntries()[cursor];
+      if (!entry) {
+        message = "No conversation under cursor.";
+        render();
+        return;
+      }
+      busy = true;
+      message = `Loading transcript for ${entry.threadId ?? entry.relativePath}...`;
+      render();
+      const transcript = await loadTranscriptForEntry(entry);
+      transcriptView = { entry, transcript };
+      transcriptScroll = 0;
+      busy = false;
+      render();
+    }
+
     async function toggleArchiveForCurrentEntry() {
       if (typeof onToggleArchive !== "function") {
         message = "Archive toggle is not available.";
@@ -689,6 +979,13 @@ async function chooseExportSelection(preview, { onToggleArchive } = {}) {
           selectedKeys.delete(entry.key);
           selectedKeys.add(updated.key);
         }
+        if (transcriptCache.has(entry.key) && updated.key !== entry.key) {
+          transcriptCache.set(updated.key, transcriptCache.get(entry.key));
+          transcriptCache.delete(entry.key);
+        }
+        if (expandedKey === entry.key) {
+          expandedKey = updated.key;
+        }
         message = `${updated.scope === "archived_sessions" ? "Archived" : "Restored"} ${updated.threadId ?? updated.relativePath}.`;
       } catch (error) {
         message = error instanceof Error ? error.message : String(error);
@@ -706,8 +1003,35 @@ async function chooseExportSelection(preview, { onToggleArchive } = {}) {
         finish(new Error("History export aborted by user."));
         return;
       }
+      if (transcriptView) {
+        const layout = buildExportBrowserLayout();
+        const transcriptLines = buildTranscriptLines(transcriptView.transcript, layout.width);
+        const maxScroll = Math.max(0, transcriptLines.length - Math.max(3, layout.height - 5));
+        if (key.name === "escape" || (key.ctrl && key.name === "t")) {
+          transcriptView = null;
+          transcriptScroll = 0;
+        } else if (key.name === "up") {
+          transcriptScroll = Math.max(0, transcriptScroll - 1);
+        } else if (key.name === "down") {
+          transcriptScroll = Math.min(maxScroll, transcriptScroll + 1);
+        } else if (key.name === "pageup" || key.name === "left") {
+          transcriptScroll = Math.max(0, transcriptScroll - Math.max(3, layout.height - 5));
+        } else if (key.name === "pagedown" || key.name === "right") {
+          transcriptScroll = Math.min(maxScroll, transcriptScroll + Math.max(3, layout.height - 5));
+        } else if (key.name === "home") {
+          transcriptScroll = 0;
+        } else if (key.name === "end") {
+          transcriptScroll = maxScroll;
+        }
+        render();
+        return;
+      }
       if (key.name === "escape") {
         finish(new Error("History export aborted by user."));
+        return;
+      }
+      if (key.ctrl && key.name === "t") {
+        await openTranscriptForCurrentEntry();
         return;
       }
       if (key.ctrl && key.name === "a") {
@@ -748,6 +1072,9 @@ async function chooseExportSelection(preview, { onToggleArchive } = {}) {
         message = includeArchived ? "Archived conversations are visible." : "Archived conversations are hidden.";
       } else if (key.name === "delete") {
         await toggleArchiveForCurrentEntry();
+        return;
+      } else if (key.ctrl && key.name === "p") {
+        await toggleInlinePreview();
         return;
       } else if (key.name === "home") {
         cursor = 0;
@@ -889,6 +1216,7 @@ async function main() {
   if (command === "export") {
     const {
       getExportHistoryPreview,
+      getExportHistoryTranscript,
       parseExportThreadIds,
       runExportHistory,
       toggleExportHistoryArchived
@@ -903,6 +1231,12 @@ async function main() {
           {
             onToggleArchive(entry) {
               return toggleExportHistoryArchived({
+                codexHome: flags["codex-home"],
+                entry
+              });
+            },
+            onLoadTranscript(entry) {
+              return getExportHistoryTranscript({
                 codexHome: flags["codex-home"],
                 entry
               });

--- a/src/cli.js
+++ b/src/cli.js
@@ -422,12 +422,14 @@ function searchableExportText(entry) {
   ].filter(Boolean).join("\n").toLowerCase();
 }
 
-function filterExportPreviewEntries(conversations, query) {
+function filterExportPreviewEntries(conversations, query, { includeArchived = true } = {}) {
   const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) {
-    return conversations;
-  }
-  return conversations.filter((entry) => searchableExportText(entry).includes(normalizedQuery));
+  return conversations.filter((entry) => {
+    if (!includeArchived && entry.scope === "archived_sessions") {
+      return false;
+    }
+    return !normalizedQuery || searchableExportText(entry).includes(normalizedQuery);
+  });
 }
 
 function buildExportBrowserLayout() {
@@ -526,6 +528,7 @@ function renderExportBrowser({
   cursor,
   scroll,
   query,
+  includeArchived,
   message
 }) {
   const layout = buildExportBrowserLayout();
@@ -533,7 +536,8 @@ function renderExportBrowser({
   const page = filtered.length === 0 ? 0 : Math.floor(scroll / layout.bodyRows) + 1;
   const pageCount = filtered.length === 0 ? 0 : Math.ceil(filtered.length / layout.bodyRows);
   const queryText = query ? `${THEME.accent}${truncateText(query, Math.max(1, layout.width - 18))}${THEME.reset}` : `${THEME.dim}(empty)${THEME.reset}`;
-  const countText = `${THEME.muted}Filtered ${filtered.length}/${preview.conversations.length}  Selected ${selectedKeys.size}  Page ${page}/${pageCount}${THEME.reset}`;
+  const archiveText = includeArchived ? "Archives on" : "Archives off";
+  const countText = `${THEME.muted}Filtered ${filtered.length}/${preview.conversations.length}  Selected ${selectedKeys.size}  ${archiveText}  Page ${page}/${pageCount}${THEME.reset}`;
   const topLine = `${THEME.header}Type to search:${THEME.reset} ${queryText}`;
   const lines = [
     padVisible(topLine, layout.width),
@@ -558,14 +562,14 @@ function renderExportBrowser({
     }));
   }
 
-  const footer = "↑/↓ browse  ←/→ PgUp/PgDn page  Space select  Ctrl+A all  Ctrl+N none  Enter export  Esc exit";
+  const footer = "↑/↓ browse  ←/→ PgUp/PgDn page  Space select  Tab archives  Delete archive/live  Ctrl+A all  Ctrl+N none  Enter export  Esc exit";
   lines.push(formatRule(layout.width));
   lines.push(`${message ? THEME.warning : THEME.dim}${padVisible(truncateText(message || footer, layout.width), layout.width)}${THEME.reset}`);
   lines.push(`${THEME.dim}${padVisible(truncateText(preview.codexHome, layout.width), layout.width)}${THEME.reset}`);
   return `\x1b[?25l\x1b[H${lines.slice(0, layout.height).join("\n")}`;
 }
 
-async function chooseExportSelection(preview) {
+async function chooseExportSelection(preview, { onToggleArchive } = {}) {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     throw new Error("Interactive export selection requires a terminal. Use --ids <thread-id[,thread-id]> for non-interactive exports.");
   }
@@ -577,12 +581,14 @@ async function chooseExportSelection(preview) {
   const previousRawMode = process.stdin.isRaw;
   const selectedKeys = new Set();
   let query = "";
+  let includeArchived = true;
   let cursor = 0;
   let scroll = 0;
   let message = "";
+  let busy = false;
 
   function filteredEntries() {
-    return filterExportPreviewEntries(preview.conversations, query);
+    return filterExportPreviewEntries(preview.conversations, query, { includeArchived });
   }
 
   function bodyHeight() {
@@ -615,6 +621,7 @@ async function chooseExportSelection(preview) {
       cursor,
       scroll,
       query,
+      includeArchived,
       message
     }));
     message = "";
@@ -655,7 +662,46 @@ async function chooseExportSelection(preview) {
       move(delta * bodyHeight());
     }
 
-    function onKeyPress(str, key = {}) {
+    async function toggleArchiveForCurrentEntry() {
+      if (typeof onToggleArchive !== "function") {
+        message = "Archive toggle is not available.";
+        return;
+      }
+      const entry = filteredEntries()[cursor];
+      if (!entry) {
+        message = "No conversation under cursor.";
+        return;
+      }
+      busy = true;
+      message = `Toggling ${entry.threadId ?? entry.relativePath}...`;
+      render();
+      try {
+        const updated = await onToggleArchive(entry);
+        const index = preview.conversations.findIndex((candidate) => candidate.key === entry.key);
+        if (index !== -1) {
+          preview.conversations[index] = {
+            ...preview.conversations[index],
+            ...updated,
+            index: preview.conversations[index].index
+          };
+        }
+        if (selectedKeys.has(entry.key) && updated.key !== entry.key) {
+          selectedKeys.delete(entry.key);
+          selectedKeys.add(updated.key);
+        }
+        message = `${updated.scope === "archived_sessions" ? "Archived" : "Restored"} ${updated.threadId ?? updated.relativePath}.`;
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      } finally {
+        busy = false;
+        render();
+      }
+    }
+
+    async function onKeyPress(str, key = {}) {
+      if (busy) {
+        return;
+      }
       if (key.ctrl && key.name === "c") {
         finish(new Error("History export aborted by user."));
         return;
@@ -695,6 +741,14 @@ async function chooseExportSelection(preview) {
         page(-1);
       } else if (key.name === "right" || key.name === "pagedown") {
         page(1);
+      } else if (key.name === "tab") {
+        includeArchived = !includeArchived;
+        cursor = 0;
+        scroll = 0;
+        message = includeArchived ? "Archived conversations are visible." : "Archived conversations are hidden.";
+      } else if (key.name === "delete") {
+        await toggleArchiveForCurrentEntry();
+        return;
       } else if (key.name === "home") {
         cursor = 0;
       } else if (key.name === "end") {
@@ -833,13 +887,28 @@ async function main() {
   }
 
   if (command === "export") {
-    const { getExportHistoryPreview, parseExportThreadIds, runExportHistory } = await loadService();
+    const {
+      getExportHistoryPreview,
+      parseExportThreadIds,
+      runExportHistory,
+      toggleExportHistoryArchived
+    } = await loadService();
     const archivePath = positionals[1] ?? flags.output;
     if (flags.select && flags.ids) {
       throw new Error("Use either --select or --ids, not both.");
     }
     const selectionKeys = flags.select
-      ? await chooseExportSelection(await getExportHistoryPreview({ codexHome: flags["codex-home"] }))
+      ? await chooseExportSelection(
+          await getExportHistoryPreview({ codexHome: flags["codex-home"] }),
+          {
+            onToggleArchive(entry) {
+              return toggleExportHistoryArchived({
+                codexHome: flags["codex-home"],
+                entry
+              });
+            }
+          }
+        )
       : null;
     const result = await runExportHistory({
       codexHome: flags["codex-home"],

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import path from "node:path";
+import readline from "node:readline";
 
 import { DEFAULT_BACKUP_RETENTION_COUNT } from "./constants.js";
 import { installWindowsLauncher } from "./launcher.js";
@@ -18,6 +19,8 @@ Usage:
   codex-provider status [--codex-home PATH]
   codex-provider sync [--provider ID] [--keep N] [--codex-home PATH]
   codex-provider switch <provider-id> [--keep N] [--codex-home PATH]
+  codex-provider export [archive-path] [--overwrite] [--codex-home PATH]
+  codex-provider import <archive-path> [--provider ID] [--conflict ask|skip|overwrite|fail] [--dry-run] [--keep N] [--codex-home PATH]
   codex-provider prune-backups [--keep N] [--codex-home PATH]
   codex-provider restore <backup-dir> [--no-config] [--no-db] [--no-sessions] [--codex-home PATH]
   codex-provider install-windows-launcher [--dir PATH] [--codex-home PATH]
@@ -99,6 +102,74 @@ function summarizePrune(result) {
   ].join("\n");
 }
 
+function summarizeExport(result) {
+  return [
+    `Exported history archive: ${result.archivePath}`,
+    `Codex home: ${result.codexHome}`,
+    `Rollout files: ${result.rolloutFiles}`,
+    `SQLite files: ${result.dbFiles}`,
+    `Global state files: ${result.globalStateFiles}`,
+    `Archive size: ${formatBytes(result.bytes)}`
+  ].join("\n");
+}
+
+function summarizeImport(result) {
+  const lines = [
+    `${result.dryRun ? "Planned" : "Imported"} history archive: ${result.archivePath}`,
+    `Codex home: ${result.codexHome}`,
+    `Target provider: ${result.targetProvider}`,
+    `Archive rollout files: ${result.plan.archiveRolloutFiles}`,
+    `Archive SQLite rows: ${result.plan.archiveSqliteRows}`,
+    `Conflicts: ${result.plan.conflicts}`
+  ];
+  if (result.dryRun) {
+    lines.push(`New rollout files: ${result.plan.newRolloutFiles}`);
+    lines.push(`New SQLite rows: ${result.plan.newSqliteRows}`);
+    lines.push(`Skipped rollout conflicts: ${result.skippedRolloutFiles}`);
+    return lines.join("\n");
+  }
+
+  lines.push(`Backup: ${result.backupDir}`);
+  lines.push(`Backup creation time: ${formatDuration(result.backupDurationMs ?? 0)}`);
+  lines.push(`Imported rollout files: ${result.importedRolloutFiles}`);
+  lines.push(`Skipped rollout files: ${result.skippedRolloutFiles}`);
+  if (result.removedLocalConflictRolloutFiles) {
+    lines.push(`Removed replaced local rollout files: ${result.removedLocalConflictRolloutFiles}`);
+  }
+  if (result.sqliteDatabaseCopied) {
+    lines.push(`Copied SQLite database files: ${result.copiedDbFiles}`);
+  }
+  lines.push(`Inserted SQLite rows: ${result.sqliteRowsInserted}`);
+  lines.push(`Overwritten SQLite rows: ${result.sqliteRowsUpdatedByImport}`);
+  lines.push(`Skipped SQLite rows: ${result.sqliteRowsSkipped}`);
+  lines.push(`Provider metadata rows updated: ${result.sqliteRowsUpdated}${result.sqlitePresent ? "" : " (state_5.sqlite not found)"}`);
+  lines.push(`Rollout metadata files updated: ${result.changedSessionFiles}`);
+  if (result.sqliteUserEventRowsUpdated) {
+    lines.push(`Updated SQLite user-event flags: ${result.sqliteUserEventRowsUpdated}`);
+  }
+  if (result.sqliteCwdRowsUpdated) {
+    lines.push(`Updated SQLite cwd paths: ${result.sqliteCwdRowsUpdated}`);
+  }
+  if (result.updatedWorkspaceRoots) {
+    lines.push(`Updated workspace roots: ${result.updatedWorkspaceRoots}`);
+  }
+  if (result.skippedLockedRolloutFiles?.length) {
+    const preview = result.skippedLockedRolloutFiles.slice(0, 5).join(", ");
+    const extraCount = result.skippedLockedRolloutFiles.length - Math.min(result.skippedLockedRolloutFiles.length, 5);
+    lines.push(`Skipped locked rollout files: ${result.skippedLockedRolloutFiles.length}`);
+    lines.push(`Locked file(s): ${preview}${extraCount > 0 ? ` (+${extraCount} more)` : ""}`);
+  }
+  if (result.autoPruneResult) {
+    lines.push(
+      `Backup cleanup: deleted ${result.autoPruneResult.deletedCount}, remaining ${result.autoPruneResult.remainingCount}, freed ${formatBytes(result.autoPruneResult.freedBytes)}`
+    );
+  }
+  if (result.autoPruneWarning) {
+    lines.push(`Backup cleanup warning: ${result.autoPruneWarning}`);
+  }
+  return lines.join("\n");
+}
+
 function formatBytes(bytes) {
   const units = ["B", "KB", "MB", "GB", "TB"];
   let value = bytes;
@@ -134,6 +205,22 @@ const SYNC_PROGRESS_STAGES = [
   ["clean_backups", "Cleaning backups..."]
 ];
 
+const EXPORT_PROGRESS_STAGES = [
+  ["create_history_archive", "Creating history archive..."]
+];
+
+const IMPORT_PROGRESS_STAGES = [
+  ["extract_history_archive", "Extracting history archive..."],
+  ["plan_history_import", "Planning history import..."],
+  ["check_import_targets", "Checking import targets..."],
+  ["create_backup", "Creating backup..."],
+  ["copy_history_rollouts", "Copying rollout files..."],
+  ["merge_history_sqlite", "Merging SQLite rows..."],
+  ["scan_imported_history", "Scanning imported history..."],
+  ["sync_imported_metadata", "Synchronizing imported metadata..."],
+  ["clean_backups", "Cleaning backups..."]
+];
+
 const SYNC_PROGRESS_STAGE_INDEX = new Map(
   SYNC_PROGRESS_STAGES.map(([stage], index) => [stage, index + 1])
 );
@@ -155,6 +242,112 @@ function createSyncProgressReporter() {
 
     console.log(`[${stageIndex}/${SYNC_PROGRESS_STAGES.length}] ${SYNC_PROGRESS_STAGES[stageIndex - 1][1]}`);
   };
+}
+
+function createProgressReporter(stages) {
+  const stageIndexMap = new Map(stages.map(([stage], index) => [stage, index + 1]));
+  return (event) => {
+    const stageIndex = stageIndexMap.get(event?.stage);
+    if (!stageIndex) {
+      return;
+    }
+    if (event.status === "start") {
+      console.log(`[${stageIndex}/${stages.length}] ${stages[stageIndex - 1][1]}`);
+      return;
+    }
+    if (event?.stage === "create_backup" && event.status === "complete") {
+      console.log(`     Backup created in ${formatDuration(event.durationMs)}: ${event.backupDir}`);
+    }
+  };
+}
+
+function formatConflictSide(side) {
+  const rollout = side?.rollout;
+  const sqlite = side?.sqlite;
+  const lines = [];
+  if (rollout) {
+    lines.push(`  rollout: ${rollout.scope}, provider ${rollout.provider}, ${rollout.size} B`);
+    lines.push(`  path: ${rollout.relativePath}`);
+    if (rollout.cwd) {
+      lines.push(`  cwd: ${rollout.cwd}`);
+    }
+    if (rollout.timestamp) {
+      lines.push(`  timestamp: ${rollout.timestamp}`);
+    }
+  } else {
+    lines.push("  rollout: (none)");
+  }
+  if (sqlite) {
+    lines.push(`  sqlite: ${sqlite.scope}, provider ${sqlite.provider}, ${sqlite.columns} column(s)`);
+    if (sqlite.firstUserMessage) {
+      const preview = String(sqlite.firstUserMessage).replace(/\s+/g, " ").slice(0, 120);
+      lines.push(`  first user: ${preview}${String(sqlite.firstUserMessage).length > 120 ? "..." : ""}`);
+    }
+    if (sqlite.cwd && (!rollout || sqlite.cwd !== rollout.cwd)) {
+      lines.push(`  sqlite cwd: ${sqlite.cwd}`);
+    }
+    if (sqlite.timestamp) {
+      lines.push(`  sqlite timestamp: ${sqlite.timestamp}`);
+    }
+  } else {
+    lines.push("  sqlite: (none)");
+  }
+  return lines.join("\n");
+}
+
+function askQuestion(rl, prompt) {
+  return new Promise((resolve) => {
+    rl.question(prompt, resolve);
+  });
+}
+
+function createConflictResolver() {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return null;
+  }
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+  let closed = false;
+  async function close() {
+    if (!closed) {
+      closed = true;
+      rl.close();
+    }
+  }
+  const resolver = async (conflict) => {
+    console.log("");
+    console.log(`Conflict: ${conflict.threadId ?? conflict.key}`);
+    console.log("Local:");
+    console.log(formatConflictSide(conflict.local));
+    console.log("Imported:");
+    console.log(formatConflictSide(conflict.imported));
+    while (true) {
+      const answer = (await askQuestion(
+        rl,
+        "Choose [l] keep local, [i] use imported, [la] keep local for all, [ia] use imported for all, [a] abort: "
+      )).trim().toLowerCase();
+      if (answer === "l") {
+        return "skip";
+      }
+      if (answer === "i") {
+        return "overwrite";
+      }
+      if (answer === "la") {
+        return "skipAll";
+      }
+      if (answer === "ia") {
+        return "overwriteAll";
+      }
+      if (answer === "a" || answer === "q") {
+        return "abort";
+      }
+      console.log("Please enter l, i, la, ia, or a.");
+    }
+  };
+  resolver.close = close;
+  return resolver;
 }
 
 function parseKeepCount(rawValue, { allowZero = false } = {}) {
@@ -212,6 +405,43 @@ async function main() {
       onProgress: createSyncProgressReporter()
     });
     console.log(summarizeSync(result, "Switched to"));
+    return;
+  }
+
+  if (command === "export") {
+    const { runExportHistory } = await loadService();
+    const archivePath = positionals[1] ?? flags.output;
+    const result = await runExportHistory({
+      codexHome: flags["codex-home"],
+      archivePath,
+      overwrite: Boolean(flags.overwrite),
+      onProgress: createProgressReporter(EXPORT_PROGRESS_STAGES)
+    });
+    console.log(summarizeExport(result));
+    return;
+  }
+
+  if (command === "import") {
+    const { runImportHistory } = await loadService();
+    const archivePath = positionals[1] ?? flags.archive;
+    const conflictResolver = flags.conflict === undefined || flags.conflict === "ask"
+      ? createConflictResolver()
+      : null;
+    try {
+      const result = await runImportHistory({
+        codexHome: flags["codex-home"],
+        archivePath,
+        provider: flags.provider,
+        conflict: flags.conflict ?? "ask",
+        dryRun: Boolean(flags["dry-run"]),
+        keepCount: parseKeepCount(flags.keep),
+        onConflict: conflictResolver ?? undefined,
+        onProgress: createProgressReporter(IMPORT_PROGRESS_STAGES)
+      });
+      console.log(summarizeImport(result));
+    } finally {
+      await conflictResolver?.close?.();
+    }
     return;
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,7 +19,7 @@ Usage:
   codex-provider status [--codex-home PATH]
   codex-provider sync [--provider ID] [--keep N] [--codex-home PATH]
   codex-provider switch <provider-id> [--keep N] [--codex-home PATH]
-  codex-provider export [archive-path] [--overwrite] [--codex-home PATH]
+  codex-provider export [archive-path] [--select] [--ids ID[,ID...]] [--overwrite] [--codex-home PATH]
   codex-provider import <archive-path> [--provider ID] [--conflict ask|skip|overwrite|fail] [--dry-run] [--keep N] [--codex-home PATH]
   codex-provider prune-backups [--keep N] [--codex-home PATH]
   codex-provider restore <backup-dir> [--no-config] [--no-db] [--no-sessions] [--codex-home PATH]
@@ -109,6 +109,7 @@ function summarizeExport(result) {
     `Rollout files: ${result.rolloutFiles}`,
     `SQLite files: ${result.dbFiles}`,
     `Global state files: ${result.globalStateFiles}`,
+    `Selected export: ${result.selected ? "yes" : "no"}`,
     `Archive size: ${formatBytes(result.bytes)}`
   ].join("\n");
 }
@@ -301,6 +302,429 @@ function askQuestion(rl, prompt) {
   });
 }
 
+function stripControlCharacters(value) {
+  return String(value ?? "").replace(/[\u0000-\u001f\u007f]/g, " ");
+}
+
+function stripAnsi(value) {
+  return String(value ?? "").replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "");
+}
+
+function isCombiningCodePoint(codePoint) {
+  return (codePoint >= 0x0300 && codePoint <= 0x036f)
+    || (codePoint >= 0x1ab0 && codePoint <= 0x1aff)
+    || (codePoint >= 0x1dc0 && codePoint <= 0x1dff)
+    || (codePoint >= 0x20d0 && codePoint <= 0x20ff)
+    || (codePoint >= 0xfe20 && codePoint <= 0xfe2f);
+}
+
+function isWideCodePoint(codePoint) {
+  return (codePoint >= 0x1100 && (
+    codePoint <= 0x115f
+    || codePoint === 0x2329
+    || codePoint === 0x232a
+    || (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f)
+    || (codePoint >= 0xac00 && codePoint <= 0xd7a3)
+    || (codePoint >= 0xf900 && codePoint <= 0xfaff)
+    || (codePoint >= 0xfe10 && codePoint <= 0xfe19)
+    || (codePoint >= 0xfe30 && codePoint <= 0xfe6f)
+    || (codePoint >= 0xff00 && codePoint <= 0xff60)
+    || (codePoint >= 0xffe0 && codePoint <= 0xffe6)
+    || (codePoint >= 0x1f300 && codePoint <= 0x1faff)
+    || (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+  ));
+}
+
+function stringDisplayWidth(value) {
+  let width = 0;
+  for (const char of Array.from(stripAnsi(value))) {
+    const codePoint = char.codePointAt(0);
+    if (!codePoint || isCombiningCodePoint(codePoint)) {
+      continue;
+    }
+    width += isWideCodePoint(codePoint) ? 2 : 1;
+  }
+  return width;
+}
+
+function truncateText(value, maxLength) {
+  const normalized = stripControlCharacters(value).replace(/\s+/g, " ").trim();
+  if (maxLength <= 0) {
+    return "";
+  }
+  if (stringDisplayWidth(normalized) <= maxLength) {
+    return normalized;
+  }
+  if (maxLength <= 3) {
+    let shortText = "";
+    let width = 0;
+    for (const char of Array.from(normalized)) {
+      const nextWidth = stringDisplayWidth(char);
+      if (width + nextWidth > maxLength) {
+        break;
+      }
+      shortText += char;
+      width += nextWidth;
+    }
+    return shortText;
+  }
+  let text = "";
+  let width = 0;
+  const targetWidth = maxLength - 3;
+  for (const char of Array.from(normalized)) {
+    const nextWidth = stringDisplayWidth(char);
+    if (width + nextWidth > targetWidth) {
+      break;
+    }
+    text += char;
+    width += nextWidth;
+  }
+  return `${text}...`;
+}
+
+function visibleLength(value) {
+  return stringDisplayWidth(value);
+}
+
+function padVisible(value, width) {
+  const text = String(value ?? "");
+  const length = visibleLength(text);
+  if (length >= width) {
+    return text;
+  }
+  return `${text}${" ".repeat(width - length)}`;
+}
+
+const THEME = {
+  reset: "\x1b[0m",
+  dim: "\x1b[90m",
+  text: "\x1b[37m",
+  muted: "\x1b[38;5;245m",
+  panel: "\x1b[48;5;236m",
+  panelAlt: "\x1b[48;5;237m",
+  active: "\x1b[48;5;240m",
+  accent: "\x1b[38;5;171m",
+  selected: "\x1b[38;5;120m",
+  warning: "\x1b[38;5;214m",
+  header: "\x1b[38;5;250m",
+  rule: "\x1b[38;5;242m"
+};
+
+function searchableExportText(entry) {
+  return [
+    entry.threadId,
+    entry.scope,
+    entry.provider,
+    entry.cwd,
+    entry.timestamp,
+    entry.firstUserMessage,
+    entry.relativePath
+  ].filter(Boolean).join("\n").toLowerCase();
+}
+
+function filterExportPreviewEntries(conversations, query) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return conversations;
+  }
+  return conversations.filter((entry) => searchableExportText(entry).includes(normalizedQuery));
+}
+
+function buildExportBrowserLayout() {
+  const width = Math.max(50, process.stdout.columns ?? 100);
+  const height = Math.max(12, process.stdout.rows ?? 30);
+  const headerRows = 4;
+  const footerRows = 3;
+  const bodyRows = Math.max(3, height - headerRows - footerRows);
+  const gutterWidth = 2;
+  const checkWidth = 3;
+  const indexWidth = width >= 72 ? 4 : 0;
+  const scopeWidth = width >= 66 ? 5 : 0;
+  const providerWidth = width >= 78 ? 13 : (width >= 62 ? 9 : 0);
+  const timeWidth = width >= 86 ? 20 : (width >= 70 ? 12 : 0);
+  const nonTitleWidths = [
+    gutterWidth,
+    checkWidth,
+    indexWidth,
+    scopeWidth,
+    providerWidth,
+    timeWidth
+  ].filter((columnWidth) => columnWidth > 0);
+  const separatorWidth = nonTitleWidths.length;
+  const fixedWidth = nonTitleWidths.reduce((total, columnWidth) => total + columnWidth, 0) + separatorWidth;
+  const titleWidth = Math.max(8, width - fixedWidth);
+  return {
+    width,
+    height,
+    headerRows,
+    footerRows,
+    bodyRows,
+    gutterWidth,
+    checkWidth,
+    indexWidth,
+    scopeWidth,
+    providerWidth,
+    timeWidth,
+    titleWidth
+  };
+}
+
+function formatCell(value, width) {
+  return width > 0 ? padVisible(truncateText(value, width), width) : "";
+}
+
+function joinRowCells(cells) {
+  return cells.filter((cell) => cell !== "").join(" ");
+}
+
+function colorRow(line, { active, selected, odd }) {
+  const background = active ? THEME.active : (odd ? THEME.panelAlt : THEME.panel);
+  const foreground = active
+    ? THEME.text
+    : (selected ? THEME.selected : THEME.muted);
+  return `${background}${foreground}${line}${THEME.reset}`;
+}
+
+function formatExportBrowserRow(entry, { selected, active, odd, layout }) {
+  const marker = selected ? "●" : "○";
+  const pointer = active ? "›" : " ";
+  const ageOrTime = entry.timestamp ? truncateText(entry.timestamp, layout.timeWidth) : "";
+  const title = entry.firstUserMessage || entry.threadId || entry.relativePath;
+  const plainLine = joinRowCells([
+    padVisible(pointer, layout.gutterWidth),
+    padVisible(marker, layout.checkWidth),
+    layout.indexWidth ? formatCell(String(entry.index), layout.indexWidth) : "",
+    layout.scopeWidth ? formatCell(entry.scope === "archived_sessions" ? "arch" : "live", layout.scopeWidth) : "",
+    layout.providerWidth ? formatCell(entry.provider, layout.providerWidth) : "",
+    layout.timeWidth ? formatCell(ageOrTime, layout.timeWidth) : "",
+    formatCell(title, layout.titleWidth)
+  ]);
+  return colorRow(padVisible(plainLine, layout.width), { active, selected, odd });
+}
+
+function formatExportBrowserHeader(layout) {
+  const line = joinRowCells([
+    "".padEnd(layout.gutterWidth, " "),
+    "".padEnd(layout.checkWidth, " "),
+    layout.indexWidth ? formatCell("#", layout.indexWidth) : "",
+    layout.scopeWidth ? formatCell("Box", layout.scopeWidth) : "",
+    layout.providerWidth ? formatCell("Provider", layout.providerWidth) : "",
+    layout.timeWidth ? formatCell("Updated", layout.timeWidth) : "",
+    formatCell("Conversation", layout.titleWidth)
+  ]);
+  return `${THEME.header}${padVisible(line, layout.width)}${THEME.reset}`;
+}
+
+function formatRule(width) {
+  return `${THEME.rule}${"─".repeat(width)}${THEME.reset}`;
+}
+
+function renderExportBrowser({
+  preview,
+  filtered,
+  selectedKeys,
+  cursor,
+  scroll,
+  query,
+  message
+}) {
+  const layout = buildExportBrowserLayout();
+  const visible = filtered.slice(scroll, scroll + layout.bodyRows);
+  const page = filtered.length === 0 ? 0 : Math.floor(scroll / layout.bodyRows) + 1;
+  const pageCount = filtered.length === 0 ? 0 : Math.ceil(filtered.length / layout.bodyRows);
+  const queryText = query ? `${THEME.accent}${truncateText(query, Math.max(1, layout.width - 18))}${THEME.reset}` : `${THEME.dim}(empty)${THEME.reset}`;
+  const countText = `${THEME.muted}Filtered ${filtered.length}/${preview.conversations.length}  Selected ${selectedKeys.size}  Page ${page}/${pageCount}${THEME.reset}`;
+  const topLine = `${THEME.header}Type to search:${THEME.reset} ${queryText}`;
+  const lines = [
+    padVisible(topLine, layout.width),
+    padVisible(countText, layout.width),
+    formatExportBrowserHeader(layout),
+    formatRule(layout.width)
+  ];
+
+  for (let offset = 0; offset < layout.bodyRows; offset += 1) {
+    const entry = visible[offset];
+    if (!entry) {
+      const blank = " ".repeat(layout.width);
+      lines.push(`${offset % 2 ? THEME.panelAlt : THEME.panel}${blank}${THEME.reset}`);
+      continue;
+    }
+    const active = scroll + offset === cursor;
+    lines.push(formatExportBrowserRow(entry, {
+      selected: selectedKeys.has(entry.key),
+      active,
+      odd: offset % 2 === 1,
+      layout
+    }));
+  }
+
+  const footer = "↑/↓ browse  ←/→ PgUp/PgDn page  Space select  Ctrl+A all  Ctrl+N none  Enter export  Esc exit";
+  lines.push(formatRule(layout.width));
+  lines.push(`${message ? THEME.warning : THEME.dim}${padVisible(truncateText(message || footer, layout.width), layout.width)}${THEME.reset}`);
+  lines.push(`${THEME.dim}${padVisible(truncateText(preview.codexHome, layout.width), layout.width)}${THEME.reset}`);
+  return `\x1b[?25l\x1b[H${lines.slice(0, layout.height).join("\n")}`;
+}
+
+async function chooseExportSelection(preview) {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error("Interactive export selection requires a terminal. Use --ids <thread-id[,thread-id]> for non-interactive exports.");
+  }
+  if (preview.conversations.length === 0) {
+    throw new Error("No exportable Codex conversations found.");
+  }
+
+  readline.emitKeypressEvents(process.stdin);
+  const previousRawMode = process.stdin.isRaw;
+  const selectedKeys = new Set();
+  let query = "";
+  let cursor = 0;
+  let scroll = 0;
+  let message = "";
+
+  function filteredEntries() {
+    return filterExportPreviewEntries(preview.conversations, query);
+  }
+
+  function bodyHeight() {
+    return buildExportBrowserLayout().bodyRows;
+  }
+
+  function clampView(filtered) {
+    if (filtered.length === 0) {
+      cursor = 0;
+      scroll = 0;
+      return;
+    }
+    cursor = Math.max(0, Math.min(cursor, filtered.length - 1));
+    const pageSize = bodyHeight();
+    if (cursor < scroll) {
+      scroll = cursor;
+    } else if (cursor >= scroll + pageSize) {
+      scroll = cursor - pageSize + 1;
+    }
+    scroll = Math.max(0, Math.min(scroll, Math.max(0, filtered.length - pageSize)));
+  }
+
+  function render() {
+    const filtered = filteredEntries();
+    clampView(filtered);
+    process.stdout.write(renderExportBrowser({
+      preview,
+      filtered,
+      selectedKeys,
+      cursor,
+      scroll,
+      query,
+      message
+    }));
+    message = "";
+  }
+
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdout.write("\x1b[?1049h\x1b[?25l\x1b[2J\x1b[H");
+  render();
+
+  return await new Promise((resolve, reject) => {
+    let finished = false;
+    function finish(error, value) {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      process.stdin.off("keypress", onKeyPress);
+      process.stdout.off("resize", render);
+      process.stdin.setRawMode(Boolean(previousRawMode));
+      process.stdout.write("\x1b[?25h\x1b[?1049l");
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(value);
+    }
+
+    function move(delta) {
+      const filtered = filteredEntries();
+      if (filtered.length === 0) {
+        return;
+      }
+      cursor = Math.max(0, Math.min(cursor + delta, filtered.length - 1));
+    }
+
+    function page(delta) {
+      move(delta * bodyHeight());
+    }
+
+    function onKeyPress(str, key = {}) {
+      if (key.ctrl && key.name === "c") {
+        finish(new Error("History export aborted by user."));
+        return;
+      }
+      if (key.name === "escape") {
+        finish(new Error("History export aborted by user."));
+        return;
+      }
+      if (key.ctrl && key.name === "a") {
+        for (const entry of filteredEntries()) {
+          selectedKeys.add(entry.key);
+        }
+        render();
+        return;
+      }
+      if (key.ctrl && key.name === "n") {
+        selectedKeys.clear();
+        render();
+        return;
+      }
+      if (key.name === "return" || key.name === "enter") {
+        if (selectedKeys.size === 0) {
+          message = "Select at least one conversation before exporting.";
+          render();
+          return;
+        }
+        finish(null, preview.conversations
+          .filter((entry) => selectedKeys.has(entry.key))
+          .map((entry) => entry.key));
+        return;
+      }
+      if (key.name === "up") {
+        move(-1);
+      } else if (key.name === "down") {
+        move(1);
+      } else if (key.name === "left" || key.name === "pageup") {
+        page(-1);
+      } else if (key.name === "right" || key.name === "pagedown") {
+        page(1);
+      } else if (key.name === "home") {
+        cursor = 0;
+      } else if (key.name === "end") {
+        cursor = Math.max(0, filteredEntries().length - 1);
+      } else if (key.name === "space") {
+        const entry = filteredEntries()[cursor];
+        if (entry) {
+          if (selectedKeys.has(entry.key)) {
+            selectedKeys.delete(entry.key);
+          } else {
+            selectedKeys.add(entry.key);
+          }
+        }
+      } else if (key.name === "backspace") {
+        query = query.slice(0, -1);
+        cursor = 0;
+        scroll = 0;
+      } else if (!key.ctrl && !key.meta && str && str >= " " && str !== "\u007f") {
+        query += str;
+        cursor = 0;
+        scroll = 0;
+      }
+      render();
+    }
+
+    process.stdin.on("keypress", onKeyPress);
+    process.stdout.on("resize", render);
+  });
+}
+
 function createConflictResolver() {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     return null;
@@ -409,11 +833,19 @@ async function main() {
   }
 
   if (command === "export") {
-    const { runExportHistory } = await loadService();
+    const { getExportHistoryPreview, parseExportThreadIds, runExportHistory } = await loadService();
     const archivePath = positionals[1] ?? flags.output;
+    if (flags.select && flags.ids) {
+      throw new Error("Use either --select or --ids, not both.");
+    }
+    const selectionKeys = flags.select
+      ? await chooseExportSelection(await getExportHistoryPreview({ codexHome: flags["codex-home"] }))
+      : null;
     const result = await runExportHistory({
       codexHome: flags["codex-home"],
       archivePath,
+      selectionKeys,
+      threadIds: parseExportThreadIds(flags.ids),
       overwrite: Boolean(flags.overwrite),
       onProgress: createProgressReporter(EXPORT_PROGRESS_STAGES)
     });

--- a/src/history-transfer.js
+++ b/src/history-transfer.js
@@ -1,6 +1,8 @@
+import { createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
+import readline from "node:readline";
 
 import * as tar from "tar";
 
@@ -20,6 +22,7 @@ import {
 
 const HISTORY_NAMESPACE = "provider-sync-history";
 const HISTORY_VERSION = 1;
+const DEFAULT_TRANSCRIPT_MESSAGE_LIMIT = 200;
 
 function toArchivePath(value) {
   return value.split(path.sep).join("/");
@@ -131,6 +134,129 @@ function parseSessionMeta(firstLine) {
     return parsed.payload;
   } catch {
     return null;
+  }
+}
+
+function textFromContent(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map(textFromContent)
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+  }
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+  for (const key of ["text", "input_text", "output_text", "message", "content"]) {
+    const text = textFromContent(value[key]);
+    if (text) {
+      return text;
+    }
+  }
+  return "";
+}
+
+function normalizeTranscriptRole(role) {
+  if (role === "assistant" || role === "user" || role === "system") {
+    return role;
+  }
+  return null;
+}
+
+function messageFromRecord(record) {
+  if (!record || typeof record !== "object") {
+    return null;
+  }
+
+  const payload = record.payload;
+  if (record.type === "event_msg" && payload && typeof payload === "object") {
+    if (payload.type === "user_message") {
+      const text = textFromContent(payload.message ?? payload.content ?? payload.text);
+      return text ? { role: "user", text } : null;
+    }
+    if (payload.type === "assistant_message" || payload.type === "agent_message") {
+      const text = textFromContent(payload.message ?? payload.content ?? payload.text);
+      return text ? { role: "assistant", text } : null;
+    }
+  }
+
+  for (const value of [record.payload, record.item, record.msg, record]) {
+    if (!value || typeof value !== "object") {
+      continue;
+    }
+    const role = normalizeTranscriptRole(value.role);
+    if (value.type === "message" && role) {
+      const text = textFromContent(value.content ?? value.message ?? value.text);
+      if (text) {
+        return { role, text };
+      }
+    }
+  }
+  return null;
+}
+
+async function scanRolloutMessages(filePath, {
+  firstUserOnly = false,
+  limit = DEFAULT_TRANSCRIPT_MESSAGE_LIMIT
+} = {}) {
+  const messages = [];
+  let truncated = false;
+  const stream = createReadStream(filePath, {
+    encoding: "utf8",
+    highWaterMark: 1024 * 1024
+  });
+  const lines = readline.createInterface({
+    input: stream,
+    crlfDelay: Infinity
+  });
+
+  try {
+    for await (const line of lines) {
+      if (!line) {
+        continue;
+      }
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const message = messageFromRecord(record);
+      if (!message) {
+        continue;
+      }
+      if (firstUserOnly) {
+        if (message.role === "user") {
+          return { messages: [message], truncated: false };
+        }
+        continue;
+      }
+      if (messages.length >= limit) {
+        truncated = true;
+        break;
+      }
+      messages.push({
+        ...message,
+        timestamp: typeof record.timestamp === "string" ? record.timestamp : null
+      });
+    }
+    return { messages, truncated };
+  } finally {
+    lines.close();
+    stream.destroy();
+  }
+}
+
+async function readRolloutFirstUserMessage(filePath) {
+  try {
+    const { messages } = await scanRolloutMessages(filePath, { firstUserOnly: true, limit: 1 });
+    return messages[0]?.text ?? "";
+  } catch {
+    return "";
   }
 }
 
@@ -256,6 +382,7 @@ export async function collectRolloutInventory(codexHome) {
         relativePath,
         scope,
         threadId: typeof meta?.id === "string" && meta.id ? meta.id : null,
+        title: typeof meta?.title === "string" && meta.title ? meta.title : null,
         provider: typeof meta?.model_provider === "string" ? meta.model_provider : null,
         cwd: typeof meta?.cwd === "string" ? meta.cwd : null,
         timestamp: typeof meta?.timestamp === "string" ? meta.timestamp : null,
@@ -344,24 +471,50 @@ export async function buildExportPreview(codexHome) {
     String(right.timestamp ?? "").localeCompare(String(left.timestamp ?? ""))
     || left.relativePath.localeCompare(right.relativePath)
   ));
-  return sortedRollouts.map((rollout, index) => {
+  const conversations = [];
+  for (let index = 0; index < sortedRollouts.length; index += 1) {
+    const rollout = sortedRollouts[index];
     const sqlite = rollout.threadId ? rowsById.get(rollout.threadId) : null;
-    return {
+    const sqliteFirstUserMessage = sqlite?.first_user_message ?? "";
+    const firstUserMessage = sqliteFirstUserMessage
+      || await readRolloutFirstUserMessage(resolveArchivePath(codexHome, rollout.relativePath));
+    conversations.push({
       index: index + 1,
       key: buildExportKey(rollout),
       threadId: rollout.threadId,
       scope: rollout.scope,
+      title: sqlite?.title ?? rollout.title ?? "",
       provider: rollout.provider ?? sqlite?.model_provider ?? "(missing)",
       cwd: rollout.cwd ?? sqlite?.cwd ?? "",
       timestamp: rollout.timestamp
         ?? sqlite?.updated_at_ms
         ?? sqlite?.created_at_ms
         ?? "",
-      firstUserMessage: sqlite?.first_user_message ?? "",
+      firstUserMessage,
       relativePath: rollout.relativePath,
       size: rollout.size
-    };
-  });
+    });
+  }
+  return conversations;
+}
+
+export async function readExportTranscript(codexHome, entry, { limit = DEFAULT_TRANSCRIPT_MESSAGE_LIMIT } = {}) {
+  if (!entry?.relativePath) {
+    throw new Error("Cannot read transcript because the selected conversation is missing rollout metadata.");
+  }
+  const filePath = resolveArchivePath(codexHome, entry.relativePath);
+  const { messages, truncated } = await scanRolloutMessages(filePath, { limit });
+  return {
+    threadId: entry.threadId ?? null,
+    title: entry.title ?? "",
+    relativePath: entry.relativePath,
+    scope: entry.scope,
+    provider: entry.provider ?? "",
+    cwd: entry.cwd ?? "",
+    timestamp: entry.timestamp ?? "",
+    messages,
+    truncated
+  };
 }
 
 export async function toggleExportConversationArchived(codexHome, entry) {

--- a/src/history-transfer.js
+++ b/src/history-transfer.js
@@ -14,7 +14,8 @@ import { openDatabase } from "./sqlite.js";
 import {
   detectStateDb,
   existingStateDbPath,
-  stateDbPath
+  wrapSqliteBusyError,
+  wrapSqliteMalformedError
 } from "./sqlite-state.js";
 
 const HISTORY_NAMESPACE = "provider-sync-history";
@@ -178,6 +179,67 @@ function selectedThreadIdsFromRollouts(rollouts) {
     .filter((threadId) => typeof threadId === "string" && threadId);
 }
 
+function oppositeSessionScope(scope) {
+  if (scope === "sessions") {
+    return "archived_sessions";
+  }
+  if (scope === "archived_sessions") {
+    return "sessions";
+  }
+  throw new Error(`Cannot toggle archive state for unsupported scope: ${scope}`);
+}
+
+function replaceRelativePathScope(relativePath, nextScope) {
+  const normalized = validateRelativePath(relativePath);
+  const parts = normalized.split("/");
+  if (!SESSION_DIRS.includes(parts[0])) {
+    throw new Error(`Cannot toggle archive state for rollout outside sessions directories: ${relativePath}`);
+  }
+  parts[0] = nextScope;
+  return parts.join("/");
+}
+
+async function updateThreadArchivedFlag(codexHome, threadId, archived) {
+  if (!threadId) {
+    return 0;
+  }
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
+    return 0;
+  }
+
+  let db;
+  let transactionOpen = false;
+  try {
+    db = await openDatabase(dbPath);
+    if (!tableExists(db, "threads") || !tableColumns(db, "threads").includes("archived")) {
+      return 0;
+    }
+    db.exec("BEGIN IMMEDIATE");
+    transactionOpen = true;
+    const result = db
+      .prepare("UPDATE threads SET archived = ? WHERE id = ?")
+      .run(archived ? 1 : 0, threadId);
+    db.exec("COMMIT");
+    transactionOpen = false;
+    return result.changes ?? 0;
+  } catch (error) {
+    if (transactionOpen) {
+      try {
+        db?.exec("ROLLBACK");
+      } catch {
+        // Ignore rollback failures and surface the original SQLite error.
+      }
+    }
+    throw wrapSqliteMalformedError(
+      wrapSqliteBusyError(error, "toggle archived session state"),
+      "toggle archived session state"
+    );
+  } finally {
+    db?.close();
+  }
+}
+
 export async function collectRolloutInventory(codexHome) {
   const rollouts = [];
   for (const scope of SESSION_DIRS) {
@@ -300,6 +362,51 @@ export async function buildExportPreview(codexHome) {
       size: rollout.size
     };
   });
+}
+
+export async function toggleExportConversationArchived(codexHome, entry) {
+  if (!entry?.relativePath || !entry.scope) {
+    throw new Error("Cannot toggle archive state because the selected conversation is missing rollout metadata.");
+  }
+
+  const nextScope = oppositeSessionScope(entry.scope);
+  const nextRelativePath = replaceRelativePathScope(entry.relativePath, nextScope);
+  const sourcePath = resolveArchivePath(codexHome, entry.relativePath);
+  const destinationPath = resolveArchivePath(codexHome, nextRelativePath);
+
+  if (await pathExists(destinationPath)) {
+    throw new Error(`Cannot toggle archive state because target rollout already exists: ${nextRelativePath}`);
+  }
+
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+  await fs.rename(sourcePath, destinationPath);
+  let sqliteRowsUpdated = 0;
+  try {
+    sqliteRowsUpdated = await updateThreadArchivedFlag(codexHome, entry.threadId, nextScope === "archived_sessions");
+  } catch (error) {
+    try {
+      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+      await fs.rename(destinationPath, sourcePath);
+    } catch (rollbackError) {
+      const originalMessage = error instanceof Error ? error.message : String(error);
+      const rollbackMessage = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+      throw new Error(
+        `Failed to restore rollout after archive toggle error. Original error: ${originalMessage}. Restore error: ${rollbackMessage}`
+      );
+    }
+    throw error;
+  }
+
+  const stat = await fs.stat(destinationPath);
+  return {
+    ...entry,
+    scope: nextScope,
+    relativePath: nextRelativePath,
+    key: entry.threadId ? `thread:${entry.threadId}` : `path:${nextRelativePath}`,
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+    sqliteRowsUpdated
+  };
 }
 
 export async function createHistoryArchive({

--- a/src/history-transfer.js
+++ b/src/history-transfer.js
@@ -1,0 +1,725 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import * as tar from "tar";
+
+import {
+  DB_FILE_BASENAME,
+  GLOBAL_STATE_BACKUP_FILE_BASENAME,
+  GLOBAL_STATE_FILE_BASENAME,
+  SESSION_DIRS
+} from "./constants.js";
+import { openDatabase } from "./sqlite.js";
+import {
+  detectStateDb,
+  existingStateDbPath,
+  stateDbPath
+} from "./sqlite-state.js";
+
+const HISTORY_NAMESPACE = "provider-sync-history";
+const HISTORY_VERSION = 1;
+
+function toArchivePath(value) {
+  return value.split(path.sep).join("/");
+}
+
+function validateRelativePath(relativePath) {
+  if (typeof relativePath !== "string" || !relativePath.trim()) {
+    throw new Error("Invalid empty path in history archive.");
+  }
+  const normalized = relativePath.replaceAll("\\", "/");
+  if (
+    normalized.startsWith("/")
+    || normalized.split("/").includes("..")
+    || path.isAbsolute(normalized)
+  ) {
+    throw new Error(`Invalid unsafe path in history archive: ${relativePath}`);
+  }
+  return normalized;
+}
+
+function resolveArchivePath(rootDir, relativePath) {
+  const normalized = validateRelativePath(relativePath);
+  return path.join(rootDir, ...normalized.split("/"));
+}
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function copyIfPresent(sourcePath, destinationPath) {
+  if (!await pathExists(sourcePath)) {
+    return false;
+  }
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+  await fs.copyFile(sourcePath, destinationPath);
+  return true;
+}
+
+async function listFilesRecursive(rootDir, predicate) {
+  let entries;
+  try {
+    entries = await fs.readdir(rootDir, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listFilesRecursive(fullPath, predicate));
+      continue;
+    }
+    if (entry.isFile() && predicate(fullPath, entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function listStagedFiles(rootDir) {
+  const files = await listFilesRecursive(rootDir, () => true);
+  return files.map((filePath) => toArchivePath(path.relative(rootDir, filePath)));
+}
+
+async function readFirstLine(filePath) {
+  const handle = await fs.open(filePath, "r");
+  try {
+    let position = 0;
+    let collected = Buffer.alloc(0);
+    while (true) {
+      const chunk = Buffer.alloc(64 * 1024);
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, position);
+      if (bytesRead === 0) {
+        break;
+      }
+      position += bytesRead;
+      collected = Buffer.concat([collected, chunk.subarray(0, bytesRead)]);
+      const newlineIndex = collected.indexOf(0x0a);
+      if (newlineIndex !== -1) {
+        const crlf = newlineIndex > 0 && collected[newlineIndex - 1] === 0x0d;
+        const lineBuffer = crlf ? collected.subarray(0, newlineIndex - 1) : collected.subarray(0, newlineIndex);
+        return lineBuffer.toString("utf8");
+      }
+    }
+    return collected.toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
+function parseSessionMeta(firstLine) {
+  if (!firstLine) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(firstLine);
+    if (parsed?.type !== "session_meta" || !parsed.payload || typeof parsed.payload !== "object") {
+      return null;
+    }
+    return parsed.payload;
+  } catch {
+    return null;
+  }
+}
+
+function summarizeRollout(entry) {
+  if (!entry) {
+    return null;
+  }
+  return {
+    threadId: entry.threadId ?? null,
+    scope: entry.scope,
+    provider: entry.provider ?? "(missing)",
+    cwd: entry.cwd ?? "",
+    timestamp: entry.timestamp ?? "",
+    relativePath: entry.relativePath,
+    size: entry.size ?? 0
+  };
+}
+
+function summarizeSqliteRow(row, sourceColumns = []) {
+  if (!row) {
+    return null;
+  }
+  const timestamp =
+    row.updated_at_ms ?? row.created_at_ms
+    ?? (row.updated_at !== undefined ? Number(row.updated_at) * 1000 : undefined)
+    ?? (row.created_at !== undefined ? Number(row.created_at) * 1000 : undefined)
+    ?? "";
+  return {
+    threadId: row.id,
+    scope: Number(row.archived) ? "archived_sessions" : "sessions",
+    provider: row.model_provider ?? "(missing)",
+    cwd: row.cwd ?? "",
+    firstUserMessage: row.first_user_message ?? "",
+    timestamp,
+    columns: sourceColumns.length
+  };
+}
+
+export async function collectRolloutInventory(codexHome) {
+  const rollouts = [];
+  for (const scope of SESSION_DIRS) {
+    const rootDir = path.join(codexHome, scope);
+    const rolloutPaths = await listFilesRecursive(
+      rootDir,
+      (_filePath, name) => name.startsWith("rollout-") && name.endsWith(".jsonl")
+    );
+    for (const rolloutPath of rolloutPaths) {
+      const stat = await fs.stat(rolloutPath);
+      const relativePath = toArchivePath(path.relative(codexHome, rolloutPath));
+      const meta = parseSessionMeta(await readFirstLine(rolloutPath));
+      rollouts.push({
+        relativePath,
+        scope,
+        threadId: typeof meta?.id === "string" && meta.id ? meta.id : null,
+        provider: typeof meta?.model_provider === "string" ? meta.model_provider : null,
+        cwd: typeof meta?.cwd === "string" ? meta.cwd : null,
+        timestamp: typeof meta?.timestamp === "string" ? meta.timestamp : null,
+        size: stat.size,
+        mtimeMs: stat.mtimeMs
+      });
+    }
+  }
+  return rollouts.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+async function copyRolloutsToStaging(codexHome, stagingDir, rollouts) {
+  for (const rollout of rollouts) {
+    await copyIfPresent(
+      resolveArchivePath(codexHome, rollout.relativePath),
+      resolveArchivePath(stagingDir, rollout.relativePath)
+    );
+  }
+}
+
+async function copyGlobalStateToStaging(codexHome, stagingDir) {
+  const copied = [];
+  for (const fileName of [GLOBAL_STATE_FILE_BASENAME, GLOBAL_STATE_BACKUP_FILE_BASENAME]) {
+    if (await copyIfPresent(path.join(codexHome, fileName), path.join(stagingDir, fileName))) {
+      copied.push(fileName);
+    }
+  }
+  return copied;
+}
+
+async function copyStateDbToStaging(codexHome, stagingDir) {
+  const stateDb = await detectStateDb(codexHome);
+  if (!stateDb) {
+    return [];
+  }
+
+  const copied = [];
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const sourcePath = `${stateDb.path}${suffix}`;
+    const relativePath = toArchivePath(path.relative(codexHome, sourcePath));
+    if (await copyIfPresent(sourcePath, resolveArchivePath(stagingDir, path.join("db", relativePath)))) {
+      copied.push(relativePath);
+    }
+  }
+  return copied;
+}
+
+export async function createHistoryArchive({
+  codexHome,
+  archivePath,
+  overwrite = false
+}) {
+  const resolvedArchivePath = path.resolve(archivePath);
+  if (await pathExists(resolvedArchivePath)) {
+    if (!overwrite) {
+      throw new Error(`Archive already exists: ${resolvedArchivePath}. Use --overwrite to replace it.`);
+    }
+    await fs.rm(resolvedArchivePath, { force: true });
+  }
+
+  await fs.mkdir(path.dirname(resolvedArchivePath), { recursive: true });
+  const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-history-export-"));
+  try {
+    const rollouts = await collectRolloutInventory(codexHome);
+    await copyRolloutsToStaging(codexHome, stagingDir, rollouts);
+    const globalStateFiles = await copyGlobalStateToStaging(codexHome, stagingDir);
+    const dbFiles = await copyStateDbToStaging(codexHome, stagingDir);
+    const manifest = {
+      version: HISTORY_VERSION,
+      namespace: HISTORY_NAMESPACE,
+      createdAt: new Date().toISOString(),
+      codexHome,
+      rollouts,
+      dbFiles,
+      globalStateFiles
+    };
+    await fs.writeFile(
+      path.join(stagingDir, "manifest.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      "utf8"
+    );
+
+    const stagedFiles = await listStagedFiles(stagingDir);
+    await tar.create({
+      gzip: true,
+      file: resolvedArchivePath,
+      cwd: stagingDir,
+      portable: true
+    }, stagedFiles);
+
+    const stat = await fs.stat(resolvedArchivePath);
+    return {
+      archivePath: resolvedArchivePath,
+      rolloutFiles: rollouts.length,
+      dbFiles: dbFiles.length,
+      globalStateFiles: globalStateFiles.length,
+      bytes: stat.size
+    };
+  } finally {
+    await fs.rm(stagingDir, { recursive: true, force: true });
+  }
+}
+
+function validateManifest(manifest) {
+  if (manifest?.namespace !== HISTORY_NAMESPACE || manifest.version !== HISTORY_VERSION) {
+    throw new Error("Archive is not a supported codex-provider history export.");
+  }
+  if (!Array.isArray(manifest.rollouts) || !Array.isArray(manifest.dbFiles)) {
+    throw new Error("History archive manifest is malformed.");
+  }
+  for (const rollout of manifest.rollouts) {
+    rollout.relativePath = validateRelativePath(rollout.relativePath);
+    if (!SESSION_DIRS.includes(rollout.scope)) {
+      throw new Error(`Invalid rollout scope in history archive: ${rollout.scope}`);
+    }
+  }
+  manifest.dbFiles = manifest.dbFiles.map(validateRelativePath);
+  manifest.globalStateFiles = (manifest.globalStateFiles ?? []).map(validateRelativePath);
+  return manifest;
+}
+
+export async function extractHistoryArchive(archivePath) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-history-import-"));
+  try {
+    await tar.extract({
+      file: path.resolve(archivePath),
+      cwd: tempDir,
+      filter(entryPath) {
+        const normalized = entryPath.replaceAll("\\", "/");
+        return !normalized.startsWith("/") && !normalized.split("/").includes("..");
+      }
+    });
+    const manifest = validateManifest(JSON.parse(await fs.readFile(path.join(tempDir, "manifest.json"), "utf8")));
+    return {
+      tempDir,
+      manifest
+    };
+  } catch (error) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export async function cleanupExtractedHistory(extracted) {
+  if (extracted?.tempDir) {
+    await fs.rm(extracted.tempDir, { recursive: true, force: true });
+  }
+}
+
+function tableColumns(db, tableName) {
+  return db
+    .prepare(`PRAGMA table_info("${tableName.replaceAll("\"", "\"\"")}")`)
+    .all()
+    .map((column) => column.name);
+}
+
+function tableExists(db, tableName) {
+  return Boolean(db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName));
+}
+
+function readThreadRows(db) {
+  if (!tableExists(db, "threads")) {
+    return { columns: [], rows: [] };
+  }
+  const columns = tableColumns(db, "threads");
+  return {
+    columns,
+    rows: db.prepare("SELECT * FROM threads").all()
+  };
+}
+
+function exportedDbBaseFile(manifest) {
+  return manifest.dbFiles.find((fileName) => path.basename(fileName) === DB_FILE_BASENAME) ?? null;
+}
+
+function exportedDbPath(extracted) {
+  const relativePath = exportedDbBaseFile(extracted.manifest);
+  return relativePath ? resolveArchivePath(extracted.tempDir, path.join("db", relativePath)) : null;
+}
+
+async function readExportedThreads(extracted) {
+  const dbPath = exportedDbPath(extracted);
+  if (!dbPath || !await pathExists(dbPath)) {
+    return { columns: [], rows: [] };
+  }
+  let db;
+  try {
+    db = await openDatabase(dbPath, { readOnly: true });
+    return readThreadRows(db);
+  } finally {
+    db?.close();
+  }
+}
+
+async function readLocalThreads(codexHome) {
+  const dbPath = await existingStateDbPath(codexHome);
+  if (!dbPath) {
+    return { dbPath: null, columns: [], rows: [] };
+  }
+  let db;
+  try {
+    db = await openDatabase(dbPath, { readOnly: true });
+    return { dbPath, ...readThreadRows(db) };
+  } finally {
+    db?.close();
+  }
+}
+
+function mapByThreadId(entries) {
+  const mapped = new Map();
+  for (const entry of entries) {
+    if (entry.threadId && !mapped.has(entry.threadId)) {
+      mapped.set(entry.threadId, entry);
+    }
+  }
+  return mapped;
+}
+
+function mapRowsById(rows) {
+  const mapped = new Map();
+  for (const row of rows) {
+    if (typeof row.id === "string" && row.id) {
+      mapped.set(row.id, row);
+    }
+  }
+  return mapped;
+}
+
+function buildConflictKey(rollout) {
+  return rollout.threadId ? `thread:${rollout.threadId}` : `path:${rollout.relativePath}`;
+}
+
+function conflictThreadIdFromKey(key) {
+  return key.startsWith("thread:") ? key.slice("thread:".length) : null;
+}
+
+export async function buildImportPlan({ codexHome, extracted }) {
+  const importedRollouts = extracted.manifest.rollouts;
+  const localRollouts = await collectRolloutInventory(codexHome);
+  const localByThreadId = mapByThreadId(localRollouts);
+  const localByPath = new Map(localRollouts.map((entry) => [entry.relativePath, entry]));
+  const exportedThreads = await readExportedThreads(extracted);
+  const localThreads = await readLocalThreads(codexHome);
+  const exportedRowsById = mapRowsById(exportedThreads.rows);
+  const localRowsById = mapRowsById(localThreads.rows);
+  const conflicts = new Map();
+
+  for (const rollout of importedRollouts) {
+    const localRollout =
+      (rollout.threadId ? localByThreadId.get(rollout.threadId) : null)
+      ?? localByPath.get(rollout.relativePath);
+    if (!localRollout) {
+      continue;
+    }
+    const key = buildConflictKey(rollout);
+    conflicts.set(key, {
+      key,
+      threadId: rollout.threadId ?? null,
+      imported: {
+        rollout: summarizeRollout(rollout),
+        sqlite: summarizeSqliteRow(exportedRowsById.get(rollout.threadId), exportedThreads.columns)
+      },
+      local: {
+        rollout: summarizeRollout(localRollout),
+        sqlite: summarizeSqliteRow(localRowsById.get(rollout.threadId), localThreads.columns)
+      }
+    });
+  }
+
+  for (const row of exportedThreads.rows) {
+    if (typeof row.id !== "string" || !row.id || !localRowsById.has(row.id)) {
+      continue;
+    }
+    const key = `thread:${row.id}`;
+    if (conflicts.has(key)) {
+      continue;
+    }
+    conflicts.set(key, {
+      key,
+      threadId: row.id,
+      imported: {
+        rollout: summarizeRollout(importedRollouts.find((rollout) => rollout.threadId === row.id)),
+        sqlite: summarizeSqliteRow(row, exportedThreads.columns)
+      },
+      local: {
+        rollout: summarizeRollout(localByThreadId.get(row.id)),
+        sqlite: summarizeSqliteRow(localRowsById.get(row.id), localThreads.columns)
+      }
+    });
+  }
+
+  const conflictList = [...conflicts.values()].sort((left, right) => left.key.localeCompare(right.key));
+  return {
+    importedRollouts,
+    localRollouts,
+    exportedThreads,
+    localThreads,
+    conflicts: conflictList,
+    newRolloutFiles: importedRollouts.filter((rollout) => !conflicts.has(buildConflictKey(rollout))).length,
+    newSqliteRows: exportedThreads.rows.filter((row) => row.id && !localRowsById.has(row.id)).length
+  };
+}
+
+export async function resolveImportConflicts({ plan, conflict = "ask", onConflict }) {
+  const valid = new Set(["ask", "skip", "overwrite", "fail"]);
+  if (!valid.has(conflict)) {
+    throw new Error(`Invalid --conflict value: ${conflict}. Expected ask, skip, overwrite, or fail.`);
+  }
+  const decisions = new Map();
+  if (plan.conflicts.length === 0) {
+    return decisions;
+  }
+  if (conflict === "fail") {
+    throw new Error(`History import found ${plan.conflicts.length} conflict(s). Rerun with --conflict ask, skip, or overwrite.`);
+  }
+  if (conflict === "skip" || conflict === "overwrite") {
+    for (const item of plan.conflicts) {
+      decisions.set(item.key, conflict);
+    }
+    return decisions;
+  }
+  if (typeof onConflict !== "function") {
+    throw new Error(`History import found ${plan.conflicts.length} conflict(s), but no interactive conflict handler is available. Rerun with --conflict skip, overwrite, or fail.`);
+  }
+
+  let defaultDecision = null;
+  for (const item of plan.conflicts) {
+    const decision = defaultDecision ?? await onConflict(item);
+    if (decision === "abort") {
+      throw new Error("History import aborted by user.");
+    }
+    if (decision === "skipAll" || decision === "overwriteAll") {
+      defaultDecision = decision === "skipAll" ? "skip" : "overwrite";
+      decisions.set(item.key, defaultDecision);
+      continue;
+    }
+    if (decision !== "skip" && decision !== "overwrite") {
+      throw new Error(`Invalid conflict decision: ${decision}`);
+    }
+    decisions.set(item.key, decision);
+  }
+  return decisions;
+}
+
+function shouldSkipConflict(decisions, rollout) {
+  return decisions.get(buildConflictKey(rollout)) === "skip";
+}
+
+function shouldOverwriteConflict(decisions, rollout) {
+  return decisions.get(buildConflictKey(rollout)) === "overwrite";
+}
+
+export async function copyImportedRollouts({ codexHome, extracted, plan, decisions }) {
+  const localByThreadId = mapByThreadId(plan.localRollouts);
+  let copied = 0;
+  let skipped = 0;
+  let removedLocalConflicts = 0;
+  for (const rollout of plan.importedRollouts) {
+    if (shouldSkipConflict(decisions, rollout)) {
+      skipped += 1;
+      continue;
+    }
+
+    if (shouldOverwriteConflict(decisions, rollout) && rollout.threadId) {
+      const localRollout = localByThreadId.get(rollout.threadId);
+      if (localRollout && localRollout.relativePath !== rollout.relativePath) {
+        await fs.rm(resolveArchivePath(codexHome, localRollout.relativePath), { force: true });
+        removedLocalConflicts += 1;
+      }
+    }
+
+    const sourcePath = resolveArchivePath(extracted.tempDir, rollout.relativePath);
+    const destinationPath = resolveArchivePath(codexHome, rollout.relativePath);
+    await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+    await fs.copyFile(sourcePath, destinationPath);
+    if (Number.isFinite(rollout.mtimeMs)) {
+      const mtime = new Date(rollout.mtimeMs);
+      await fs.utimes(destinationPath, mtime, mtime);
+    }
+    copied += 1;
+  }
+  return { copied, skipped, removedLocalConflicts };
+}
+
+function quotedIdentifier(identifier) {
+  return `"${identifier.replaceAll("\"", "\"\"")}"`;
+}
+
+function updateRowProvider(row, targetProvider, columns) {
+  if (columns.includes("model_provider")) {
+    return {
+      ...row,
+      model_provider: targetProvider
+    };
+  }
+  return row;
+}
+
+function decisionForThreadId(decisions, threadId) {
+  return decisions.get(`thread:${threadId}`);
+}
+
+async function copyExportedDatabase({ codexHome, extracted }) {
+  const baseFile = exportedDbBaseFile(extracted.manifest);
+  if (!baseFile) {
+    return { copied: false, copiedFiles: 0 };
+  }
+  const destinationBase = path.join(codexHome, baseFile);
+  await fs.mkdir(path.dirname(destinationBase), { recursive: true });
+  let copiedFiles = 0;
+  for (const dbFile of extracted.manifest.dbFiles) {
+    const sourcePath = resolveArchivePath(extracted.tempDir, path.join("db", dbFile));
+    const destinationPath = resolveArchivePath(codexHome, dbFile);
+    if (await pathExists(sourcePath)) {
+      await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+      await fs.copyFile(sourcePath, destinationPath);
+      copiedFiles += 1;
+    }
+  }
+  return { copied: true, copiedFiles };
+}
+
+export async function mergeImportedSqliteThreads({ codexHome, extracted, plan, decisions, targetProvider }) {
+  const exportedDb = exportedDbPath(extracted);
+  if (!exportedDb || !await pathExists(exportedDb)) {
+    return {
+      databasePresent: false,
+      databaseCopied: false,
+      copiedDbFiles: 0,
+      insertedRows: 0,
+      updatedRows: 0,
+      skippedRows: 0
+    };
+  }
+
+  const destinationDb = await existingStateDbPath(codexHome);
+  if (!destinationDb) {
+    const copyResult = await copyExportedDatabase({ codexHome, extracted });
+    return {
+      databasePresent: true,
+      databaseCopied: copyResult.copied,
+      copiedDbFiles: copyResult.copiedFiles,
+      insertedRows: plan.exportedThreads.rows.length,
+      updatedRows: 0,
+      skippedRows: 0
+    };
+  }
+
+  const sourceRows = plan.exportedThreads.rows;
+  if (sourceRows.length === 0) {
+    return {
+      databasePresent: true,
+      databaseCopied: false,
+      copiedDbFiles: 0,
+      insertedRows: 0,
+      updatedRows: 0,
+      skippedRows: 0
+    };
+  }
+
+  let db;
+  try {
+    db = await openDatabase(destinationDb);
+    db.exec("BEGIN IMMEDIATE");
+    const destinationColumns = tableColumns(db, "threads");
+    const commonColumns = plan.exportedThreads.columns.filter((column) => destinationColumns.includes(column));
+    if (!commonColumns.includes("id")) {
+      throw new Error("Destination SQLite threads table does not have an id column.");
+    }
+
+    const existingStmt = db.prepare("SELECT id FROM threads WHERE id = ?");
+    const insertSql = `INSERT INTO threads (${commonColumns.map(quotedIdentifier).join(", ")}) VALUES (${commonColumns.map(() => "?").join(", ")})`;
+    const insertStmt = db.prepare(insertSql);
+    const updateColumns = commonColumns.filter((column) => column !== "id");
+    const updateStmt = updateColumns.length
+      ? db.prepare(`UPDATE threads SET ${updateColumns.map((column) => `${quotedIdentifier(column)} = ?`).join(", ")} WHERE id = ?`)
+      : null;
+
+    let insertedRows = 0;
+    let updatedRows = 0;
+    let skippedRows = 0;
+    for (const originalRow of sourceRows) {
+      const threadId = originalRow.id;
+      if (typeof threadId !== "string" || !threadId) {
+        skippedRows += 1;
+        continue;
+      }
+      const decision = decisionForThreadId(decisions, threadId);
+      const exists = Boolean(existingStmt.get(threadId));
+      if (exists && decision !== "overwrite") {
+        skippedRows += 1;
+        continue;
+      }
+
+      const row = updateRowProvider(originalRow, targetProvider, commonColumns);
+      if (exists) {
+        if (!updateStmt) {
+          skippedRows += 1;
+          continue;
+        }
+        updateStmt.run(...updateColumns.map((column) => row[column] ?? null), threadId);
+        updatedRows += 1;
+      } else {
+        insertStmt.run(...commonColumns.map((column) => row[column] ?? null));
+        insertedRows += 1;
+      }
+    }
+    db.exec("COMMIT");
+    return {
+      databasePresent: true,
+      databaseCopied: false,
+      copiedDbFiles: 0,
+      insertedRows,
+      updatedRows,
+      skippedRows
+    };
+  } catch (error) {
+    try {
+      db?.exec("ROLLBACK");
+    } catch {
+      // Ignore rollback failures and surface the original merge error.
+    }
+    throw error;
+  } finally {
+    db?.close();
+  }
+}
+
+export function summarizeImportPlan(plan) {
+  return {
+    archiveRolloutFiles: plan.importedRollouts.length,
+    archiveSqliteRows: plan.exportedThreads.rows.length,
+    newRolloutFiles: plan.newRolloutFiles,
+    newSqliteRows: plan.newSqliteRows,
+    conflicts: plan.conflicts.length
+  };
+}

--- a/src/history-transfer.js
+++ b/src/history-transfer.js
@@ -168,6 +168,16 @@ function summarizeSqliteRow(row, sourceColumns = []) {
   };
 }
 
+function buildExportKey(rollout) {
+  return rollout.threadId ? `thread:${rollout.threadId}` : `path:${rollout.relativePath}`;
+}
+
+function selectedThreadIdsFromRollouts(rollouts) {
+  return rollouts
+    .map((rollout) => rollout.threadId)
+    .filter((threadId) => typeof threadId === "string" && threadId);
+}
+
 export async function collectRolloutInventory(codexHome) {
   const rollouts = [];
   for (const scope of SESSION_DIRS) {
@@ -231,10 +241,72 @@ async function copyStateDbToStaging(codexHome, stagingDir) {
   return copied;
 }
 
+async function pruneStagedStateDb(stagingDir, dbFiles, selectedThreadIds) {
+  if (!selectedThreadIds) {
+    return dbFiles;
+  }
+  const baseFile = dbFiles.find((fileName) => path.basename(fileName) === DB_FILE_BASENAME);
+  if (!baseFile) {
+    return [];
+  }
+
+  const dbPath = resolveArchivePath(stagingDir, path.join("db", baseFile));
+  let db;
+  try {
+    db = await openDatabase(dbPath);
+    if (tableExists(db, "threads")) {
+      if (selectedThreadIds.length === 0) {
+        db.prepare("DELETE FROM threads").run();
+      } else {
+        const placeholders = selectedThreadIds.map(() => "?").join(", ");
+        db.prepare(`DELETE FROM threads WHERE id NOT IN (${placeholders})`).run(...selectedThreadIds);
+      }
+    }
+  } finally {
+    db?.close();
+  }
+
+  for (const dbFile of dbFiles) {
+    if (dbFile !== baseFile) {
+      await fs.rm(resolveArchivePath(stagingDir, path.join("db", dbFile)), { force: true });
+    }
+  }
+  return [baseFile];
+}
+
+export async function buildExportPreview(codexHome) {
+  const rollouts = await collectRolloutInventory(codexHome);
+  const localThreads = await readLocalThreads(codexHome);
+  const rowsById = mapRowsById(localThreads.rows);
+  const sortedRollouts = [...rollouts].sort((left, right) => (
+    String(right.timestamp ?? "").localeCompare(String(left.timestamp ?? ""))
+    || left.relativePath.localeCompare(right.relativePath)
+  ));
+  return sortedRollouts.map((rollout, index) => {
+    const sqlite = rollout.threadId ? rowsById.get(rollout.threadId) : null;
+    return {
+      index: index + 1,
+      key: buildExportKey(rollout),
+      threadId: rollout.threadId,
+      scope: rollout.scope,
+      provider: rollout.provider ?? sqlite?.model_provider ?? "(missing)",
+      cwd: rollout.cwd ?? sqlite?.cwd ?? "",
+      timestamp: rollout.timestamp
+        ?? sqlite?.updated_at_ms
+        ?? sqlite?.created_at_ms
+        ?? "",
+      firstUserMessage: sqlite?.first_user_message ?? "",
+      relativePath: rollout.relativePath,
+      size: rollout.size
+    };
+  });
+}
+
 export async function createHistoryArchive({
   codexHome,
   archivePath,
-  overwrite = false
+  overwrite = false,
+  selectionKeys
 }) {
   const resolvedArchivePath = path.resolve(archivePath);
   if (await pathExists(resolvedArchivePath)) {
@@ -247,15 +319,28 @@ export async function createHistoryArchive({
   await fs.mkdir(path.dirname(resolvedArchivePath), { recursive: true });
   const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-history-export-"));
   try {
-    const rollouts = await collectRolloutInventory(codexHome);
+    const allRollouts = await collectRolloutInventory(codexHome);
+    const selectedKeySet = selectionKeys ? new Set(selectionKeys) : null;
+    const rollouts = selectedKeySet
+      ? allRollouts.filter((rollout) => selectedKeySet.has(buildExportKey(rollout)))
+      : allRollouts;
+    if (selectedKeySet && rollouts.length === 0) {
+      throw new Error("No conversations matched the selected export items.");
+    }
     await copyRolloutsToStaging(codexHome, stagingDir, rollouts);
     const globalStateFiles = await copyGlobalStateToStaging(codexHome, stagingDir);
-    const dbFiles = await copyStateDbToStaging(codexHome, stagingDir);
+    const copiedDbFiles = await copyStateDbToStaging(codexHome, stagingDir);
+    const dbFiles = await pruneStagedStateDb(
+      stagingDir,
+      copiedDbFiles,
+      selectedKeySet ? selectedThreadIdsFromRollouts(rollouts) : null
+    );
     const manifest = {
       version: HISTORY_VERSION,
       namespace: HISTORY_NAMESPACE,
       createdAt: new Date().toISOString(),
       codexHome,
+      selected: Boolean(selectedKeySet),
       rollouts,
       dbFiles,
       globalStateFiles
@@ -280,6 +365,7 @@ export async function createHistoryArchive({
       rolloutFiles: rollouts.length,
       dbFiles: dbFiles.length,
       globalStateFiles: globalStateFiles.length,
+      selected: Boolean(selectedKeySet),
       bytes: stat.size
     };
   } finally {

--- a/src/service.js
+++ b/src/service.js
@@ -43,6 +43,16 @@ import {
   readThreadCwdStats,
   syncWorkspaceRoots
 } from "./workspace-roots.js";
+import {
+  buildImportPlan,
+  cleanupExtractedHistory,
+  copyImportedRollouts,
+  createHistoryArchive,
+  extractHistoryArchive,
+  mergeImportedSqliteThreads,
+  resolveImportConflicts,
+  summarizeImportPlan
+} from "./history-transfer.js";
 
 function normalizeCodexHome(explicitCodexHome) {
   return path.resolve(explicitCodexHome ?? process.env.CODEX_HOME ?? defaultCodexHome());
@@ -50,6 +60,17 @@ function normalizeCodexHome(explicitCodexHome) {
 
 async function ensureCodexHome(codexHome) {
   await fs.access(codexHome);
+}
+
+async function readConfigTextOrEmpty(configPath) {
+  try {
+    return await readConfigText(configPath);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
 }
 
 function formatCounts(counts) {
@@ -77,6 +98,23 @@ function emitProgress(onProgress, event) {
 
 function sumCounts(counts) {
   return Object.values(counts ?? {}).reduce((total, value) => total + value, 0);
+}
+
+function formatLocalTimestampForFileName(date = new Date()) {
+  const pad = (value) => String(value).padStart(2, "0");
+  return [
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+    "_",
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds())
+  ].join("");
+}
+
+export function defaultHistoryArchivePath(date = new Date()) {
+  return path.resolve(process.cwd(), `codex-history_${formatLocalTimestampForFileName(date)}.tgz`);
 }
 
 function buildEncryptedContentWarning(encryptedContentCounts, targetProvider) {
@@ -484,6 +522,251 @@ export async function runPruneBackups({
   try {
     return await pruneBackups(codexHome, keepCount);
   } finally {
+    await releaseLock();
+  }
+}
+
+export async function runExportHistory({
+  codexHome: explicitCodexHome,
+  archivePath,
+  overwrite = false,
+  onProgress
+} = {}) {
+  const codexHome = normalizeCodexHome(explicitCodexHome);
+  const resolvedArchivePath = archivePath ? path.resolve(archivePath) : defaultHistoryArchivePath();
+  await ensureCodexHome(codexHome);
+  const releaseLock = await acquireLock(codexHome, "export-history");
+  try {
+    emitProgress(onProgress, { stage: "create_history_archive", status: "start" });
+    const result = await createHistoryArchive({
+      codexHome,
+      archivePath: resolvedArchivePath,
+      overwrite
+    });
+    emitProgress(onProgress, { stage: "create_history_archive", status: "complete", archivePath: result.archivePath });
+    return {
+      codexHome,
+      ...result
+    };
+  } finally {
+    await releaseLock();
+  }
+}
+
+async function syncProviderMetadataAfterImport({
+  codexHome,
+  targetProvider,
+  backupDir,
+  sqliteBusyTimeoutMs,
+  onProgress
+}) {
+  emitProgress(onProgress, { stage: "scan_imported_history", status: "start" });
+  const {
+    changes,
+    lockedPaths: lockedReadPaths,
+    userEventThreadIds,
+    threadCwdById
+  } = await collectSessionChanges(codexHome, targetProvider, { skipLockedReads: true });
+  emitProgress(onProgress, {
+    stage: "scan_imported_history",
+    status: "complete",
+    scannedChanges: changes.length,
+    lockedReadCount: lockedReadPaths.length
+  });
+
+  const cwdStats = await readThreadCwdStats(codexHome);
+  const { writableChanges, lockedChanges } = await splitLockedSessionChanges(changes);
+  let applyResult = { appliedChanges: 0, appliedPaths: [], skippedPaths: [] };
+  let workspaceRootResult = {
+    updated: false,
+    updatedWorkspaceRoots: 0,
+    savedWorkspaceRootCount: 0
+  };
+
+  emitProgress(onProgress, { stage: "sync_imported_metadata", status: "start" });
+  const sqliteResult = await updateSqliteProvider(
+    codexHome,
+    targetProvider,
+    async () => {
+      if (writableChanges.length > 0) {
+        applyResult = await applySessionChanges(writableChanges);
+        const appliedPathSet = new Set(applyResult.appliedPaths ?? []);
+        const appliedSessionChanges = writableChanges.filter((change) => appliedPathSet.has(change.path));
+        await updateSessionBackupManifest(backupDir, appliedSessionChanges);
+      }
+      workspaceRootResult = await syncWorkspaceRoots(codexHome, { cwdStats });
+    },
+    { busyTimeoutMs: sqliteBusyTimeoutMs, userEventThreadIds, threadCwdById }
+  );
+  emitProgress(onProgress, {
+    stage: "sync_imported_metadata",
+    status: "complete",
+    updatedRows: sqliteResult.updatedRows,
+    appliedChanges: applyResult.appliedChanges
+  });
+
+  return {
+    changedSessionFiles: applyResult.appliedChanges,
+    skippedLockedRolloutFiles: [...new Set([
+      ...lockedReadPaths,
+      ...lockedChanges.map((change) => change.path),
+      ...applyResult.skippedPaths
+    ])].sort((left, right) => left.localeCompare(right)),
+    sqliteRowsUpdated: sqliteResult.updatedRows,
+    sqliteProviderRowsUpdated: sqliteResult.providerRowsUpdated,
+    sqliteUserEventRowsUpdated: sqliteResult.userEventRowsUpdated,
+    sqliteCwdRowsUpdated: sqliteResult.cwdRowsUpdated,
+    updatedWorkspaceRoots: workspaceRootResult.updatedWorkspaceRoots,
+    savedWorkspaceRootCount: workspaceRootResult.savedWorkspaceRootCount,
+    sqlitePresent: sqliteResult.databasePresent
+  };
+}
+
+export async function runImportHistory({
+  codexHome: explicitCodexHome,
+  archivePath,
+  provider,
+  conflict = "ask",
+  dryRun = false,
+  keepCount = DEFAULT_BACKUP_RETENTION_COUNT,
+  sqliteBusyTimeoutMs,
+  onConflict,
+  onProgress
+} = {}) {
+  if (!archivePath) {
+    throw new Error("Missing archive path. Usage: codex-provider import <archive-path>");
+  }
+  if (!Number.isInteger(keepCount) || keepCount < 1) {
+    throw new Error(`Invalid automatic keep count: ${keepCount}. Expected an integer greater than or equal to 1.`);
+  }
+
+  const codexHome = normalizeCodexHome(explicitCodexHome);
+  await ensureCodexHome(codexHome);
+  const configPath = path.join(codexHome, "config.toml");
+  const configText = await readConfigTextOrEmpty(configPath);
+  const current = readCurrentProviderFromConfigText(configText);
+  const targetProvider = provider ?? current.provider ?? DEFAULT_PROVIDER;
+  if (provider && !configDeclaresProvider(configText, provider)) {
+    throw new Error(`Provider "${provider}" is not available in config.toml. Configure it first or use one of: ${listConfiguredProviderIds(configText).join(", ")}`);
+  }
+
+  const releaseLock = await acquireLock(codexHome, "import-history");
+  let extracted = null;
+  try {
+    emitProgress(onProgress, { stage: "extract_history_archive", status: "start" });
+    extracted = await extractHistoryArchive(archivePath);
+    emitProgress(onProgress, { stage: "extract_history_archive", status: "complete" });
+
+    emitProgress(onProgress, { stage: "plan_history_import", status: "start" });
+    const plan = await buildImportPlan({ codexHome, extracted });
+    const planSummary = summarizeImportPlan(plan);
+    emitProgress(onProgress, { stage: "plan_history_import", status: "complete", ...planSummary });
+
+    const decisions = await resolveImportConflicts({ plan, conflict, onConflict });
+    if (dryRun) {
+      return {
+        codexHome,
+        archivePath: path.resolve(archivePath),
+        targetProvider,
+        dryRun: true,
+        backupDir: null,
+        plan: planSummary,
+        importedRolloutFiles: 0,
+        skippedRolloutFiles: plan.conflicts.filter((item) => decisions.get(item.key) === "skip").length,
+        sqliteRowsInserted: 0,
+        sqliteRowsUpdatedByImport: 0,
+        sqliteRowsSkipped: 0,
+        changedSessionFiles: 0,
+        skippedLockedRolloutFiles: [],
+        sqliteRowsUpdated: 0,
+        sqlitePresent: Boolean(plan.localThreads.dbPath)
+      };
+    }
+
+    emitProgress(onProgress, { stage: "check_import_targets", status: "start" });
+    await assertSqliteWritable(codexHome, { busyTimeoutMs: sqliteBusyTimeoutMs });
+    emitProgress(onProgress, { stage: "check_import_targets", status: "complete" });
+
+    emitProgress(onProgress, { stage: "create_backup", status: "start" });
+    const backupStartedAt = Date.now();
+    const backupDir = await createBackup({
+      codexHome,
+      targetProvider,
+      sessionChanges: [],
+      configPath
+    });
+    const backupDurationMs = Date.now() - backupStartedAt;
+    emitProgress(onProgress, {
+      stage: "create_backup",
+      status: "complete",
+      backupDir,
+      durationMs: backupDurationMs
+    });
+
+    emitProgress(onProgress, { stage: "copy_history_rollouts", status: "start" });
+    const rolloutResult = await copyImportedRollouts({ codexHome, extracted, plan, decisions });
+    emitProgress(onProgress, { stage: "copy_history_rollouts", status: "complete", copied: rolloutResult.copied });
+
+    emitProgress(onProgress, { stage: "merge_history_sqlite", status: "start" });
+    const sqliteMergeResult = await mergeImportedSqliteThreads({
+      codexHome,
+      extracted,
+      plan,
+      decisions,
+      targetProvider
+    });
+    emitProgress(onProgress, {
+      stage: "merge_history_sqlite",
+      status: "complete",
+      insertedRows: sqliteMergeResult.insertedRows,
+      updatedRows: sqliteMergeResult.updatedRows
+    });
+
+    const syncResult = await syncProviderMetadataAfterImport({
+      codexHome,
+      targetProvider,
+      backupDir,
+      sqliteBusyTimeoutMs,
+      onProgress
+    });
+
+    let autoPruneResult = null;
+    let autoPruneWarning = null;
+    emitProgress(onProgress, { stage: "clean_backups", status: "start", keepCount });
+    try {
+      autoPruneResult = await pruneBackups(codexHome, keepCount);
+    } catch (pruneError) {
+      autoPruneWarning = `Automatic backup cleanup failed: ${pruneError instanceof Error ? pruneError.message : String(pruneError)}`;
+    }
+    emitProgress(onProgress, {
+      stage: "clean_backups",
+      status: "complete",
+      deletedCount: autoPruneResult?.deletedCount ?? 0,
+      warning: autoPruneWarning
+    });
+
+    return {
+      codexHome,
+      archivePath: path.resolve(archivePath),
+      targetProvider,
+      dryRun: false,
+      backupDir,
+      backupDurationMs,
+      plan: planSummary,
+      importedRolloutFiles: rolloutResult.copied,
+      skippedRolloutFiles: rolloutResult.skipped,
+      removedLocalConflictRolloutFiles: rolloutResult.removedLocalConflicts,
+      sqliteRowsInserted: sqliteMergeResult.insertedRows,
+      sqliteRowsUpdatedByImport: sqliteMergeResult.updatedRows,
+      sqliteRowsSkipped: sqliteMergeResult.skippedRows,
+      sqliteDatabaseCopied: sqliteMergeResult.databaseCopied,
+      copiedDbFiles: sqliteMergeResult.copiedDbFiles,
+      ...syncResult,
+      autoPruneResult,
+      autoPruneWarning
+    };
+  } finally {
+    await cleanupExtractedHistory(extracted);
     await releaseLock();
   }
 }

--- a/src/service.js
+++ b/src/service.js
@@ -44,6 +44,7 @@ import {
   syncWorkspaceRoots
 } from "./workspace-roots.js";
 import {
+  buildExportPreview,
   buildImportPlan,
   cleanupExtractedHistory,
   copyImportedRollouts,
@@ -115,6 +116,23 @@ function formatLocalTimestampForFileName(date = new Date()) {
 
 export function defaultHistoryArchivePath(date = new Date()) {
   return path.resolve(process.cwd(), `codex-history_${formatLocalTimestampForFileName(date)}.tgz`);
+}
+
+export function parseExportThreadIds(rawValue) {
+  if (rawValue === undefined) {
+    return null;
+  }
+  if (rawValue === true) {
+    throw new Error("Missing --ids value. Expected comma-separated thread ids.");
+  }
+  const ids = String(rawValue)
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (ids.length === 0) {
+    throw new Error("Missing --ids value. Expected comma-separated thread ids.");
+  }
+  return ids;
 }
 
 function buildEncryptedContentWarning(encryptedContentCounts, targetProvider) {
@@ -530,18 +548,33 @@ export async function runExportHistory({
   codexHome: explicitCodexHome,
   archivePath,
   overwrite = false,
+  selectionKeys,
+  threadIds,
   onProgress
 } = {}) {
   const codexHome = normalizeCodexHome(explicitCodexHome);
   const resolvedArchivePath = archivePath ? path.resolve(archivePath) : defaultHistoryArchivePath();
   await ensureCodexHome(codexHome);
+  let resolvedSelectionKeys = selectionKeys ?? null;
+  if (!resolvedSelectionKeys && threadIds?.length) {
+    const preview = await buildExportPreview(codexHome);
+    const requestedIds = new Set(threadIds);
+    const matched = preview.filter((entry) => entry.threadId && requestedIds.has(entry.threadId));
+    const matchedIds = new Set(matched.map((entry) => entry.threadId));
+    const missingIds = [...requestedIds].filter((threadId) => !matchedIds.has(threadId));
+    if (missingIds.length > 0) {
+      throw new Error(`No exportable conversation found for thread id(s): ${missingIds.join(", ")}`);
+    }
+    resolvedSelectionKeys = matched.map((entry) => entry.key);
+  }
   const releaseLock = await acquireLock(codexHome, "export-history");
   try {
     emitProgress(onProgress, { stage: "create_history_archive", status: "start" });
     const result = await createHistoryArchive({
       codexHome,
       archivePath: resolvedArchivePath,
-      overwrite
+      overwrite,
+      selectionKeys: resolvedSelectionKeys
     });
     emitProgress(onProgress, { stage: "create_history_archive", status: "complete", archivePath: result.archivePath });
     return {
@@ -551,6 +584,15 @@ export async function runExportHistory({
   } finally {
     await releaseLock();
   }
+}
+
+export async function getExportHistoryPreview({ codexHome: explicitCodexHome } = {}) {
+  const codexHome = normalizeCodexHome(explicitCodexHome);
+  await ensureCodexHome(codexHome);
+  return {
+    codexHome,
+    conversations: await buildExportPreview(codexHome)
+  };
 }
 
 async function syncProviderMetadataAfterImport({

--- a/src/service.js
+++ b/src/service.js
@@ -52,7 +52,8 @@ import {
   extractHistoryArchive,
   mergeImportedSqliteThreads,
   resolveImportConflicts,
-  summarizeImportPlan
+  summarizeImportPlan,
+  toggleExportConversationArchived
 } from "./history-transfer.js";
 
 function normalizeCodexHome(explicitCodexHome) {
@@ -593,6 +594,20 @@ export async function getExportHistoryPreview({ codexHome: explicitCodexHome } =
     codexHome,
     conversations: await buildExportPreview(codexHome)
   };
+}
+
+export async function toggleExportHistoryArchived({
+  codexHome: explicitCodexHome,
+  entry
+} = {}) {
+  const codexHome = normalizeCodexHome(explicitCodexHome);
+  await ensureCodexHome(codexHome);
+  const releaseLock = await acquireLock(codexHome, "toggle-history-archive");
+  try {
+    return await toggleExportConversationArchived(codexHome, entry);
+  } finally {
+    await releaseLock();
+  }
 }
 
 async function syncProviderMetadataAfterImport({

--- a/src/service.js
+++ b/src/service.js
@@ -51,6 +51,7 @@ import {
   createHistoryArchive,
   extractHistoryArchive,
   mergeImportedSqliteThreads,
+  readExportTranscript,
   resolveImportConflicts,
   summarizeImportPlan,
   toggleExportConversationArchived
@@ -608,6 +609,16 @@ export async function toggleExportHistoryArchived({
   } finally {
     await releaseLock();
   }
+}
+
+export async function getExportHistoryTranscript({
+  codexHome: explicitCodexHome,
+  entry,
+  limit
+} = {}) {
+  const codexHome = normalizeCodexHome(explicitCodexHome);
+  await ensureCodexHome(codexHome);
+  return readExportTranscript(codexHome, entry, { limit });
 }
 
 async function syncProviderMetadataAfterImport({

--- a/test/history-transfer.test.js
+++ b/test/history-transfer.test.js
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  getExportHistoryPreview,
   runExportHistory,
   runImportHistory
 } from "../src/service.js";
@@ -162,6 +163,54 @@ test("cli export defaults to a dated archive in the current terminal directory",
     .filter((name) => /^codex-history_\d{8}_\d{6}\.tgz$/.test(name));
   assert.equal(archiveNames.length, 1);
   await fs.access(path.join(root, archiveNames[0]));
+});
+
+test("selected export includes only chosen conversations and merges them incrementally", async () => {
+  const { root, codexHome: sourceHome } = await makeTempCodexHome();
+  await writeConfig(sourceHome, 'model_provider = "openai"');
+  await writeRollout(sourceHome, "sessions", "19", "thread-a", "openai", "source a");
+  await writeRollout(sourceHome, "sessions", "20", "thread-b", "openai", "source b");
+  await writeRollout(sourceHome, "archived_sessions", "21", "thread-c", "openai", "source c");
+  await writeStateDb(sourceHome, [
+    { id: "thread-a", model_provider: "openai", first_user_message: "source sqlite a" },
+    { id: "thread-b", model_provider: "openai", first_user_message: "source sqlite b" },
+    { id: "thread-c", model_provider: "openai", archived: true, first_user_message: "source sqlite c" }
+  ]);
+
+  const preview = await getExportHistoryPreview({ codexHome: sourceHome });
+  assert.equal(preview.conversations.length, 3);
+  const archivePath = path.join(root, "selected.tgz");
+  const exportResult = await runExportHistory({
+    codexHome: sourceHome,
+    archivePath,
+    threadIds: ["thread-b"]
+  });
+  assert.equal(exportResult.selected, true);
+  assert.equal(exportResult.rolloutFiles, 1);
+
+  const { codexHome: targetHome } = await makeTempCodexHome();
+  await writeConfig(targetHome, 'model_provider = "openai"');
+  await writeRollout(targetHome, "sessions", "18", "thread-local", "openai", "local");
+  await writeStateDb(targetHome, [
+    { id: "thread-local", model_provider: "openai", first_user_message: "local sqlite" }
+  ]);
+
+  const importResult = await runImportHistory({
+    codexHome: targetHome,
+    archivePath,
+    conflict: "fail"
+  });
+
+  assert.equal(importResult.plan.archiveRolloutFiles, 1);
+  assert.equal(importResult.plan.archiveSqliteRows, 1);
+  assert.equal(importResult.sqliteRowsInserted, 1);
+  assert.deepEqual(await readThreadRows(targetHome), [
+    { id: "thread-b", model_provider: "openai", archived: 0, first_user_message: "source sqlite b" },
+    { id: "thread-local", model_provider: "openai", archived: 0, first_user_message: "local sqlite" }
+  ]);
+  await fs.access(path.join(targetHome, "sessions", "2026", "03", "20", "rollout-thread-b.jsonl"));
+  await assert.rejects(fs.access(path.join(targetHome, "sessions", "2026", "03", "19", "rollout-thread-a.jsonl")));
+  await assert.rejects(fs.access(path.join(targetHome, "archived_sessions", "2026", "03", "21", "rollout-thread-c.jsonl")));
 });
 
 test("runImportHistory imports into a Codex home without SQLite and rewrites provider to current provider", async () => {

--- a/test/history-transfer.test.js
+++ b/test/history-transfer.test.js
@@ -8,7 +8,8 @@ import path from "node:path";
 import {
   getExportHistoryPreview,
   runExportHistory,
-  runImportHistory
+  runImportHistory,
+  toggleExportHistoryArchived
 } from "../src/service.js";
 import {
   DB_FILE_BASENAME,
@@ -211,6 +212,40 @@ test("selected export includes only chosen conversations and merges them increme
   await fs.access(path.join(targetHome, "sessions", "2026", "03", "20", "rollout-thread-b.jsonl"));
   await assert.rejects(fs.access(path.join(targetHome, "sessions", "2026", "03", "19", "rollout-thread-a.jsonl")));
   await assert.rejects(fs.access(path.join(targetHome, "archived_sessions", "2026", "03", "21", "rollout-thread-c.jsonl")));
+});
+
+test("toggleExportHistoryArchived moves rollout files and updates SQLite archived flag", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const activePath = await writeRollout(codexHome, "sessions", "19", "thread-toggle", "openai", "toggle me");
+  await writeStateDb(codexHome, [
+    { id: "thread-toggle", model_provider: "openai", archived: false, first_user_message: "toggle sqlite" }
+  ]);
+
+  let preview = await getExportHistoryPreview({ codexHome });
+  const activeEntry = preview.conversations.find((entry) => entry.threadId === "thread-toggle");
+  const archivedEntry = await toggleExportHistoryArchived({ codexHome, entry: activeEntry });
+
+  assert.equal(archivedEntry.scope, "archived_sessions");
+  await assert.rejects(fs.access(activePath));
+  const archivedPath = path.join(codexHome, "archived_sessions", "2026", "03", "19", "rollout-thread-toggle.jsonl");
+  await fs.access(archivedPath);
+  assert.deepEqual(await readThreadRows(codexHome), [
+    { id: "thread-toggle", model_provider: "openai", archived: 1, first_user_message: "toggle sqlite" }
+  ]);
+
+  preview = await getExportHistoryPreview({ codexHome });
+  const restoredEntry = await toggleExportHistoryArchived({
+    codexHome,
+    entry: preview.conversations.find((entry) => entry.threadId === "thread-toggle")
+  });
+
+  assert.equal(restoredEntry.scope, "sessions");
+  await fs.access(activePath);
+  await assert.rejects(fs.access(archivedPath));
+  assert.deepEqual(await readThreadRows(codexHome), [
+    { id: "thread-toggle", model_provider: "openai", archived: 0, first_user_message: "toggle sqlite" }
+  ]);
 });
 
 test("runImportHistory imports into a Codex home without SQLite and rewrites provider to current provider", async () => {

--- a/test/history-transfer.test.js
+++ b/test/history-transfer.test.js
@@ -1,0 +1,313 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  runExportHistory,
+  runImportHistory
+} from "../src/service.js";
+import {
+  DB_FILE_BASENAME,
+  SQLITE_DIR_BASENAME
+} from "../src/constants.js";
+import { openDatabase } from "../src/sqlite.js";
+
+async function makeTempCodexHome() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-provider-history-"));
+  const codexHome = path.join(root, ".codex");
+  await fs.mkdir(codexHome, { recursive: true });
+  return { root, codexHome };
+}
+
+async function writeConfig(codexHome, modelProviderLine = 'model_provider = "openai"') {
+  const config = `${modelProviderLine}\n\n[model_providers.apigather]\nbase_url = "https://example.com"\n`;
+  await fs.writeFile(path.join(codexHome, "config.toml"), config, "utf8");
+}
+
+async function writeRollout(codexHome, scope, day, id, provider, message, cwd = "C:\\AITemp") {
+  const dir = path.join(codexHome, scope, "2026", "03", day);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `rollout-${id}.jsonl`);
+  const timestamp = `2026-03-${day}T00:00:00.000Z`;
+  const payload = {
+    id,
+    timestamp,
+    cwd,
+    source: "cli",
+    cli_version: "0.115.0",
+    model_provider: provider
+  };
+  await fs.writeFile(
+    filePath,
+    [
+      JSON.stringify({ timestamp, type: "session_meta", payload }),
+      JSON.stringify({ timestamp, type: "event_msg", payload: { type: "user_message", message } })
+    ].join("\n") + "\n",
+    "utf8"
+  );
+  return filePath;
+}
+
+function stateDbPath(codexHome) {
+  return path.join(codexHome, SQLITE_DIR_BASENAME, DB_FILE_BASENAME);
+}
+
+async function writeStateDb(codexHome, rows) {
+  const dbPath = stateDbPath(codexHome);
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
+  const db = await openDatabase(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE threads (
+        id TEXT PRIMARY KEY,
+        model_provider TEXT,
+        cwd TEXT NOT NULL DEFAULT '',
+        archived INTEGER NOT NULL DEFAULT 0,
+        has_user_event INTEGER NOT NULL DEFAULT 0,
+        first_user_message TEXT NOT NULL DEFAULT '',
+        updated_at_ms INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+    const stmt = db.prepare("INSERT INTO threads (id, model_provider, cwd, archived, has_user_event, first_user_message, updated_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?)");
+    for (const row of rows) {
+      stmt.run(
+        row.id,
+        row.model_provider,
+        row.cwd ?? "C:\\AITemp",
+        row.archived ? 1 : 0,
+        row.has_user_event ? 1 : 0,
+        row.first_user_message ?? "hello",
+        row.updated_at_ms ?? 1
+      );
+    }
+  } finally {
+    db.close();
+  }
+}
+
+async function readThreadRows(codexHome) {
+  const db = await openDatabase(stateDbPath(codexHome));
+  try {
+    return db
+      .prepare("SELECT id, model_provider, archived, first_user_message FROM threads ORDER BY id")
+      .all()
+      .map((row) => ({ ...row }));
+  } finally {
+    db.close();
+  }
+}
+
+async function runCli(args, cwd) {
+  const cliPath = path.resolve("src", "cli.js");
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+test("runExportHistory creates an archive with active, archived, and SQLite history", async () => {
+  const { root, codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome);
+  await writeRollout(codexHome, "sessions", "19", "thread-a", "apigather", "active");
+  await writeRollout(codexHome, "archived_sessions", "18", "thread-b", "apigather", "archived");
+  await writeStateDb(codexHome, [
+    { id: "thread-a", model_provider: "apigather", archived: false },
+    { id: "thread-b", model_provider: "apigather", archived: true }
+  ]);
+  const archivePath = path.join(root, "history.tgz");
+
+  const result = await runExportHistory({ codexHome, archivePath });
+
+  assert.equal(result.rolloutFiles, 2);
+  assert.equal(result.dbFiles, 1);
+  assert.ok(result.bytes > 0);
+  await fs.access(archivePath);
+  await assert.rejects(
+    () => runExportHistory({ codexHome, archivePath }),
+    /Archive already exists/
+  );
+});
+
+test("cli export defaults to a dated archive in the current terminal directory", async () => {
+  const { root, codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome);
+  await writeRollout(codexHome, "sessions", "19", "thread-default", "openai", "default archive");
+  await writeStateDb(codexHome, [
+    { id: "thread-default", model_provider: "openai", archived: false }
+  ]);
+
+  const result = await runCli(["export", "--codex-home", codexHome], root);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Exported history archive:/);
+  const archiveNames = (await fs.readdir(root))
+    .filter((name) => /^codex-history_\d{8}_\d{6}\.tgz$/.test(name));
+  assert.equal(archiveNames.length, 1);
+  await fs.access(path.join(root, archiveNames[0]));
+});
+
+test("runImportHistory imports into a Codex home without SQLite and rewrites provider to current provider", async () => {
+  const { root, codexHome: sourceHome } = await makeTempCodexHome();
+  await writeConfig(sourceHome, 'model_provider = "apigather"');
+  const sourceRollout = await writeRollout(sourceHome, "sessions", "19", "thread-a", "apigather", "source message");
+  await writeStateDb(sourceHome, [
+    { id: "thread-a", model_provider: "apigather", archived: false, first_user_message: "source sqlite" }
+  ]);
+  const archivePath = path.join(root, "history.tgz");
+  await runExportHistory({ codexHome: sourceHome, archivePath });
+
+  const { codexHome: targetHome } = await makeTempCodexHome();
+  await writeConfig(targetHome, 'model_provider = "openai"');
+  const result = await runImportHistory({ codexHome: targetHome, archivePath, conflict: "fail" });
+
+  assert.equal(result.importedRolloutFiles, 1);
+  assert.equal(result.sqliteDatabaseCopied, true);
+  const importedRolloutPath = path.join(targetHome, path.relative(sourceHome, sourceRollout));
+  const rolloutText = await fs.readFile(importedRolloutPath, "utf8");
+  assert.match(rolloutText, /"model_provider":"openai"/);
+  assert.match(rolloutText, /source message/);
+  assert.deepEqual(await readThreadRows(targetHome), [
+    { id: "thread-a", model_provider: "openai", archived: 0, first_user_message: "source sqlite" }
+  ]);
+});
+
+test("runImportHistory inserts non-conflicting SQLite rows and supports provider override", async () => {
+  const { root, codexHome: sourceHome } = await makeTempCodexHome();
+  await writeConfig(sourceHome, 'model_provider = "openai"');
+  await writeRollout(sourceHome, "sessions", "19", "thread-source", "openai", "source");
+  await writeStateDb(sourceHome, [
+    { id: "thread-source", model_provider: "openai", first_user_message: "source sqlite" }
+  ]);
+  const archivePath = path.join(root, "history.tgz");
+  await runExportHistory({ codexHome: sourceHome, archivePath });
+
+  const { codexHome: targetHome } = await makeTempCodexHome();
+  await writeConfig(targetHome, 'model_provider = "openai"');
+  await writeRollout(targetHome, "sessions", "20", "thread-local", "openai", "local");
+  await writeStateDb(targetHome, [
+    { id: "thread-local", model_provider: "openai", first_user_message: "local sqlite" }
+  ]);
+
+  const result = await runImportHistory({
+    codexHome: targetHome,
+    archivePath,
+    provider: "apigather",
+    conflict: "fail"
+  });
+
+  assert.equal(result.sqliteRowsInserted, 1);
+  assert.deepEqual(await readThreadRows(targetHome), [
+    { id: "thread-local", model_provider: "apigather", archived: 0, first_user_message: "local sqlite" },
+    { id: "thread-source", model_provider: "apigather", archived: 0, first_user_message: "source sqlite" }
+  ]);
+});
+
+test("runImportHistory handles conflicts with skip, overwrite, fail, and ask callback", async () => {
+  const { root, codexHome: sourceHome } = await makeTempCodexHome();
+  await writeConfig(sourceHome, 'model_provider = "apigather"');
+  await writeRollout(sourceHome, "sessions", "19", "thread-conflict", "apigather", "source message");
+  await writeStateDb(sourceHome, [
+    { id: "thread-conflict", model_provider: "apigather", first_user_message: "source sqlite" }
+  ]);
+  const archivePath = path.join(root, "history.tgz");
+  await runExportHistory({ codexHome: sourceHome, archivePath });
+
+  const { codexHome: skipHome } = await makeTempCodexHome();
+  await writeConfig(skipHome, 'model_provider = "openai"');
+  const skipRollout = await writeRollout(skipHome, "sessions", "19", "thread-conflict", "openai", "local message");
+  await writeStateDb(skipHome, [
+    { id: "thread-conflict", model_provider: "openai", first_user_message: "local sqlite" }
+  ]);
+  const skipResult = await runImportHistory({ codexHome: skipHome, archivePath, conflict: "skip" });
+  assert.equal(skipResult.plan.conflicts, 1);
+  assert.match(await fs.readFile(skipRollout, "utf8"), /local message/);
+  assert.deepEqual(await readThreadRows(skipHome), [
+    { id: "thread-conflict", model_provider: "openai", archived: 0, first_user_message: "local sqlite" }
+  ]);
+
+  const { codexHome: overwriteHome } = await makeTempCodexHome();
+  await writeConfig(overwriteHome, 'model_provider = "openai"');
+  const overwriteRollout = await writeRollout(overwriteHome, "sessions", "19", "thread-conflict", "openai", "local message");
+  await writeStateDb(overwriteHome, [
+    { id: "thread-conflict", model_provider: "openai", first_user_message: "local sqlite" }
+  ]);
+  const overwriteResult = await runImportHistory({ codexHome: overwriteHome, archivePath, conflict: "overwrite" });
+  assert.equal(overwriteResult.sqliteRowsUpdatedByImport, 1);
+  assert.match(await fs.readFile(overwriteRollout, "utf8"), /source message/);
+  assert.deepEqual(await readThreadRows(overwriteHome), [
+    { id: "thread-conflict", model_provider: "openai", archived: 0, first_user_message: "source sqlite" }
+  ]);
+
+  const { codexHome: failHome } = await makeTempCodexHome();
+  await writeConfig(failHome, 'model_provider = "openai"');
+  await writeRollout(failHome, "sessions", "19", "thread-conflict", "openai", "local message");
+  await writeStateDb(failHome, [
+    { id: "thread-conflict", model_provider: "openai", first_user_message: "local sqlite" }
+  ]);
+  await assert.rejects(
+    () => runImportHistory({ codexHome: failHome, archivePath, conflict: "fail" }),
+    /found 1 conflict/
+  );
+
+  const { codexHome: askHome } = await makeTempCodexHome();
+  await writeConfig(askHome, 'model_provider = "openai"');
+  const askRollout = await writeRollout(askHome, "sessions", "19", "thread-conflict", "openai", "local message");
+  await writeStateDb(askHome, [
+    { id: "thread-conflict", model_provider: "openai", first_user_message: "local sqlite" }
+  ]);
+  const decisions = [];
+  await runImportHistory({
+    codexHome: askHome,
+    archivePath,
+    conflict: "ask",
+    onConflict(conflict) {
+      decisions.push(conflict.threadId);
+      return "overwriteAll";
+    }
+  });
+  assert.deepEqual(decisions, ["thread-conflict"]);
+  assert.match(await fs.readFile(askRollout, "utf8"), /source message/);
+});
+
+test("runImportHistory dry-run reports the plan without writing files", async () => {
+  const { root, codexHome: sourceHome } = await makeTempCodexHome();
+  await writeConfig(sourceHome);
+  await writeRollout(sourceHome, "sessions", "19", "thread-dry", "openai", "source");
+  await writeStateDb(sourceHome, [
+    { id: "thread-dry", model_provider: "openai", first_user_message: "source sqlite" }
+  ]);
+  const archivePath = path.join(root, "history.tgz");
+  await runExportHistory({ codexHome: sourceHome, archivePath });
+
+  const { codexHome: targetHome } = await makeTempCodexHome();
+  await writeConfig(targetHome);
+  const result = await runImportHistory({
+    codexHome: targetHome,
+    archivePath,
+    conflict: "fail",
+    dryRun: true
+  });
+
+  assert.equal(result.dryRun, true);
+  assert.equal(result.plan.newRolloutFiles, 1);
+  await assert.rejects(fs.access(path.join(targetHome, "sessions", "2026", "03", "19", "rollout-thread-dry.jsonl")));
+  await assert.rejects(fs.access(stateDbPath(targetHome)));
+});

--- a/test/history-transfer.test.js
+++ b/test/history-transfer.test.js
@@ -7,6 +7,7 @@ import path from "node:path";
 
 import {
   getExportHistoryPreview,
+  getExportHistoryTranscript,
   runExportHistory,
   runImportHistory,
   toggleExportHistoryArchived
@@ -212,6 +213,62 @@ test("selected export includes only chosen conversations and merges them increme
   await fs.access(path.join(targetHome, "sessions", "2026", "03", "20", "rollout-thread-b.jsonl"));
   await assert.rejects(fs.access(path.join(targetHome, "sessions", "2026", "03", "19", "rollout-thread-a.jsonl")));
   await assert.rejects(fs.access(path.join(targetHome, "archived_sessions", "2026", "03", "21", "rollout-thread-c.jsonl")));
+});
+
+test("export preview falls back to rollout title and first user message when SQLite preview is empty", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  await writeRollout(codexHome, "sessions", "19", "thread-title", "openai", "rollout first user");
+  await writeRollout(codexHome, "sessions", "20", "thread-message", "openai", "rollout fallback user");
+  const titlePath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-thread-title.jsonl");
+  const lines = (await fs.readFile(titlePath, "utf8")).trimEnd().split("\n");
+  const meta = JSON.parse(lines[0]);
+  meta.payload.title = "Renamed title";
+  lines[0] = JSON.stringify(meta);
+  await fs.writeFile(titlePath, `${lines.join("\n")}\n`, "utf8");
+  await writeStateDb(codexHome, [
+    { id: "thread-title", model_provider: "openai", first_user_message: "" },
+    { id: "thread-message", model_provider: "openai", first_user_message: "" }
+  ]);
+
+  const preview = await getExportHistoryPreview({ codexHome });
+  const titled = preview.conversations.find((entry) => entry.threadId === "thread-title");
+  const messageOnly = preview.conversations.find((entry) => entry.threadId === "thread-message");
+
+  assert.equal(titled.title, "Renamed title");
+  assert.equal(titled.firstUserMessage, "rollout first user");
+  assert.equal(messageOnly.title, "");
+  assert.equal(messageOnly.firstUserMessage, "rollout fallback user");
+});
+
+test("getExportHistoryTranscript reads user and assistant messages from rollout JSONL", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const rolloutPath = await writeRollout(codexHome, "sessions", "19", "thread-transcript", "openai", "hello from user");
+  await fs.appendFile(
+    rolloutPath,
+    JSON.stringify({
+      timestamp: "2026-03-19T00:00:01.000Z",
+      type: "event_msg",
+      payload: { type: "assistant_message", message: "hello from assistant" }
+    }) + "\n",
+    "utf8"
+  );
+  await writeStateDb(codexHome, [
+    { id: "thread-transcript", model_provider: "openai", first_user_message: "" }
+  ]);
+  const preview = await getExportHistoryPreview({ codexHome });
+  const entry = preview.conversations.find((candidate) => candidate.threadId === "thread-transcript");
+
+  const transcript = await getExportHistoryTranscript({ codexHome, entry });
+
+  assert.deepEqual(
+    transcript.messages.map((message) => [message.role, message.text]),
+    [
+      ["user", "hello from user"],
+      ["assistant", "hello from assistant"]
+    ]
+  );
 });
 
 test("toggleExportHistoryArchived moves rollout files and updates SQLite archived flag", async () => {


### PR DESCRIPTION
## Summary
- add CLI history export/import support for Codex rollout files and SQLite thread metadata
- add selective export TUI with search, keyboard navigation, archive visibility toggle, archive/live toggle, and transcript preview fixes
- keep imports incremental with conflict handling and provider metadata alignment

## Tests
- npm test (51 passed)
