### PR TITLE
fix: stabilize switching, window restore, and releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,12 @@ jobs:
           node-version: "24"
           cache: npm
 
+      - name: Verify release version consistency
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: node scripts/verify-release-version.js --tag $env:RELEASE_TAG
+
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0.x"

--- a/desktop/CodexProviderSync.App.Tests/WindowPlacementPolicyTests.cs
+++ b/desktop/CodexProviderSync.App.Tests/WindowPlacementPolicyTests.cs
@@ -1,0 +1,168 @@
+using System.Drawing;
+using System.Windows.Forms;
+using CodexProviderSync.Core;
+
+namespace CodexProviderSync.App.Tests;
+
+public sealed class WindowPlacementPolicyTests
+{
+    private static readonly Rectangle PrimaryWorkingArea = new(0, 0, 1920, 1040);
+    private static readonly Size DefaultSize = new(1280, 820);
+    private static readonly Size MinimumSavedSize = new(800, 600);
+
+    [Fact]
+    public void Restore_RecentersBoundsWhenOnlyATinyHorizontalSliverIsVisible()
+    {
+        WindowBoundsState saved = Bounds(1910, 100, 1280, 820);
+
+        WindowPlacement placement = Restore(saved, [PrimaryWorkingArea]);
+
+        Assert.Equal(new Rectangle(320, 110, 1280, 820), placement.Bounds);
+        Assert.False(placement.Maximized);
+    }
+
+    [Fact]
+    public void Restore_PreservesBoundsWhenAUsablePartOfTheTitleBarIsVisible()
+    {
+        WindowBoundsState saved = Bounds(1800, 100, 1280, 820);
+
+        WindowPlacement placement = Restore(saved, [PrimaryWorkingArea]);
+
+        Assert.Equal(new Rectangle(1800, 100, 1280, 820), placement.Bounds);
+        Assert.False(placement.Maximized);
+    }
+
+    [Fact]
+    public void Restore_RecentersBoundsWhenContentIsVisibleButTheTitleBarIsOffscreen()
+    {
+        WindowBoundsState saved = Bounds(100, -100, 1200, 800);
+
+        WindowPlacement placement = Restore(saved, [PrimaryWorkingArea]);
+
+        Assert.Equal(new Rectangle(360, 120, 1200, 800), placement.Bounds);
+        Assert.False(placement.Maximized);
+    }
+
+    [Fact]
+    public void Restore_PreservesBoundsOnANegativeCoordinateDisplay()
+    {
+        Rectangle secondaryWorkingArea = new(-1600, 0, 1600, 860);
+        WindowBoundsState saved = Bounds(-1500, 40, 1200, 760);
+
+        WindowPlacement placement = Restore(saved, [PrimaryWorkingArea, secondaryWorkingArea]);
+
+        Assert.Equal(new Rectangle(-1500, 40, 1200, 760), placement.Bounds);
+    }
+
+    [Fact]
+    public void Restore_RecentersBoundsWhenTheirSecondaryDisplayWasRemoved()
+    {
+        WindowBoundsState saved = Bounds(2100, 100, 1200, 800);
+
+        WindowPlacement placement = Restore(saved, [PrimaryWorkingArea]);
+
+        Assert.Equal(new Rectangle(360, 120, 1200, 800), placement.Bounds);
+        Assert.False(placement.Maximized);
+    }
+
+    [Fact]
+    public void Restore_RecentersNormalBoundsBeforeRestoringMaximizedState()
+    {
+        WindowBoundsState saved = Bounds(2100, 100, 1200, 800, maximized: true);
+
+        WindowPlacement placement = Restore(saved, [PrimaryWorkingArea]);
+
+        Assert.Equal(new Rectangle(360, 120, 1200, 800), placement.Bounds);
+        Assert.True(placement.Maximized);
+    }
+
+    [Fact]
+    public void Restore_FitsRecoveredBoundsToASmallerCurrentDisplay()
+    {
+        Rectangle smallerWorkingArea = new(0, 0, 1440, 800);
+        WindowBoundsState saved = Bounds(2000, 0, 1600, 900);
+
+        WindowPlacement placement = Restore(saved, [smallerWorkingArea], smallerWorkingArea);
+
+        Assert.Equal(smallerWorkingArea, placement.Bounds);
+    }
+
+    [Fact]
+    public void Restore_UsesCenteredDefaultForMissingOrInvalidSettings()
+    {
+        WindowPlacement missing = Restore(null, [PrimaryWorkingArea]);
+        WindowPlacement invalid = Restore(Bounds(100, 100, 799, 599), [PrimaryWorkingArea]);
+
+        Rectangle expected = new(320, 110, 1280, 820);
+        Assert.Equal(expected, missing.Bounds);
+        Assert.Equal(expected, invalid.Bounds);
+        Assert.False(missing.Maximized);
+        Assert.False(invalid.Maximized);
+    }
+
+    [Theory]
+    [InlineData(FormWindowState.Minimized, false)]
+    [InlineData(FormWindowState.Maximized, true)]
+    public void Capture_UsesRestoreBoundsForNonNormalStates(
+        FormWindowState state,
+        bool expectedMaximized)
+    {
+        Rectangle current = new(0, 0, 1920, 1040);
+        Rectangle restore = new(200, 120, 1280, 820);
+
+        WindowBoundsState captured = WindowPlacementPolicy.Capture(current, restore, state);
+
+        Assert.Equal(restore.X, captured.X);
+        Assert.Equal(restore.Y, captured.Y);
+        Assert.Equal(restore.Width, captured.Width);
+        Assert.Equal(restore.Height, captured.Height);
+        Assert.Equal(expectedMaximized, captured.Maximized);
+    }
+
+    [Fact]
+    public void Capture_UsesCurrentBoundsForNormalState()
+    {
+        Rectangle current = new(300, 180, 1180, 760);
+
+        WindowBoundsState captured = WindowPlacementPolicy.Capture(
+            current,
+            new Rectangle(10, 10, 800, 600),
+            FormWindowState.Normal);
+
+        Assert.Equal(current.X, captured.X);
+        Assert.Equal(current.Y, captured.Y);
+        Assert.Equal(current.Width, captured.Width);
+        Assert.Equal(current.Height, captured.Height);
+        Assert.False(captured.Maximized);
+    }
+
+    private static WindowPlacement Restore(
+        WindowBoundsState? saved,
+        IReadOnlyList<Rectangle> workingAreas,
+        Rectangle? fallbackWorkingArea = null)
+    {
+        return WindowPlacementPolicy.Restore(
+            saved,
+            workingAreas,
+            fallbackWorkingArea ?? PrimaryWorkingArea,
+            DefaultSize,
+            MinimumSavedSize);
+    }
+
+    private static WindowBoundsState Bounds(
+        int x,
+        int y,
+        int width,
+        int height,
+        bool maximized = false)
+    {
+        return new WindowBoundsState
+        {
+            X = x,
+            Y = y,
+            Width = width,
+            Height = height,
+            Maximized = maximized
+        };
+    }
+}

