### PR TITLE
release: prepare v0.3.2

### DIFF
--- a/desktop/CodexProviderSync.App/CodexProviderSync.App.csproj
+++ b/desktop/CodexProviderSync.App/CodexProviderSync.App.csproj
@@ -13,9 +13,9 @@
     <AssemblyName>CodexProviderSync</AssemblyName>
     <Product>Codex Provider Sync</Product>
     <Company>Dailin521</Company>
-    <Version>0.3.1</Version>
-    <AssemblyVersion>0.3.1.0</AssemblyVersion>
-    <FileVersion>0.3.1.0</FileVersion>
+    <Version>0.3.2</Version>
+    <AssemblyVersion>0.3.2.0</AssemblyVersion>
+    <FileVersion>0.3.2.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/desktop/CodexProviderSync.Core/CodexProviderSync.Core.csproj
+++ b/desktop/CodexProviderSync.Core/CodexProviderSync.Core.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.3.1</Version>
-    <AssemblyVersion>0.3.1.0</AssemblyVersion>
-    <FileVersion>0.3.1.0</FileVersion>
+    <Version>0.3.2</Version>
+    <AssemblyVersion>0.3.2.0</AssemblyVersion>
+    <FileVersion>0.3.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj
+++ b/desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj
@@ -17,9 +17,9 @@
     <AssemblyName>CodexProviderSync</AssemblyName>
     <Product>Codex Provider Sync</Product>
     <Company>Dailin521</Company>
-    <Version>0.3.1</Version>
-    <AssemblyVersion>0.3.1.0</AssemblyVersion>
-    <FileVersion>0.3.1.0</FileVersion>
+    <Version>0.3.2</Version>
+    <AssemblyVersion>0.3.2.0</AssemblyVersion>
+    <FileVersion>0.3.2.0</FileVersion>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-provider-sync",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-provider-sync",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "bin": {
         "codex-provider": "src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-provider-sync",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Synchronize Codex session provider metadata across rollout files and SQLite state.",
   "type": "module",
   "files": [

--- a/scripts/publish-gui-macos.sh
+++ b/scripts/publish-gui-macos.sh
@@ -91,9 +91,9 @@ cat > "$contents_dir/Info.plist" <<'EOF'
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.3.1</string>
+  <string>0.3.2</string>
   <key>CFBundleVersion</key>
-  <string>0.3.1</string>
+  <string>0.3.2</string>
   <key>LSMinimumSystemVersion</key>
   <string>12.0</string>
   <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
## Summary

- bump the npm package version to `0.3.2`
- bump Core, Windows GUI, and macOS GUI assembly/file versions to `0.3.2`
- update the generated macOS bundle version to `0.3.2`

## Release contents

- upgrade the shared native SQLite bundle to `SQLitePCLRaw.bundle_e_sqlite3 2.1.12`, resolving `GHSA-2m69-gcr7-jv3q` / `CVE-2025-6965`
- harden macOS ad-hoc signing in File-Provider-managed workspaces
- add an English macOS GUI guide and refresh the documentation
- exclude the still-pending independent SQLite Home work from #55

## Validation

- `npm ci`: passed
- `npm audit --omit=dev`: 0 vulnerabilities
- `npm test`: 80/80 passed
- Core Release tests: 71/71 passed
- Windows App Release tests: 15/15 passed
- macOS project vulnerable-package scan: no known vulnerable packages
- Windows self-contained single-file candidate: built successfully
- candidate ProductVersion: `0.3.2+c4af146166f7db9393e39d821c84ac2fc0ac6ce0`
- candidate ZIP and SHA-256 manifest: verified
- Windows GUI status/read/write regression test: passed on a real local Codex Home