### PR TITLE
docs: add English macOS GUI guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ GUI 会保留备份并显示同步结果。每天首次启动会在后台检查�
 
 项目目前未做 Windows 代码签名，从浏览器下载后可能出现 SmartScreen 提示。请从本项目 Release 下载，并按需核对同版本 SHA-256。
 
-Windows 完整说明见 [README_GUI_ZH.md](docs/README_GUI_ZH.md)。macOS 用户可自行构建 Avalonia 桌面版，参见 [README_MAC_GUI_ZH.md](docs/README_MAC_GUI_ZH.md)。
+Windows 完整说明见 [README_GUI_ZH.md](docs/README_GUI_ZH.md)。macOS 用户可自行构建 Avalonia 桌面版，分别参见 [中文说明](docs/README_MAC_GUI_ZH.md)和[英文说明](docs/README_MAC_GUI_EN.md)。
 
 ### CLI
 
@@ -95,7 +95,7 @@ codex-provider sync
 ## 文档
 
 - [Windows GUI 说明](docs/README_GUI_ZH.md)
-- [macOS GUI 说明](docs/README_MAC_GUI_ZH.md)
+- macOS GUI 说明：[中文](docs/README_MAC_GUI_ZH.md) · [English](docs/README_MAC_GUI_EN.md)
 - [English documentation](docs/README_EN.md)
 - [AI / Agent 操作指南](AGENTS.md)
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -8,7 +8,7 @@
 [![Release](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync)](https://github.com/Dailin521/codex-provider-sync/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 
-[Download Windows GUI](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [中文](../README.md) · English
+[Download Windows GUI](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [Build macOS GUI](README_MAC_GUI_EN.md) · [中文](../README.md) · English
 
 </div>
 
@@ -51,7 +51,7 @@ The GUI keeps backups and displays the synchronization result. It checks for a s
 
 The Windows executable is currently unsigned, so browser downloads may trigger a SmartScreen warning. Download it only from this project's Releases and verify the matching SHA-256 when needed.
 
-See [README_GUI_ZH.md](README_GUI_ZH.md) for the full Windows guide. A self-built Avalonia macOS app is also available; see [README_MAC_GUI_ZH.md](README_MAC_GUI_ZH.md).
+See [README_GUI_ZH.md](README_GUI_ZH.md) for the full Windows guide. A self-built Avalonia macOS app is also available; see the [English macOS GUI guide](README_MAC_GUI_EN.md).
 
 ### CLI
 
@@ -97,7 +97,7 @@ Before each `sync` or `switch`, the tool creates a backup under:
 ## Documentation
 
 - [Windows GUI guide](README_GUI_ZH.md)
-- [macOS GUI guide](README_MAC_GUI_ZH.md)
+- [macOS GUI guide](README_MAC_GUI_EN.md)
 - [中文说明](../README.md)
 - [AI / Agent guide](../AGENTS.md)
 

--- a/docs/README_MAC_GUI_EN.md
+++ b/docs/README_MAC_GUI_EN.md
@@ -1,0 +1,100 @@
+# macOS GUI Guide
+
+[中文](README_MAC_GUI_ZH.md) · English
+
+`CodexProviderSync.app` is the macOS desktop GUI. It is built with Avalonia and
+reuses the status, synchronization, switching, restore, and backup-cleanup
+logic from `desktop/CodexProviderSync.Core`.
+
+## Build
+
+The app requires the .NET 10 SDK and macOS 12 or later.
+
+Build the default Apple Silicon (`osx-arm64`) app:
+
+```bash
+./scripts/publish-gui-macos.sh
+```
+
+Build the Intel (`osx-x64`) app:
+
+```bash
+./scripts/publish-gui-macos.sh --runtime osx-x64 --output artifacts/osx-x64
+```
+
+The default output is:
+
+```text
+artifacts/osx-arm64/CodexProviderSync.app
+```
+
+To use a specific .NET SDK:
+
+```bash
+DOTNET=/path/to/dotnet ./scripts/publish-gui-macos.sh
+```
+
+Open the locally built app:
+
+```bash
+open artifacts/osx-arm64/CodexProviderSync.app
+```
+
+## Features
+
+- Select or enter a Codex Home; the default is `~/.codex`.
+- Use `Refresh` to inspect the current Provider, rollout and SQLite Provider
+  counts, managed backups, project visibility, and `encrypted_content` risks.
+- See where each Provider was discovered: `config`, `rollout`, `SQLite`, or
+  `manual`.
+- Add or remove manual Providers.
+- Run `Sync Metadata Only`.
+- Run `Switch config.toml and sync`.
+- Use `Restore Backup` to restore selected `config.toml`, SQLite, and rollout
+  metadata.
+- Use `Clean Old Backups` and `Open Backup Folder`.
+- Review operation logs and error messages in the app.
+
+## Backups and Safety
+
+- Launching the app or using `Refresh` does not modify sessions, SQLite, or
+  `config.toml` metadata in the selected Codex Home.
+- The app asks for confirmation before write operations.
+- The Core creates a managed backup before `sync` or `switch` changes metadata.
+  Backups are stored under
+  `~/.codex/backups_state/provider-sync/<timestamp>`.
+- The app does not manage `auth.json`, sign in, authenticate, change
+  conversation content, or modify `updated_at`.
+- `encrypted_content` is reported as a risk; the app does not promise to repair
+  encrypted conversations across Providers or accounts.
+
+## Before Write Operations
+
+Before using `Sync Metadata Only`, `Switch config.toml and sync`,
+`Restore Backup`, or `Clean Old Backups`, close:
+
+- Codex CLI;
+- Codex App;
+- app-server; and
+- terminal tasks that are still using the selected Codex Home.
+
+If the app reports `state_5.sqlite is currently in use`, close those processes
+and retry.
+
+If the log reports skipped locked rollout files, an active session usually
+still holds those files open. Most of the synchronization may already be
+complete. Run sync again after the active session ends to update the skipped
+files.
+
+## Build and Distribution Notes
+
+The macOS desktop project currently uses Avalonia 12.0.4.
+
+`scripts/publish-gui-macos.sh` publishes an `osx-arm64` self-contained `.app`
+bundle by default. When `codesign` is available, the script applies ad-hoc
+signing. Ad-hoc signing is not Apple Developer ID signing or notarization.
+
+The project currently provides the macOS build script rather than a prebuilt
+macOS asset in GitHub Releases. Build the app locally using the commands above.
+The macOS script does not modify the Windows GUI publishing script at
+`scripts/publish-gui.ps1`.

--- a/docs/README_MAC_GUI_ZH.md
+++ b/docs/README_MAC_GUI_ZH.md
@@ -1,5 +1,7 @@
 # macOS GUI 使用说明
 
+中文 · [English](README_MAC_GUI_EN.md)
+
 `CodexProviderSync.app` 是 macOS 桌面版 GUI，使用 Avalonia 构建，复用 `desktop/CodexProviderSync.Core` 的状态、同步、切换、恢复和清理逻辑。
 
 ## 构建
@@ -69,4 +71,6 @@ DOTNET=/path/to/dotnet ./scripts/publish-gui-macos.sh
 
 `scripts/publish-gui-macos.sh` 默认发布 `osx-arm64` self-contained `.app` bundle，并在本机可用时执行 ad-hoc `codesign`。该脚本不修改 Windows GUI 发布脚本 `scripts/publish-gui.ps1`。
 
-当前 Avalonia 11.3.x 构建可能显示 `Tmds.DBus.Protocol` 的 NuGet advisory warning。该依赖来自 Avalonia 桌面包的跨平台传递依赖；macOS 发布产物可构建运行，但发布前仍应按团队安全策略评估或升级 Avalonia。
+macOS 桌面项目当前使用 Avalonia 12.0.4。ad-hoc 签名不等同于 Apple Developer ID 签名或公证。
+
+项目目前提供 macOS 构建脚本，GitHub Releases 中没有预构建的 macOS 产物，请使用上述命令在本地构建。


### PR DESCRIPTION
## Summary

- add a dedicated English macOS GUI guide for Apple Silicon and Intel builds
- document GUI features, managed backups, safety boundaries, write-operation precautions, and current self-build distribution status
- add English macOS guide links to the root and English READMEs
- update the Chinese macOS guide for Avalonia 12.0.4 and remove the obsolete Avalonia 11.3.x advisory note

## Why

The existing macOS GUI guide was available only in Chinese, so English-speaking macOS users had no complete build and operation reference. This addresses the documentation request and incorporates the confirmed Apple Silicon/Avalonia 12 context from the issue.

## Validation

- relative Markdown link check: passed for all four changed documentation files
- `npm test`: 80/80 passed
- Core tests: 71/71 passed
- Windows App tests: 15/15 passed
- macOS project vulnerable-package scan: no known vulnerable packages

Fixes #59