--- a/desktop/CodexProviderSync.App/MainForm.cs
+++ b/desktop/CodexProviderSync.App/MainForm.cs
@@ -1285,28 +1285,23 @@ public sealed class MainForm : Form
 
     private WindowBoundsState CaptureWindowBounds()
     {
-        Rectangle bounds = WindowState == FormWindowState.Normal ? Bounds : RestoreBounds;
-        return new WindowBoundsState
-        {
-            X = bounds.X,
-            Y = bounds.Y,
-            Width = bounds.Width,
-            Height = bounds.Height,
-            Maximized = WindowState == FormWindowState.Maximized
-        };
+        return WindowPlacementPolicy.Capture(Bounds, RestoreBounds, WindowState);
     }
 
     private void ApplyWindowBounds(WindowBoundsState? bounds)
     {
-        if (bounds is null || bounds.Width < 800 || bounds.Height < 600)
-        {
-            Size = new Size(1280, 820);
-            return;
-        }
-
+        Rectangle[] workingAreas = Screen.AllScreens.Select(screen => screen.WorkingArea).ToArray();
+        Rectangle fallbackWorkingArea = Screen.PrimaryScreen?.WorkingArea
+            ?? workingAreas.FirstOrDefault();
+        WindowPlacement placement = WindowPlacementPolicy.Restore(
+            bounds,
+            workingAreas,
+            fallbackWorkingArea,
+            defaultSize: new Size(1280, 820),
+            minimumSavedSize: new Size(800, 600));
         StartPosition = FormStartPosition.Manual;
-        Bounds = new Rectangle(bounds.X, bounds.Y, bounds.Width, bounds.Height);
-        if (bounds.Maximized)
+        Bounds = placement.Bounds;
+        if (placement.Maximized)
         {
             WindowState = FormWindowState.Maximized;
         }

--- a/desktop/CodexProviderSync.App/WindowPlacementPolicy.cs
+++ b/desktop/CodexProviderSync.App/WindowPlacementPolicy.cs
@@ -1,0 +1,108 @@
+using CodexProviderSync.Core;
+
+namespace CodexProviderSync.App;
+
+internal readonly record struct WindowPlacement(Rectangle Bounds, bool Maximized);
+
+internal static class WindowPlacementPolicy
+{
+    private const int TitleBarProbeHeight = 32;
+    private const int MinimumVisibleTitleBarWidth = 120;
+    private const int MinimumVisibleTitleBarHeight = 24;
+
+    internal static WindowBoundsState Capture(
+        Rectangle currentBounds,
+        Rectangle restoreBounds,
+        FormWindowState windowState)
+    {
+        Rectangle bounds = windowState == FormWindowState.Normal ? currentBounds : restoreBounds;
+        return new WindowBoundsState
+        {
+            X = bounds.X,
+            Y = bounds.Y,
+            Width = bounds.Width,
+            Height = bounds.Height,
+            Maximized = windowState == FormWindowState.Maximized
+        };
+    }
+
+    internal static WindowPlacement Restore(
+        WindowBoundsState? saved,
+        IReadOnlyList<Rectangle> workingAreas,
+        Rectangle fallbackWorkingArea,
+        Size defaultSize,
+        Size minimumSavedSize)
+    {
+        Rectangle safeWorkingArea = NormalizeWorkingArea(fallbackWorkingArea, defaultSize);
+        bool hasValidSavedSize = saved is not null
+            && saved.Width >= minimumSavedSize.Width
+            && saved.Height >= minimumSavedSize.Height;
+
+        if (!hasValidSavedSize)
+        {
+            return new WindowPlacement(CenterAndFit(defaultSize, safeWorkingArea), Maximized: false);
+        }
+
+        Rectangle savedBounds = new(saved!.X, saved.Y, saved.Width, saved.Height);
+        if (workingAreas.Any(area => HasUsableVisibleTitleBar(savedBounds, area)))
+        {
+            return new WindowPlacement(savedBounds, saved.Maximized);
+        }
+
+        // A previously attached display may no longer exist. Keep the user's
+        // normal window size where possible, but move it onto the current
+        // primary display before applying a saved maximized state.
+        Rectangle recoveredBounds = CenterAndFit(savedBounds.Size, safeWorkingArea);
+        return new WindowPlacement(recoveredBounds, saved.Maximized);
+    }
+
+    private static bool HasUsableVisibleTitleBar(Rectangle windowBounds, Rectangle workingArea)
+    {
+        if (workingArea.Width <= 0 || workingArea.Height <= 0)
+        {
+            return false;
+        }
+
+        // A few visible content pixels are not enough to recover a window: the
+        // user needs a usable section of the title bar to drag it back. Use
+        // Int64 arithmetic so malformed settings near Int32 limits cannot
+        // overflow while calculating either rectangle.
+        long windowRight = (long)windowBounds.X + windowBounds.Width;
+        long areaRight = (long)workingArea.X + workingArea.Width;
+        long areaBottom = (long)workingArea.Y + workingArea.Height;
+        long titleBarBottom = Math.Min(
+            (long)windowBounds.Y + windowBounds.Height,
+            (long)windowBounds.Y + TitleBarProbeHeight);
+
+        long visibleWidth = Math.Min(windowRight, areaRight)
+            - Math.Max((long)windowBounds.X, workingArea.X);
+        long visibleHeight = Math.Min(titleBarBottom, areaBottom)
+            - Math.Max((long)windowBounds.Y, workingArea.Y);
+
+        return visibleWidth >= MinimumVisibleTitleBarWidth
+            && visibleHeight >= MinimumVisibleTitleBarHeight;
+    }
+
+    private static Rectangle CenterAndFit(Size requestedSize, Rectangle workingArea)
+    {
+        int width = Math.Min(Math.Max(1, requestedSize.Width), workingArea.Width);
+        int height = Math.Min(Math.Max(1, requestedSize.Height), workingArea.Height);
+        int x = workingArea.X + ((workingArea.Width - width) / 2);
+        int y = workingArea.Y + ((workingArea.Height - height) / 2);
+        return new Rectangle(x, y, width, height);
+    }
+
+    private static Rectangle NormalizeWorkingArea(Rectangle workingArea, Size defaultSize)
+    {
+        if (workingArea.Width > 0 && workingArea.Height > 0)
+        {
+            return workingArea;
+        }
+
+        return new Rectangle(
+            0,
+            0,
+            Math.Max(1, defaultSize.Width),
+            Math.Max(1, defaultSize.Height));
+    }
+}

--- a/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreIntegrationTests.cs
@@ -252,6 +252,67 @@ public sealed class CoreIntegrationTests
     }
 
     [Fact]
