### PR TITLE
fix: harden macOS build dependencies

### DIFF
--- a/desktop/CodexProviderSync.Core/CodexProviderSync.Core.csproj
+++ b/desktop/CodexProviderSync.Core/CodexProviderSync.Core.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 
 </Project>

--- a/scripts/publish-gui-macos.sh
+++ b/scripts/publish-gui-macos.sh
@@ -105,7 +105,14 @@ EOF
 rm -rf "$publish_dir"
 
 if command -v codesign >/dev/null 2>&1; then
-  codesign --force --deep --sign - "$app_dir" >/dev/null
+  signing_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-provider-sync-sign.XXXXXX")"
+  signing_app="$signing_dir/CodexProviderSync.app"
+  ditto --noextattr --noqtn "$app_dir" "$signing_app"
+  xattr -cr "$signing_app"
+  codesign --force --deep --sign - "$signing_app" >/dev/null
+  rm -rf "$app_dir"
+  ditto --noextattr --noqtn "$signing_app" "$app_dir"
+  rm -rf "$signing_dir"
 fi
 
 echo "macOS GUI app published to $app_dir"


### PR DESCRIPTION
## What changed

- Pin `SQLitePCLRaw.bundle_e_sqlite3` to `2.1.12` in the shared Core project.
- Sign the macOS app bundle from a temporary non-File-Provider directory, then copy the signed bundle back without extended attributes.

## Why

`Microsoft.Data.Sqlite 10.0.5` previously resolved `SQLitePCLRaw.lib.e_sqlite3 2.1.11`, which is affected by high-severity advisory `GHSA-2m69-gcr7-jv3q` / `CVE-2025-6965`. The explicit bundle reference resolves the native SQLite dependency to `2.1.12` and removes the NuGet advisory.

On macOS directories managed by File Provider, `com.apple.FinderInfo` or related extended attributes can be attached to the generated `.app` between assembly and `codesign`. Signing in a temporary local directory avoids the race and makes the publish script reliable in those workspaces.

## Impact

- The macOS and shared Core builds use the non-vulnerable SQLitePCLRaw package.
- `publish-gui-macos.sh` can produce an ad-hoc-signed ARM64 bundle from File-Provider-managed workspaces.
- No session synchronization behavior or authentication handling changes.

## Validation

- `npm audit --omit=dev`: 0 vulnerabilities
- `npm test`: 80 passed
- `dotnet list desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj package --vulnerable --include-transitive`: no vulnerable packages
- `dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj --configuration Release`: 71 passed
- `./scripts/publish-gui-macos.sh --runtime osx-arm64 --output artifacts/pr-check`: passed
- `codesign --verify --deep --strict`: passed after publication
