### PR TITLE
ci: harden release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           - "16"
           - "24"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -33,8 +33,8 @@ jobs:
   desktop-test:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0.x"
       - run: dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
@@ -43,8 +43,8 @@ jobs:
   desktop-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0.x"
       - run: dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,20 +5,34 @@ on:
     tags:
       - "v*"
 
-jobs:
-  publish:
-    runs-on: windows-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
+permissions:
+  contents: read
 
-      - uses: actions/setup-node@v4
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify release tag commit is on main
+        shell: pwsh
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$env:GITHUB_SHA" "refs/remotes/origin/main"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release tags must point to a commit contained in main."
+            exit 1
+          }
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: npm
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0.x"
 
@@ -52,11 +66,32 @@ jobs:
           }
           Set-Content -LiteralPath (Join-Path $assetRoot "checksums.txt") -Value $checksums -Encoding ASCII
 
+      - name: Upload packaged assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-assets
+          path: artifacts/release/*
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download packaged assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-assets
+          path: artifacts/release
+
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
             artifacts/release/*
+          fail_on_unmatched_files: true
           body: |
             ## Windows SmartScreen 提示
             当前 Windows GUI 未做代码签名，首次运行时可能提示“发布者未知”或“Windows 已保护你的电脑”。这是未签名 EXE 的常见提示。


### PR DESCRIPTION
## What changed

- pin every Action used by CI and publishing to a full commit SHA, with version comments
- move CI actions to Node 24-based releases to remove the Node 20 runtime deprecation warning
- make workflow-level permissions read-only by default
- split release building from GitHub Release publication
- keep `contents: write` only in the final release job
- disable persisted checkout credentials in the build job
- reject release tags whose commit is not contained in `main`
- transfer packaged assets between jobs through a one-day GitHub Actions artifact
- fail release publication when no packaged assets are found

## Why

The previous publish job held `contents: write` while checking out code, installing tools, testing, and building. It also followed mutable major-version Action tags. A compromised dependency or moved Action tag therefore had a larger-than-needed release token and could affect published assets.

## Security boundary

The build and test job now runs with `contents: read`. Only the small release job receives `contents: write`, and the actions in that job are pinned to reviewed commits. A release tag must resolve to a commit already contained in `main`.

## Validation

- YAML parsing passed for both workflows
- tag ancestry guard accepted `main` and rejected an unmerged branch commit
- `npm test`: 100 passed
- Core tests: 88 passed, 1 expected WSL-only skip
- Windows App tests: 18 passed
- Windows single-file GUI build succeeded
- all pinned SHAs were resolved from the latest official Action release tags and use the Node 24 runtime

## Follow-up

After this PR is merged and the `main` push CI succeeds, create a separate `v*` Tag Ruleset. Do not create a test `v*` tag because it would trigger the real publish workflow.