+    public async Task RunSwitch_BackupCapturesPreSwitchProviderAndModel()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"gpt-5.4-mini\"");
+        string configPath = Path.Combine(fixture.CodexHome, "config.toml");
+        string originalConfig = await File.ReadAllTextAsync(configPath);
+
+        SyncResult result = await new CodexSyncService().RunSwitchAsync(
+            fixture.CodexHome,
+            "apigather",
+            model: "apigather-prod");
+
+        Assert.Equal(
+            originalConfig,
+            await File.ReadAllTextAsync(Path.Combine(result.BackupDir, "config.toml")));
+        string switchedConfig = await File.ReadAllTextAsync(configPath);
+        Assert.Contains("model_provider = \"apigather\"", switchedConfig);
+        Assert.Contains("model = \"apigather-prod\"", switchedConfig);
+    }
+
+    [Fact]
+    public async Task RunSwitch_DoesNotTouchConfig_WhenPreSwitchBackupCreationFails()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"gpt-5.4-mini\"");
+        string configPath = Path.Combine(fixture.CodexHome, "config.toml");
+        string originalConfig = await File.ReadAllTextAsync(configPath);
+        DateTime pinnedLastWriteTime = new(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(configPath, pinnedLastWriteTime);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(fixture.BackupRoot())!);
+        await File.WriteAllTextAsync(fixture.BackupRoot(), "blocks backup directory creation");
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => new CodexSyncService().RunSwitchAsync(fixture.CodexHome, "apigather"));
+        Assert.Equal(originalConfig, await File.ReadAllTextAsync(configPath));
+        Assert.Equal(pinnedLastWriteTime, File.GetLastWriteTimeUtc(configPath));
+    }
+
+    [Fact]
+    public async Task RunSwitch_RestoresConfig_AfterPostBackupSyncFailure()
+    {
+        TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();
+        await fixture.WriteConfigAsync("model_provider = \"openai\"\nmodel = \"gpt-5.4-mini\"");
+        string configPath = Path.Combine(fixture.CodexHome, "config.toml");
+        string originalConfig = await File.ReadAllTextAsync(configPath);
+        await File.WriteAllTextAsync(
+            Path.Combine(fixture.CodexHome, AppConstants.GlobalStateFileBasename),
+            "{not-json");
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => new CodexSyncService().RunSwitchAsync(fixture.CodexHome, "apigather"));
+        Assert.Equal(originalConfig, await File.ReadAllTextAsync(configPath));
+
+        string backupDir = Assert.Single(Directory.GetDirectories(fixture.BackupRoot()));
+        Assert.Equal(
+            originalConfig,
+            await File.ReadAllTextAsync(Path.Combine(backupDir, "config.toml")));
+    }
+
+    [Fact]
     public async Task RunSync_RepairsSqliteHasUserEventFromRolloutUserMessages()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();

