### PR TITLE
ci: add stable required-check gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -46,3 +49,25 @@ jobs:
           dotnet-version: "10.0.x"
       - run: dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
       - run: dotnet build desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj --configuration Release
+
+  ci-gate:
+    name: ci-gate
+    if: ${{ always() }}
+    needs:
+      - test
+      - desktop-test
+      - desktop-macos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          NODE_TEST_RESULT: ${{ needs.test.result }}
+          DESKTOP_TEST_RESULT: ${{ needs.desktop-test.result }}
+          MACOS_TEST_RESULT: ${{ needs.desktop-macos.result }}
+        run: |
+          if [ "$NODE_TEST_RESULT" != "success" ] ||
+             [ "$DESKTOP_TEST_RESULT" != "success" ] ||
+             [ "$MACOS_TEST_RESULT" != "success" ]; then
+            echo "One or more required CI jobs did not succeed."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- add an explicit `contents: read` permission boundary to the normal CI workflow
- add a stable `ci-gate` job that waits for the Node matrix, Windows desktop tests, and macOS build validation
- fail the gate when any required job fails, is cancelled, or is skipped

## Why

The future `main` ruleset needs one stable required check. Binding branch protection directly to every matrix-generated check name is fragile when operating systems, Node versions, or job names change.

## Impact

No application or release behavior changes. Once this PR is merged and `ci-gate` succeeds on `main`, the branch ruleset can require `ci-gate` with GitHub Actions as its expected source.

## Validation

- `git diff --check`
- workflow scope reviewed locally
- GitHub Actions on this PR is the authoritative cross-platform validation