--- a/desktop/CodexProviderSync.Core/CodexSyncService.cs
+++ b/desktop/CodexProviderSync.Core/CodexSyncService.cs
@@ -104,7 +104,7 @@ public sealed class CodexSyncService
         return _providerDiscoveryService.ExtractDetectedProviderIds(status);
     }
 
-    public async Task<SyncResult> RunSyncAsync(
+    public Task<SyncResult> RunSyncAsync(
         string? explicitCodexHome = null,
         string? provider = null,
         string? configBackupText = null,
@@ -112,6 +112,27 @@ public sealed class CodexSyncService
         int? sqliteBusyTimeoutMs = null,
         string? model = null,
         string? explicitSqliteHome = null)
+    {
+        return RunSyncCoreAsync(
+            explicitCodexHome,
+            provider,
+            configBackupText,
+            keepCount,
+            sqliteBusyTimeoutMs,
+            model,
+            explicitSqliteHome,
+            afterBackup: null);
+    }
+
+    private async Task<SyncResult> RunSyncCoreAsync(
+        string? explicitCodexHome,
+        string? provider,
+        string? configBackupText,
+        int keepCount,
+        int? sqliteBusyTimeoutMs,
+        string? model,
+        string? explicitSqliteHome,
+        Func<string, Task>? afterBackup)
     {
         if (keepCount < 1)
         {
@@ -159,6 +180,10 @@ public sealed class CodexSyncService
 
         await _sqliteStateService.AssertSqliteWritableAsync(storage, sqliteBusyTimeoutMs);
         string backupDir = await _backupService.CreateBackupAsync(storage, targetProvider, writableChanges, configPath, configBackupText);
+        if (afterBackup is not null)
+        {
+            await afterBackup(backupDir);
+        }
 
         bool sessionRestoreNeeded = false;
         List<SessionChange> appliedSessionChanges = [];
@@ -305,8 +330,7 @@ public sealed class CodexSyncService
             nextConfigText = _configFileService.SetRootModelInConfigText(nextConfigText, modelSync.Model!);
         }
 
-        await _configFileService.WriteConfigTextAsync(configPath, nextConfigText);
-
+        bool configMutationAttempted = false;
         try
         {
             // Even when the switch keeps the existing root model, keep
@@ -314,13 +338,19 @@ public sealed class CodexSyncService
             string? modelForThreads = modelSync.Applied
                 ? modelSync.Model
                 : _configFileService.ReadRootModelFromConfigText(nextConfigText);
-            SyncResult result = await RunSyncAsync(
+            SyncResult result = await RunSyncCoreAsync(
                 codexHome,
                 provider,
                 originalConfigText,
                 keepCount,
+                sqliteBusyTimeoutMs: null,
                 model: modelForThreads,
-                explicitSqliteHome: explicitSqliteHome);
+                explicitSqliteHome: explicitSqliteHome,
+                afterBackup: async _ =>
+                {
+                    configMutationAttempted = true;
+                    await _configFileService.WriteConfigTextAsync(configPath, nextConfigText);
+                });
             return new SyncResult
             {
                 CodexHome = result.CodexHome,
@@ -351,7 +381,10 @@ public sealed class CodexSyncService
         }
         catch
         {
-            await _configFileService.WriteConfigTextAsync(configPath, originalConfigText);
+            if (configMutationAttempted)
+            {
+                await _configFileService.WriteConfigTextAsync(configPath, originalConfigText);
+            }
             throw;
         }
     }

--- a/scripts/verify-release-version.js
+++ b/scripts/verify-release-version.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+
+const VERSION_PROPERTIES = ["Version", "AssemblyVersion", "FileVersion"];
+
+function parseSemanticVersion(value, source) {
+  const match = SEMVER_PATTERN.exec(value);
+  if (!match) {
+    throw new Error(`${source} must be a valid semantic version; received ${JSON.stringify(value)}.`);
+  }
+
+  return {
+    value,
+    numericVersion: `${match[1]}.${match[2]}.${match[3]}`,
+  };
+}
+
+function parseReleaseTag(tag) {
+  if (typeof tag !== "string" || !tag.startsWith("v")) {
+    throw new Error(`Release tag must use the form v<semver>; received ${JSON.stringify(tag)}.`);
+  }
+
+  return parseSemanticVersion(tag.slice(1), "Release tag");
+}
+
+function collectProjectFiles(directory) {
+  const projects = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      projects.push(...collectProjectFiles(entryPath));
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".csproj")) {
+      projects.push(entryPath);
+    }
+  }
+
+  return projects;
+}
+
+function isTestProject(relativeProjectPath, projectXml) {
+  const normalizedPath = relativeProjectPath.replaceAll("\\", "/");
+  return (
+    /(?:^|[./_-])tests?(?:[./_-]|$)/i.test(normalizedPath) ||
+    /<IsTestProject\b[^>]*>\s*true\s*<\/IsTestProject>/i.test(projectXml) ||
+    /<PackageReference\b[^>]*\bInclude\s*=\s*["']Microsoft\.NET\.Test\.Sdk["']/i.test(projectXml)
+  );
+}
+
+function readPropertyValues(projectXml, propertyName) {
+  const xmlWithoutComments = projectXml.replace(/<!--[\s\S]*?-->/g, "");
+  const expression = new RegExp(
+    `<${propertyName}\\b[^>]*>([\\s\\S]*?)<\\/${propertyName}\\s*>`,
+    "gi",
+  );
+
+  return [...xmlWithoutComments.matchAll(expression)].map((match) => match[1].trim());
+}
+
+function displayPath(rootDir, targetPath) {
+  return path.relative(rootDir, targetPath).replaceAll("\\", "/");
+}
+
+export function verifyReleaseVersion({ rootDir, tag }) {
+  const release = parseReleaseTag(tag);
+  const errors = [];
+
+  const packageJsonPath = path.join(rootDir, "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  const packageVersion = packageJson.version;
+
+  try {
+    parseSemanticVersion(packageVersion, "package.json version");
+  } catch (error) {
+    errors.push(error.message);
+  }
+
+  if (packageVersion !== release.value) {
+    errors.push(
+      `package.json version is ${JSON.stringify(packageVersion)}; expected ${JSON.stringify(release.value)} from tag ${tag}.`,
+    );
+  }
+
+  const packageLockPath = path.join(rootDir, "package-lock.json");
+  const packageLock = JSON.parse(fs.readFileSync(packageLockPath, "utf8"));
+  const packageLockVersions = [
+    ["package-lock.json version", packageLock.version],
+    ['package-lock.json packages[""].version', packageLock.packages?.[""]?.version],
+  ];
+
+  for (const [source, value] of packageLockVersions) {
+    if (value !== release.value) {
+      errors.push(
+        `${source} is ${JSON.stringify(value)}; expected ${JSON.stringify(release.value)} from tag ${tag}.`,
+      );
+    }
+  }
+
+  const desktopDirectory = path.join(rootDir, "desktop");
+  const shippedProjects = collectProjectFiles(desktopDirectory)
+    .map((projectPath) => ({
+      projectPath,
+      projectXml: fs.readFileSync(projectPath, "utf8"),
+    }))
+    .filter(
+      ({ projectPath, projectXml }) =>
+        !isTestProject(path.relative(desktopDirectory, projectPath), projectXml),
+    )
+    .sort((left, right) => left.projectPath.localeCompare(right.projectPath));
+
+  if (shippedProjects.length === 0) {
+    errors.push("No shipped .csproj files were found under desktop/.");
+  }
+
+  const expectedValues = {
+    Version: release.value,
+    AssemblyVersion: `${release.numericVersion}.0`,
+    FileVersion: `${release.numericVersion}.0`,
+  };
+
+  for (const { projectPath, projectXml } of shippedProjects) {
+    const projectDisplayPath = displayPath(rootDir, projectPath);
+
+    for (const propertyName of VERSION_PROPERTIES) {
+      const values = readPropertyValues(projectXml, propertyName);
+      const expectedValue = expectedValues[propertyName];
+
+      if (values.length === 0) {
+        errors.push(`${projectDisplayPath} does not declare <${propertyName}>${expectedValue}</${propertyName}>.`);
+        continue;
+      }
+
+      for (const value of values) {
+        if (value !== expectedValue) {
+          errors.push(
+            `${projectDisplayPath} declares <${propertyName}>${value}</${propertyName}>; expected ${expectedValue}.`,
+          );
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Release version consistency check failed:\n- ${errors.join("\n- ")}`);
+  }
+
+  return {
+    tag,
+    version: release.value,
+    projects: shippedProjects.map(({ projectPath }) => displayPath(rootDir, projectPath)),
+  };
+}
+
+function parseArguments(argumentsList) {
+  if (argumentsList.length !== 2 || argumentsList[0] !== "--tag" || !argumentsList[1]) {
+    throw new Error("Usage: node scripts/verify-release-version.js --tag v<semver>");
+  }
+
+  return { tag: argumentsList[1] };
+}
+
+function main() {
+  try {
+    const { tag } = parseArguments(process.argv.slice(2));
+    const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+    const result = verifyReleaseVersion({
+      rootDir: path.resolve(scriptDirectory, ".."),
+      tag,
+    });
+    console.log(
+      `Release version check passed: ${result.tag} matches the npm manifests and ${result.projects.length} shipped .csproj files.`,
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+const isDirectInvocation =
+  process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isDirectInvocation) {
+  main();
+}

--- a/src/service.js
+++ b/src/service.js
@@ -225,7 +225,11 @@ export function renderStatus(status) {
   return lines.join("\n");
 }
 
-export async function runSync({
+export async function runSync(options = {}) {
+  return runSyncCore(options);
+}
+
+async function runSyncCore({
   codexHome: explicitCodexHome,
   sqliteHome,
   storage: providedStorage,
@@ -236,7 +240,7 @@ export async function runSync({
   onProgress,
   model = null,
   platform
-} = {}) {
+} = {}, { afterBackup } = {}) {
   if (!Number.isInteger(keepCount) || keepCount < 1) {
     throw new Error(`Invalid automatic keep count: ${keepCount}. Expected an integer greater than or equal to 1.`);
   }
@@ -313,6 +317,10 @@ export async function runSync({
       backupDir,
       durationMs: backupDurationMs
     });
+
+    if (typeof afterBackup === "function") {
+      await afterBackup(backupDir);
+    }
 
     let sessionRestoreNeeded = false;
     let appliedSessionChanges = [];
@@ -488,44 +496,52 @@ export async function runSwitch({
     }
   }
 
-  emitProgress(onProgress, {
-    stage: "update_config",
-    status: "start",
-    provider
-  });
-  await writeConfigText(configPath, nextConfigText);
-  emitProgress(onProgress, {
-    stage: "update_config",
-    status: "complete",
-    provider
-  });
-
+  let configMutationAttempted = false;
   try {
-    // After the config update, `nextConfigText` has the final root-level
-    // `model` value. We use that to drive the per-thread `model` column
-    // rewrite so old sessions pick up the same model that new ones will.
+    // `nextConfigText` has the final root-level `model` value. Use that to
+    // drive the per-thread rewrite so old sessions match new sessions.
     let modelForThreads = null;
     if (modelSync.applied && modelSync.model) {
       modelForThreads = modelSync.model;
     } else {
       modelForThreads = readRootModelFromConfigText(nextConfigText);
     }
-    const syncResult = await runSync({
-      codexHome,
-      storage,
-      provider,
-      configBackupText: originalConfigText,
-      keepCount,
-      onProgress,
-      model: modelForThreads
-    });
+    const syncResult = await runSyncCore(
+      {
+        codexHome,
+        storage,
+        provider,
+        configBackupText: originalConfigText,
+        keepCount,
+        onProgress,
+        model: modelForThreads
+      },
+      {
+        afterBackup: async () => {
+          emitProgress(onProgress, {
+            stage: "update_config",
+            status: "start",
+            provider
+          });
+          configMutationAttempted = true;
+          await writeConfigText(configPath, nextConfigText);
+          emitProgress(onProgress, {
+            stage: "update_config",
+            status: "complete",
+            provider
+          });
+        }
+      }
+    );
     return {
       ...syncResult,
       configUpdated: true,
       modelSync
     };
   } catch (error) {
-    await writeConfigText(configPath, originalConfigText);
+    if (configMutationAttempted) {
+      await writeConfigText(configPath, originalConfigText);
+    }
     throw error;
   }
 }

--- a/test/release-version.test.js
+++ b/test/release-version.test.js
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { verifyReleaseVersion } from "../scripts/verify-release-version.js";
+
+function createFixture({ packageVersion = "1.2.3", projects = [] } = {}) {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "release-version-"));
+
+  fs.mkdirSync(path.join(rootDir, "desktop"), { recursive: true });
+  fs.writeFileSync(
+    path.join(rootDir, "package.json"),
+    `${JSON.stringify({ name: "fixture", version: packageVersion }, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "package-lock.json"),
+    `${JSON.stringify(
+      {
+        name: "fixture",
+        version: packageVersion,
+        lockfileVersion: 3,
+        packages: { "": { name: "fixture", version: packageVersion } },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  for (const project of projects) {
+    const projectPath = path.join(rootDir, "desktop", project.path);
+    fs.mkdirSync(path.dirname(projectPath), { recursive: true });
+    fs.writeFileSync(projectPath, project.xml);
+  }
+
+  return rootDir;
+}
+
+function withFixture(options, operation) {
+  const rootDir = createFixture(options);
+  try {
+    return operation(rootDir);
+  } finally {
+    fs.rmSync(rootDir, { force: true, recursive: true });
+  }
+}
+
+function createProjectXml({
+  version = "1.2.3",
+  assemblyVersion = "1.2.3.0",
+  fileVersion = "1.2.3.0",
+} = {}) {
+  return `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>${version}</Version>
+    <AssemblyVersion>${assemblyVersion}</AssemblyVersion>
+    <FileVersion>${fileVersion}</FileVersion>
+  </PropertyGroup>
+</Project>
+`;
+}
+
+test("current repository versions match an explicit tag", () => {
+  const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+  const rootDir = path.resolve(testDirectory, "..");
+  const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, "package.json"), "utf8"));
+
+  const result = verifyReleaseVersion({ rootDir, tag: `v${packageJson.version}` });
+
+  assert.deepEqual(result.projects, [
+    "desktop/CodexProviderSync.App/CodexProviderSync.App.csproj",
+    "desktop/CodexProviderSync.Core/CodexProviderSync.Core.csproj",
+    "desktop/CodexProviderSync.Mac/CodexProviderSync.Mac.csproj",
+  ]);
+});
+
+test("validates every discovered shipped project and ignores test projects", () =>
+  withFixture(
+    {
+      projects: [
+        { path: "Product/Product.csproj", xml: createProjectXml() },
+        { path: "NewGui/NewGui.csproj", xml: createProjectXml() },
+        {
+          path: "Product.Tests/Product.Tests.csproj",
+          xml: '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup /></Project>',
+        },
+      ],
+    },
+    (rootDir) => {
+      const result = verifyReleaseVersion({ rootDir, tag: "v1.2.3" });
+
+      assert.deepEqual(result.projects, [
+        "desktop/NewGui/NewGui.csproj",
+        "desktop/Product/Product.csproj",
+      ]);
+    },
+  ));
+
+test("reports tag, package, and project version drift together", () =>
+  withFixture(
+    {
+      packageVersion: "1.2.2",
+      projects: [
+        {
+          path: "Product/Product.csproj",
+          xml: createProjectXml({ version: "1.2.1", fileVersion: "1.2.1.0" }),
+        },
+      ],
+    },
+    (rootDir) => {
+      assert.throws(
+        () => verifyReleaseVersion({ rootDir, tag: "v1.2.3" }),
+        (error) => {
+          assert.match(error.message, /package\.json version is "1\.2\.2"/);
+          assert.match(error.message, /<Version>1\.2\.1<\/Version>; expected 1\.2\.3/);
+          assert.match(
+            error.message,
+            /<FileVersion>1\.2\.1\.0<\/FileVersion>; expected 1\.2\.3\.0/,
+          );
+          return true;
+        },
+      );
+    },
+  ));
+
+test("rejects stale package-lock version metadata", () =>
+  withFixture(
+    {
+      projects: [{ path: "Product/Product.csproj", xml: createProjectXml() }],
+    },
+    (rootDir) => {
+      fs.writeFileSync(
+        path.join(rootDir, "package-lock.json"),
+        `${JSON.stringify(
+          {
+            name: "fixture",
+            version: "1.2.2",
+            lockfileVersion: 3,
+            packages: { "": { name: "fixture", version: "1.2.1" } },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      assert.throws(
+        () => verifyReleaseVersion({ rootDir, tag: "v1.2.3" }),
+        (error) => {
+          assert.match(error.message, /package-lock\.json version is "1\.2\.2"/);
+          assert.match(error.message, /packages\[""\]\.version is "1\.2\.1"/);
+          return true;
+        },
+      );
+    },
+  ));
+
+test("fails when a shipped project omits a release version declaration", () =>
+  withFixture(
+    {
+      projects: [
+        {
+          path: "Product/Product.csproj",
+          xml: `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>1.2.3</Version>
+    <AssemblyVersion>1.2.3.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>`,
+        },
+      ],
+    },
+    (rootDir) => {
+      assert.throws(
+        () => verifyReleaseVersion({ rootDir, tag: "v1.2.3" }),
+        /does not declare <FileVersion>1\.2\.3\.0<\/FileVersion>/,
+      );
+    },
+  ));
+
+test("supports prerelease tags while keeping numeric assembly versions", () =>
+  withFixture(
+    {
+      packageVersion: "1.2.3-rc.1",
+      projects: [
+        {
+          path: "Product/Product.csproj",
+          xml: createProjectXml({ version: "1.2.3-rc.1" }),
+        },
+      ],
+    },
+    (rootDir) => {
+      assert.doesNotThrow(() => verifyReleaseVersion({ rootDir, tag: "v1.2.3-rc.1" }));
+    },
+  ));
+
+test("requires a strict v-prefixed semantic version tag", () =>
+  withFixture(
+    {
+      projects: [{ path: "Product/Product.csproj", xml: createProjectXml() }],
+    },
+    (rootDir) => {
+      assert.throws(
+        () => verifyReleaseVersion({ rootDir, tag: "1.2.3" }),
+        /Release tag must use the form v<semver>/,
+      );
+      assert.throws(
+        () => verifyReleaseVersion({ rootDir, tag: "v01.2.3" }),
+        /Release tag must be a valid semantic version/,
+      );
+    },
+  ));

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -911,6 +911,76 @@ test("runSwitch updates config and syncs provider metadata", async () => {
   assert.match(rollout, /"model_provider":"apigather"/);
 });
 
+test("runSwitch completes a pre-switch backup before mutating config", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const originalConfig = `model_provider = "openai"\nmodel = "gpt-5.4-mini"\n\n[model_providers.apigather]\nmodel = "apigather-prod"\nbase_url = "https://example.com"\n`;
+  const configPath = path.join(codexHome, "config.toml");
+  await fs.writeFile(configPath, originalConfig, "utf8");
+
+  const progressEvents = [];
+  const result = await runSwitch({
+    codexHome,
+    provider: "apigather",
+    onProgress(event) {
+      progressEvents.push(event);
+    }
+  });
+
+  const backupCompleteIndex = progressEvents.findIndex(
+    (event) => event.stage === "create_backup" && event.status === "complete"
+  );
+  const configUpdateIndex = progressEvents.findIndex(
+    (event) => event.stage === "update_config" && event.status === "start"
+  );
+  assert.ok(backupCompleteIndex >= 0);
+  assert.ok(configUpdateIndex > backupCompleteIndex);
+  assert.equal(
+    await fs.readFile(path.join(result.backupDir, "config.toml"), "utf8"),
+    originalConfig
+  );
+
+  const switchedConfig = await fs.readFile(configPath, "utf8");
+  assert.match(switchedConfig, /^model_provider = "apigather"/m);
+  assert.match(switchedConfig, /^model = "apigather-prod"/m);
+});
+
+test("runSwitch does not touch config when pre-switch backup creation fails", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const originalConfig = `model_provider = "openai"\nmodel = "gpt-5.4-mini"\n\n[model_providers.apigather]\nbase_url = "https://example.com"\n`;
+  const configPath = path.join(codexHome, "config.toml");
+  await fs.writeFile(configPath, originalConfig, "utf8");
+  const pinnedMtime = new Date("2001-02-03T04:05:06.000Z");
+  await fs.utimes(configPath, pinnedMtime, pinnedMtime);
+
+  await fs.mkdir(path.dirname(backupRoot(codexHome)), { recursive: true });
+  await fs.writeFile(backupRoot(codexHome), "blocks backup directory creation", "utf8");
+
+  await assert.rejects(() => runSwitch({ codexHome, provider: "apigather" }));
+  assert.equal(await fs.readFile(configPath, "utf8"), originalConfig);
+  assert.equal((await fs.stat(configPath)).mtimeMs, pinnedMtime.getTime());
+});
+
+test("runSwitch restores config after a post-backup sync failure", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  const originalConfig = `model_provider = "openai"\nmodel = "gpt-5.4-mini"\n\n[model_providers.apigather]\nbase_url = "https://example.com"\n`;
+  const configPath = path.join(codexHome, "config.toml");
+  await fs.writeFile(configPath, originalConfig, "utf8");
+  await fs.writeFile(path.join(codexHome, ".codex-global-state.json"), "{not-json", "utf8");
+
+  await assert.rejects(
+    () => runSwitch({ codexHome, provider: "apigather" }),
+    /JSON|position|property name/i
+  );
+  assert.equal(await fs.readFile(configPath, "utf8"), originalConfig);
+
+  const backupDirectories = await fs.readdir(backupRoot(codexHome));
+  assert.equal(backupDirectories.length, 1);
+  assert.equal(
+    await fs.readFile(path.join(backupRoot(codexHome), backupDirectories[0], "config.toml"), "utf8"),
+    originalConfig
+  );
+});
+
 test("runSwitch copies root-level model from the new provider section", async () => {
   const { codexHome } = await makeTempCodexHome();
   const config = `model_provider = "openai"\nmodel = "gpt-5.4-mini"\n\n[model_providers.apigather]\nmodel = "apigather-prod"\nbase_url = "https://example.com"\n`;


### PR DESCRIPTION
## 目的 / Why

为下一版稳定化收口三个已确认风险：

- `switch` 先写 `config.toml`、后建备份，强杀或断电窗口内缺少切换前托管备份；
- Windows GUI 在副屏移除后可能恢复到不可操作的屏幕外位置；
- Release Tag 与 npm/.NET 版本可能不一致，直到发布后才暴露。

## 关联 Issue / Related issue

Addresses #45.

Follow-up to the unresolved backup-order finding in #60.

## 改动 / Changes

- Node 与 .NET Core 的 switch 流程统一为：扫描/可写性检查 → 创建完整切换前备份 → 写入配置 → 同步 SQLite/rollout/global state。
- 保留普通失败时的配置自动回滚；备份失败时不触碰 `config.toml`。
- Windows GUI 恢复保存位置前校验当前显示器；只有露出可拖动标题栏区域才保留原坐标，否则在主屏居中并适配工作区。
- Release 工作流新增版本门禁，校验 Tag、`package.json`、`package-lock.json` 和所有非测试 `.csproj` 的版本。
- 本 PR 不修改版本号；正式发布 `v0.3.3` 前需另行统一 bump，门禁会阻止遗漏。

## 影响范围 / Impact

- [x] Node.js CLI
- [x] Shared .NET Core
- [x] Windows GUI
- [x] macOS GUI
- [ ] WSL / SQLite paths
- [x] Backup / restore
- [x] CI / GitHub Actions
- [ ] Documentation

### 数据写入 / Data writes

没有新增数据类型或路径。switch 仍写入 `config.toml`、rollout、SQLite/global state 并创建托管备份；本次仅把完整备份移动到配置写入之前。

## 验证 / Validation

### Automated

- `npm test`: 110/110 passed on Node 24.
- Release-version focused suite: passed on Node 16.20.2 and Node 24.
- `node scripts/verify-release-version.js --tag v0.3.2`: passed.
- `--tag v0.3.3`: failed as expected and reported every current version mismatch.
- `node --check` for modified Node scripts: passed.
- `git diff --check`: passed.
- [CI #129](https://github.com/Dailin521/codex-provider-sync/actions/runs/30805494983): passed all Node 16/24 Windows/Linux jobs, Windows Core/App tests, macOS Core tests/build, and `ci-gate`.

### Manual

- Source and failure-path review completed independently for Node/C#, window placement, and release workflow.

### Not run

Real Windows multi-monitor GUI validation was not available in the current environment. Compilation and automated Windows placement tests passed in CI; the physical unplug/replug scenario still needs release-candidate verification.

## 检查清单 / Checklist

- [x] PR 只包含相关修改 / This PR contains only related changes
- [x] 已补充相关测试，或说明不需要测试的原因 / Tests were added or the reason they are unnecessary is explained
- [x] 如有用户可见变化，已更新相关文档 / Relevant documentation was updated or existing behavior documentation remains accurate
- [x] 未提交未脱敏的凭据、会话、SQLite、备份、日志或个人信息 / No unredacted credentials, sessions, databases, backups, logs, or personal data are included

## Follow-up

Independent review found a pre-existing partial-rollback gap if a multi-file rollout/global-state write fails after an earlier file has already been changed but before the batch returns its applied-file list. The managed backup still exists, but automatic rollback may be incomplete. This is intentionally kept out of this focused PR and is tracked in #69.