### PR TITLE
perf: reuse Windows rollout rewrite worker

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -23,8 +23,7 @@ import {
   getBackupSummary,
   pruneBackups,
   restoreBackup,
-  restoreGlobalStateFilesFromBackup,
-  updateSessionBackupManifest
+  restoreGlobalStateFilesFromBackup
 } from "./backup.js";
 import { acquireLock } from "./locking.js";
 import {
@@ -575,7 +574,6 @@ async function runSyncCore({
                 appliedSessionChanges.push(change);
                 sessionRestoreNeeded = true;
                 await journal.applied("rollout", change.path);
-                await updateSessionBackupManifest(backupDir, appliedSessionChanges);
                 await faultInjector?.({ point: "after_rollout_apply", path: change.path, appliedCount: appliedSessionChanges.length });
               },
               onSkipped: async (change, reason) => {

--- a/src/session-files.js
+++ b/src/session-files.js
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
@@ -467,24 +467,6 @@ function isValidWindowsRewriteResult(result) {
     || result === "SKIP_CHANGED";
 }
 
-function parseWindowsRewriteResults(stdout, changes) {
-  const trimmed = stdout.trim();
-  const parsed = trimmed ? JSON.parse(trimmed) : [];
-  const results = Array.isArray(parsed) ? parsed : [parsed];
-
-  if (results.length !== changes.length) {
-    throw new Error(`Unexpected rewrite result count. Expected ${changes.length}, received ${results.length}.`);
-  }
-
-  return results.map((entry, index) => {
-    const expectedPath = changes[index].path;
-    if (entry?.path !== expectedPath || !isValidWindowsRewriteResult(entry?.result)) {
-      throw new Error(`Unexpected rewrite result for ${expectedPath}: ${JSON.stringify(entry)}`);
-    }
-    return entry.result;
-  });
-}
-
 async function restoreOriginalMtime(filePath, mtimeMs) {
   if (!Number.isFinite(mtimeMs)) {
     return;
@@ -498,16 +480,22 @@ async function restoreOriginalMtime(filePath, mtimeMs) {
   }
 }
 
-async function invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatch }) {
-  if (!changes.length) {
-    return [];
-  }
+const WINDOWS_REWRITE_PROTOCOL_VERSION = 1;
+const WINDOWS_REWRITE_READY_TIMEOUT_MS = 15_000;
 
-  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "codex-provider-rewrite-"));
-  const manifestPath = path.join(tempDir, "changes.json");
-  const script = `
+const WINDOWS_EXCLUSIVE_REWRITE_WORKER_SCRIPT = `
 & {
-  param([string]$manifestPath)
+  $ErrorActionPreference = "Stop"
+  $ProgressPreference = "SilentlyContinue"
+  $utf8 = [System.Text.UTF8Encoding]::new($false)
+  [Console]::InputEncoding = $utf8
+  [Console]::OutputEncoding = $utf8
+
+  function Write-ProtocolMessage($value) {
+    $json = $value | ConvertTo-Json -Compress -Depth 8
+    [Console]::Out.WriteLine($json)
+    [Console]::Out.Flush()
+  }
 
   function Read-FirstLineRecord([System.IO.FileStream]$stream) {
     $stream.Seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
@@ -554,7 +542,7 @@ async function invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatc
       try {
         $source = [System.IO.File]::Open($path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
       } catch {
-        if (Test-Path $path) {
+        if (Test-Path -LiteralPath $path) {
           return "SKIP_BUSY"
         }
         return "SKIP_CHANGED"
@@ -604,7 +592,7 @@ async function invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatc
       try {
         [System.IO.File]::Replace($tmpPath, $path, $replaceBackupPath, $true)
       } catch {
-        if (Test-Path $path) {
+        if (Test-Path -LiteralPath $path) {
           return "SKIP_BUSY"
         }
         return "SKIP_CHANGED"
@@ -618,58 +606,285 @@ async function invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatc
       if ($source) {
         $source.Dispose()
       }
-      Remove-Item -Path $tmpPath -Force -ErrorAction SilentlyContinue
-      Remove-Item -Path $replaceBackupPath -Force -ErrorAction SilentlyContinue
+      Remove-Item -LiteralPath $tmpPath -Force -ErrorAction SilentlyContinue
+      Remove-Item -LiteralPath $replaceBackupPath -Force -ErrorAction SilentlyContinue
     }
   }
 
-  $changes = Get-Content -Raw -Encoding UTF8 -Path $manifestPath | ConvertFrom-Json
-  if ($null -eq $changes) {
-    $changes = @()
-  } elseif ($changes -is [string] -or $changes -isnot [System.Collections.IEnumerable]) {
-    $changes = @($changes)
-  } else {
-    $changes = @($changes)
-  }
-
-  $results = @(foreach ($change in $changes) {
-    [pscustomobject]@{
-      path = [string]$change.path
-      result = Invoke-RewriteChange $change
-    }
+  Write-ProtocolMessage ([ordered]@{
+    protocolVersion = 1
+    type = "ready"
   })
 
-  $results | ConvertTo-Json -Compress
+  while ($null -ne ($line = [Console]::In.ReadLine())) {
+    if ([string]::IsNullOrWhiteSpace($line)) {
+      continue
+    }
+
+    $request = $null
+    try {
+      $request = $line | ConvertFrom-Json
+      $requestPath = [string]$request.path
+      if (([int]$request.protocolVersion -ne 1) -or
+          ([string]$request.type -ne "rewrite") -or
+          ($null -eq $request.id) -or
+          [string]::IsNullOrWhiteSpace($requestPath) -or
+          (-not [System.IO.Path]::IsPathRooted($requestPath))) {
+        throw [System.InvalidOperationException]::new("Invalid Windows rewrite worker request.")
+      }
+
+      $result = Invoke-RewriteChange $request
+      Write-ProtocolMessage ([ordered]@{
+        protocolVersion = 1
+        type = "result"
+        id = $request.id
+        path = $requestPath
+        result = $result
+      })
+    } catch {
+      [Console]::Error.WriteLine($_.Exception.ToString())
+      [Console]::Error.Flush()
+      $errorId = $null
+      $errorPath = $null
+      if ($null -ne $request) {
+        $errorId = $request.id
+        $errorPath = [string]$request.path
+      }
+      Write-ProtocolMessage ([ordered]@{
+        protocolVersion = 1
+        type = "error"
+        id = $errorId
+        path = $errorPath
+        message = $_.Exception.Message
+      })
+      exit 1
+    }
+  }
 }
 `.trim();
 
-  try {
-    const manifestChanges = changes.map((change) => ({
-      ...change,
-      requireOriginalMatch
-    }));
-    await fsp.writeFile(
-      manifestPath,
-      JSON.stringify(manifestChanges),
-      "utf8"
-    );
+function formatWindowsRewriteWorkerError(message, stderr) {
+  const detail = stderr.trim();
+  return detail ? `${message} PowerShell diagnostics: ${detail}` : message;
+}
 
-    const { stdout } = await execFileAsync("powershell.exe", [
+function writeWorkerRequest(stream, request) {
+  return new Promise((resolve, reject) => {
+    stream.write(`${JSON.stringify(request)}\n`, "utf8", (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function createWindowsExclusiveRewriteWorker(options = {}) {
+  const {
+    spawnImpl = spawn,
+    readyTimeoutMs = WINDOWS_REWRITE_READY_TIMEOUT_MS
+  } = options;
+  const child = spawnImpl("powershell.exe", [
+      "-NoLogo",
       "-NoProfile",
+      "-NonInteractive",
+      "-InputFormat",
+      "Text",
+      "-OutputFormat",
+      "Text",
       "-ExecutionPolicy",
       "Bypass",
       "-Command",
-      script,
-      manifestPath
+      WINDOWS_EXCLUSIVE_REWRITE_WORKER_SCRIPT
     ], {
-      maxBuffer: 16 * 1024 * 1024
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true
     });
 
-    return parseWindowsRewriteResults(stdout, changes);
+  let stderr = "";
+  let spawnError = null;
+  let exitInfo = null;
+  let closed = false;
+  let inFlight = false;
+  let nextRequestId = 1;
+  let stdinError = null;
+  const stdoutLines = readline.createInterface({
+    input: child.stdout,
+    crlfDelay: Infinity
+  });
+  const stdoutIterator = stdoutLines[Symbol.asyncIterator]();
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderr = `${stderr}${chunk}`.slice(-64 * 1024);
+  });
+  child.stdin.on("error", (error) => {
+    stdinError = error;
+  });
+
+  const completion = new Promise((resolve) => {
+    child.once("error", (error) => {
+      spawnError = error;
+      resolve({ error, code: null, signal: null });
+    });
+    child.once("exit", (code, signal) => {
+      exitInfo = { error: null, code, signal };
+      resolve(exitInfo);
+    });
+  });
+
+  async function readProtocolMessage(timeoutMs = null) {
+    let timeoutId = null;
+    const timeoutPromise = timeoutMs === null
+      ? null
+      : new Promise((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`Windows rewrite worker did not become ready within ${timeoutMs} ms.`));
+        }, timeoutMs);
+      });
+    try {
+      const nextLine = timeoutPromise
+        ? await Promise.race([stdoutIterator.next(), timeoutPromise])
+        : await stdoutIterator.next();
+      if (nextLine.done) {
+        const message = spawnError
+          ? `Unable to start Windows rewrite worker: ${spawnError.message}`
+          : `Windows rewrite worker closed stdout unexpectedly${exitInfo ? ` (exit ${exitInfo.code ?? "null"}, signal ${exitInfo.signal ?? "null"})` : ""}.`;
+        throw new Error(formatWindowsRewriteWorkerError(message, stderr));
+      }
+      try {
+        return JSON.parse(nextLine.value);
+      } catch (error) {
+        throw new Error(
+          formatWindowsRewriteWorkerError(
+            `Windows rewrite worker returned malformed JSON: ${error.message}`,
+            stderr
+          )
+        );
+      }
+    } finally {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  try {
+    const ready = await readProtocolMessage(readyTimeoutMs);
+    if (ready?.protocolVersion !== WINDOWS_REWRITE_PROTOCOL_VERSION || ready?.type !== "ready") {
+      throw new Error(`Unexpected Windows rewrite worker ready message: ${JSON.stringify(ready)}`);
+    }
   } catch (error) {
-    throw wrapRolloutFileBusyError(error, changes[0]?.path, "rewrite");
+    child.stdin.destroy();
+    child.kill();
+    stdoutLines.close();
+    throw error;
+  }
+
+  return {
+    pid: child.pid,
+    async rewrite(change, { requireOriginalMatch }) {
+      if (closed) {
+        throw new Error("Windows rewrite worker is already closed.");
+      }
+      if (inFlight) {
+        throw new Error("Windows rewrite worker already has an in-flight request.");
+      }
+      if (!change || typeof change.path !== "string" || !path.isAbsolute(change.path)) {
+        throw new Error(`Windows rewrite worker requires an absolute rollout path: ${change?.path ?? "(missing)"}`);
+      }
+
+      const id = nextRequestId;
+      nextRequestId += 1;
+      inFlight = true;
+      try {
+        await writeWorkerRequest(child.stdin, {
+          ...change,
+          protocolVersion: WINDOWS_REWRITE_PROTOCOL_VERSION,
+          type: "rewrite",
+          id,
+          requireOriginalMatch: Boolean(requireOriginalMatch)
+        });
+        const response = await readProtocolMessage();
+        if (response?.protocolVersion !== WINDOWS_REWRITE_PROTOCOL_VERSION
+            || response?.type !== "result"
+            || response?.id !== id
+            || response?.path !== change.path
+            || !isValidWindowsRewriteResult(response?.result)) {
+          throw new Error(`Unexpected Windows rewrite worker response for ${change.path}: ${JSON.stringify(response)}`);
+        }
+        return response.result;
+      } catch (error) {
+        child.stdin.destroy();
+        child.kill();
+        throw wrapRolloutFileBusyError(
+          new Error(
+            formatWindowsRewriteWorkerError(
+              `Windows rewrite worker failed for ${change.path}: ${stdinError?.message ?? error.message}`,
+              stderr
+            ),
+            { cause: error }
+          ),
+          change.path,
+          "rewrite"
+        );
+      } finally {
+        inFlight = false;
+      }
+    },
+    async close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      if (!child.stdin.destroyed) {
+        child.stdin.end();
+      }
+      const completed = await completion;
+      stdoutLines.close();
+      if (completed.error) {
+        throw new Error(formatWindowsRewriteWorkerError(
+          `Windows rewrite worker failed to start: ${completed.error.message}`,
+          stderr
+        ));
+      }
+      if (completed.code !== 0) {
+        throw new Error(formatWindowsRewriteWorkerError(
+          `Windows rewrite worker exited with code ${completed.code ?? "null"} and signal ${completed.signal ?? "null"}.`,
+          stderr
+        ));
+      }
+    }
+  };
+}
+
+async function invokeWindowsExclusiveRewriteBatch(changes, { requireOriginalMatch }) {
+  if (!changes.length) {
+    return [];
+  }
+
+  let worker = null;
+  let primaryError = null;
+  try {
+    worker = await createWindowsExclusiveRewriteWorker();
+    const results = [];
+    for (const change of changes) {
+      results.push(await worker.rewrite(change, { requireOriginalMatch }));
+    }
+    return results;
+  } catch (error) {
+    primaryError = error;
+    throw error;
   } finally {
-    await fsp.rm(tempDir, { recursive: true, force: true });
+    if (worker) {
+      try {
+        await worker.close();
+      } catch (closeError) {
+        if (!primaryError) {
+          throw closeError;
+        }
+      }
+    }
   }
 }
 
@@ -1095,7 +1310,8 @@ export async function applySessionChanges(changes, options = {}) {
     onBeforeApply,
     onMutation,
     onApplied,
-    onSkipped
+    onSkipped,
+    windowsRewriteWorkerFactory = createWindowsExclusiveRewriteWorker
   } = options ?? {};
   const skippedPaths = [];
   const appliedPaths = [];
@@ -1113,31 +1329,50 @@ export async function applySessionChanges(changes, options = {}) {
   const firstLineChanges = normalizedChanges.filter((change) => !change?.modelOnlyChange);
 
   if (process.platform === "win32") {
-    // Process one file per helper invocation. A failed Windows batch cannot
-    // report which earlier members were already replaced, which was the root
-    // cause of #69. Per-target calls let the durable coordinator observe each
-    // successful mutation before the next target starts.
-    for (const change of firstLineChanges) {
-      await onBeforeApply?.(change);
-      const [result] = await invokeWindowsExclusiveRewriteBatch([change], { requireOriginalMatch: true });
-      if (result === "APPLIED" || result === "APPLIED_IN_PLACE") {
-        appliedChanges += 1;
-        inPlaceChanges += result === "APPLIED_IN_PLACE" ? 1 : 0;
-        appliedPaths.push(change.path);
-        await onMutation?.(change, { stage: "firstLine", result });
-        if (change.modelRewriteRequired) {
-          const modelResult = await rewriteRolloutModelField(change, targetModel);
-          retainOrValidateModelSnapshot(change, modelResult.originalTurnContextModels);
-          change.appliedTurnContextRewrites = modelResult.replacedLines;
-          if (modelResult.replacedLines > 0) {
-            await onMutation?.(change, { stage: "model", result: "APPLIED" });
+    // Keep one PowerShell process alive, but send exactly one target at a time.
+    // The coordinator persists applying/applied around each awaited request, so
+    // an abrupt exit can never mutate a later rollout that has no journal entry.
+    let worker = null;
+    let primaryError = null;
+    try {
+      if (firstLineChanges.length > 0) {
+        worker = await windowsRewriteWorkerFactory();
+      }
+      for (const change of firstLineChanges) {
+        await onBeforeApply?.(change);
+        const result = await worker.rewrite(change, { requireOriginalMatch: true });
+        if (result === "APPLIED" || result === "APPLIED_IN_PLACE") {
+          appliedChanges += 1;
+          inPlaceChanges += result === "APPLIED_IN_PLACE" ? 1 : 0;
+          appliedPaths.push(change.path);
+          await onMutation?.(change, { stage: "firstLine", result });
+          if (change.modelRewriteRequired) {
+            const modelResult = await rewriteRolloutModelField(change, targetModel);
+            retainOrValidateModelSnapshot(change, modelResult.originalTurnContextModels);
+            change.appliedTurnContextRewrites = modelResult.replacedLines;
+            if (modelResult.replacedLines > 0) {
+              await onMutation?.(change, { stage: "model", result: "APPLIED" });
+            }
+          }
+          await restoreOriginalMtime(change.path, change.originalMtimeMs);
+          await onApplied?.(change);
+        } else {
+          skippedPaths.push(change.path);
+          await onSkipped?.(change, result);
+        }
+      }
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      if (worker) {
+        try {
+          await worker.close();
+        } catch (closeError) {
+          if (!primaryError) {
+            throw closeError;
           }
         }
-        await restoreOriginalMtime(change.path, change.originalMtimeMs);
-        await onApplied?.(change);
-      } else {
-        skippedPaths.push(change.path);
-        await onSkipped?.(change, result);
       }
     }
   } else {

--- a/test/sync-service.test.js
+++ b/test/sync-service.test.js
@@ -16,7 +16,11 @@ import {
 import { getStatus, renderStatus, runRestore, runSwitch, runSync } from "../src/service.js";
 import { DB_FILE_BASENAME, DEFAULT_BACKUP_RETENTION_COUNT, SQLITE_DIR_BASENAME } from "../src/constants.js";
 import { getUnsupportedNodeVersionMessage } from "../src/node-version.js";
-import { applySessionChanges, collectSessionChanges } from "../src/session-files.js";
+import {
+  applySessionChanges,
+  collectSessionChanges,
+  createWindowsExclusiveRewriteWorker
+} from "../src/session-files.js";
 import { openDatabase } from "../src/sqlite.js";
 import {
   TransactionJournal,
@@ -720,6 +724,40 @@ test("repeated sync is idempotent for rollout and SQLite state", async () => {
   assert.deepEqual(await findPendingTransactions(codexHome), []);
 });
 
+test("runSync leaves the backup manifest and metadata unchanged after creation", async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-immutable-backup.jsonl");
+  await writeRollout(sessionPath, "thread-immutable-backup", "apigather");
+  await writeStateDb(codexHome, [{ id: "thread-immutable-backup", model_provider: "apigather" }]);
+
+  let backupDir = null;
+  let manifestBefore = null;
+  let metadataBefore = null;
+  const result = await runSync({
+    codexHome,
+    onProgress(event) {
+      if (event.stage === "create_backup" && event.status === "complete") {
+        backupDir = event.backupDir;
+      }
+    },
+    async faultInjector({ point }) {
+      if (point === "before_rollout_apply" && manifestBefore === null) {
+        manifestBefore = await fs.readFile(path.join(backupDir, "session-meta-backup.json"));
+        metadataBefore = await fs.readFile(path.join(backupDir, "metadata.json"));
+      }
+    }
+  });
+
+  assert.equal(result.changedSessionFiles, 1);
+  assert.ok(manifestBefore);
+  assert.ok(metadataBefore);
+  assert.deepEqual(await fs.readFile(path.join(backupDir, "session-meta-backup.json")), manifestBefore);
+  assert.deepEqual(await fs.readFile(path.join(backupDir, "metadata.json")), metadataBefore);
+  const manifest = JSON.parse(manifestBefore.toString("utf8"));
+  assert.equal(manifest.appliedPaths, null);
+});
+
 test("failure after model mutation but before journal applied restores full rollout bytes", async () => {
   const { codexHome } = await makeTempCodexHome();
   await writeConfig(codexHome, 'model_provider = "openai"\nmodel = "gpt-new"');
@@ -752,6 +790,56 @@ test("failure after model mutation but before journal applied restores full roll
   assert.ok(error.completedTargets.includes(path.resolve(sessionPath)));
   assert.deepEqual(await fs.readFile(sessionPath), before);
   assert.deepEqual(await findPendingTransactions(codexHome), []);
+});
+
+test("lost Windows worker acknowledgement after File.Replace restores the applying target", {
+  skip: process.platform !== "win32"
+}, async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const configPath = path.join(codexHome, "config.toml");
+  const sessionPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-lost-worker-ack.jsonl");
+  await writeRollout(sessionPath, "thread-lost-worker-ack", "apigather");
+  const before = await fs.readFile(sessionPath);
+  const { changes } = await collectSessionChanges(codexHome, "openai");
+  const backupDir = await createBackup({
+    codexHome,
+    targetProvider: "openai",
+    sessionChanges: changes,
+    configPath
+  });
+  const journal = await TransactionJournal.create(backupDir, {
+    codexHome,
+    targetProvider: "openai",
+    potentialTargets: [sessionPath]
+  });
+
+  await assert.rejects(
+    applySessionChanges(changes, {
+      onBeforeApply: (change) => journal.applying("rollout", change.path),
+      windowsRewriteWorkerFactory: async () => {
+        const actual = await createWindowsExclusiveRewriteWorker();
+        return {
+          async rewrite(change, options) {
+            await actual.rewrite(change, options);
+            throw new Error("injected lost worker acknowledgement");
+          },
+          close: () => actual.close()
+        };
+      }
+    }),
+    /injected lost worker acknowledgement/
+  );
+
+  assert.notDeepEqual(await fs.readFile(sessionPath), before);
+  const pending = await readTransactionJournal(journal.filePath);
+  assert.equal(pending.state, "applying");
+  await restoreBackup(backupDir, codexHome, {
+    restoreConfig: false,
+    restoreDatabase: false,
+    restoreSessions: true
+  });
+  assert.deepEqual(await fs.readFile(sessionPath), before);
 });
 
 test("immutable full manifest restores a later applying target after abrupt exit", async () => {
@@ -797,6 +885,7 @@ test("immutable full manifest restores a later applying target after abrupt exit
   const fullBackupDir = path.join(backupRoot(codexHome), backupDir);
   const manifest = JSON.parse(await fs.readFile(path.join(fullBackupDir, "session-meta-backup.json"), "utf8"));
   assert.equal(manifest.files.length, 2);
+  assert.equal(manifest.appliedPaths, null);
 
   await runRestore({
     codexHome,
@@ -807,6 +896,51 @@ test("immutable full manifest restores a later applying target after abrupt exit
   assert.deepEqual(await fs.readFile(firstPath), before[0]);
   assert.deepEqual(await fs.readFile(secondPath), before[1]);
   assert.deepEqual(await findPendingTransactions(codexHome), []);
+});
+
+test("abrupt parent exit after the first applied rollout never mutates the next rollout", {
+  skip: process.platform !== "win32"
+}, async () => {
+  const { codexHome } = await makeTempCodexHome();
+  await writeConfig(codexHome, 'model_provider = "openai"');
+  const firstPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-parent-exit-a.jsonl");
+  const secondPath = path.join(codexHome, "sessions", "2026", "03", "19", "rollout-parent-exit-b.jsonl");
+  await writeRollout(firstPath, "thread-parent-exit-a", "apigather");
+  await writeRollout(secondPath, "thread-parent-exit-b", "apigather");
+  const before = await Promise.all([fs.readFile(firstPath), fs.readFile(secondPath)]);
+
+  const childScript = `
+    import { runSync } from "./src/service.js";
+    await runSync({
+      codexHome: ${JSON.stringify(codexHome)},
+      provider: "openai",
+      faultInjector: ({ point, appliedCount }) => {
+        if (point === "after_rollout_apply" && appliedCount === 1) {
+          process.exit(24);
+        }
+      }
+    });
+  `;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", childScript], {
+    cwd: path.resolve(".")
+  });
+  const exitCode = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", resolve);
+  });
+
+  assert.equal(exitCode, 24);
+  assert.notDeepEqual(await fs.readFile(firstPath), before[0]);
+  assert.deepEqual(await fs.readFile(secondPath), before[1]);
+  const [backupDir] = await fs.readdir(backupRoot(codexHome));
+  await runRestore({
+    codexHome,
+    backupDir: path.join(backupRoot(codexHome), backupDir),
+    restoreConfig: false,
+    restoreDatabase: false
+  });
+  assert.deepEqual(await fs.readFile(firstPath), before[0]);
+  assert.deepEqual(await fs.readFile(secondPath), before[1]);
 });
 
 test("foreign operationId and missing-final-newline journals stay pending until explicit restore", async (t) => {
@@ -3757,6 +3891,45 @@ test("invalid journal tail with no validated target restores the full session ma
   assert.equal(repaired.state, "rolledBack");
   assert.equal(repaired.terminal, true);
   assert.deepEqual(await findPendingTransactions(codexHome), []);
+});
+
+test("missing or empty journal restores the full immutable session manifest", async (t) => {
+  for (const journalState of ["missing", "empty"]) {
+    await t.test(journalState, async () => {
+      const { codexHome } = await makeTempCodexHome();
+      await writeConfig(codexHome, 'model_provider = "openai"');
+      const configPath = path.join(codexHome, "config.toml");
+      const sessionPath = path.join(
+        codexHome,
+        "sessions",
+        "2026",
+        "03",
+        "19",
+        `rollout-${journalState}-journal.jsonl`
+      );
+      await writeRollout(sessionPath, `thread-${journalState}-journal`, "apigather");
+      const original = await fs.readFile(sessionPath, "utf8");
+      const { changes } = await collectSessionChanges(codexHome, "openai");
+      const backupDir = await createBackup({
+        codexHome,
+        targetProvider: "openai",
+        sessionChanges: changes,
+        configPath
+      });
+      if (journalState === "empty") {
+        await fs.writeFile(path.join(backupDir, "transaction-journal.jsonl"), "", "utf8");
+      }
+      await writeRollout(sessionPath, `thread-${journalState}-journal`, "openai");
+
+      await restoreBackup(backupDir, codexHome, {
+        restoreConfig: false,
+        restoreDatabase: false,
+        restoreSessions: true
+      });
+
+      assert.equal(await fs.readFile(sessionPath, "utf8"), original);
+    });
+  }
 });
 
 test("automatic rollback does not report success unless the rolledBack terminal re-reads valid", async () => {

--- a/test/windows-rewrite-worker.test.js
+++ b/test/windows-rewrite-worker.test.js
@@ -1,0 +1,262 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applySessionChanges,
+  createWindowsExclusiveRewriteWorker
+} from "../src/session-files.js";
+
+function createFakeSpawn({ ready = { protocolVersion: 1, type: "ready" }, respond }) {
+  let spawnCount = 0;
+  const spawnImpl = () => {
+    spawnCount += 1;
+    const child = new EventEmitter();
+    child.pid = 4242;
+    child.stdin = new PassThrough();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    let input = "";
+    let exited = false;
+
+    function exit(code, signal = null) {
+      if (exited) {
+        return;
+      }
+      exited = true;
+      child.stdout.end();
+      child.stderr.end();
+      queueMicrotask(() => child.emit("exit", code, signal));
+    }
+
+    child.kill = () => {
+      exit(1, "SIGTERM");
+      return true;
+    };
+    child.stdin.setEncoding("utf8");
+    child.stdin.on("data", (chunk) => {
+      input += chunk;
+      while (input.includes("\n")) {
+        const newline = input.indexOf("\n");
+        const line = input.slice(0, newline);
+        input = input.slice(newline + 1);
+        if (!line) {
+          continue;
+        }
+        const request = JSON.parse(line);
+        const response = respond(request);
+        if (response && typeof response === "object" && Object.hasOwn(response, "exitCode")) {
+          exit(response.exitCode, response.signal ?? null);
+          continue;
+        }
+        child.stdout.write(
+          typeof response === "string" ? `${response}\n` : `${JSON.stringify(response)}\n`,
+          "utf8"
+        );
+      }
+    });
+    child.stdin.on("finish", () => exit(0));
+    queueMicrotask(() => child.stdout.write(`${JSON.stringify(ready)}\n`, "utf8"));
+    return child;
+  };
+  return { spawnImpl, getSpawnCount: () => spawnCount };
+}
+
+test("Windows rewrite worker reuses one process and preserves the closed result set", async () => {
+  const expectedResults = ["APPLIED", "APPLIED_IN_PLACE", "SKIP_BUSY", "SKIP_CHANGED"];
+  const fake = createFakeSpawn({
+    respond(request) {
+      return {
+        protocolVersion: 1,
+        type: "result",
+        id: request.id,
+        path: request.path,
+        result: expectedResults[request.id - 1]
+      };
+    }
+  });
+  const worker = await createWindowsExclusiveRewriteWorker({ spawnImpl: fake.spawnImpl });
+  const results = [];
+  try {
+    for (let index = 0; index < expectedResults.length; index += 1) {
+      results.push(await worker.rewrite(
+        { path: path.resolve(`rollout-${index}.jsonl`) },
+        { requireOriginalMatch: true }
+      ));
+    }
+  } finally {
+    await worker.close();
+  }
+
+  assert.equal(fake.getSpawnCount(), 1);
+  assert.deepEqual(results, expectedResults);
+});
+
+test("Windows rewrite worker rejects mismatched and malformed protocol responses", async (t) => {
+  await t.test("invalid ready message", async () => {
+    const fake = createFakeSpawn({
+      ready: { protocolVersion: 1, type: "unexpected" },
+      respond: () => assert.fail("invalid ready must stop before requests")
+    });
+    await assert.rejects(
+      createWindowsExclusiveRewriteWorker({ spawnImpl: fake.spawnImpl }),
+      /Unexpected Windows rewrite worker ready message/
+    );
+  });
+
+  await t.test("mismatched id", async () => {
+    const fake = createFakeSpawn({
+      respond(request) {
+        return {
+          protocolVersion: 1,
+          type: "result",
+          id: request.id + 1,
+          path: request.path,
+          result: "APPLIED"
+        };
+      }
+    });
+    const worker = await createWindowsExclusiveRewriteWorker({ spawnImpl: fake.spawnImpl });
+    await assert.rejects(
+      worker.rewrite({ path: path.resolve("rollout-id.jsonl") }, { requireOriginalMatch: true }),
+      /Unexpected Windows rewrite worker response/
+    );
+  });
+
+  await t.test("malformed JSON", async () => {
+    const fake = createFakeSpawn({ respond: () => "not-json" });
+    const worker = await createWindowsExclusiveRewriteWorker({ spawnImpl: fake.spawnImpl });
+    await assert.rejects(
+      worker.rewrite({ path: path.resolve("rollout-json.jsonl") }, { requireOriginalMatch: true }),
+      /malformed JSON/
+    );
+  });
+
+  await t.test("worker exits before acknowledgement", async () => {
+    const fake = createFakeSpawn({ respond: () => ({ exitCode: 9 }) });
+    const worker = await createWindowsExclusiveRewriteWorker({ spawnImpl: fake.spawnImpl });
+    await assert.rejects(
+      worker.rewrite({ path: path.resolve("rollout-exit.jsonl") }, { requireOriginalMatch: true }),
+      /closed stdout unexpectedly/
+    );
+  });
+
+  await t.test("worker returns an error protocol message", async () => {
+    const fake = createFakeSpawn({
+      respond(request) {
+        return {
+          protocolVersion: 1,
+          type: "error",
+          id: request.id,
+          path: request.path,
+          message: "injected worker error"
+        };
+      }
+    });
+    const worker = await createWindowsExclusiveRewriteWorker({ spawnImpl: fake.spawnImpl });
+    await assert.rejects(
+      worker.rewrite({ path: path.resolve("rollout-error.jsonl") }, { requireOriginalMatch: true }),
+      /Unexpected Windows rewrite worker response/
+    );
+  });
+});
+
+test("applySessionChanges creates one Windows worker and does not queue the next target", {
+  skip: process.platform !== "win32"
+}, async () => {
+  const firstPath = path.resolve("rollout-order-a.jsonl");
+  const secondPath = path.resolve("rollout-order-b.jsonl");
+  const changes = [firstPath, secondPath].map((filePath) => ({
+    path: filePath,
+    originalMtimeMs: Date.now(),
+    modelRewriteRequired: false,
+    modelOnlyChange: false
+  }));
+  const events = [];
+  let factoryCalls = 0;
+  let closeCalls = 0;
+
+  const result = await applySessionChanges(changes, {
+    windowsRewriteWorkerFactory: async () => {
+      factoryCalls += 1;
+      return {
+        async rewrite(change) {
+          events.push(`rewrite:${path.basename(change.path)}`);
+          return "APPLIED";
+        },
+        async close() {
+          closeCalls += 1;
+        }
+      };
+    },
+    async onBeforeApply(change) {
+      events.push(`applying:${path.basename(change.path)}`);
+    },
+    async onApplied(change) {
+      events.push(`applied:${path.basename(change.path)}`);
+    }
+  });
+
+  assert.equal(factoryCalls, 1);
+  assert.equal(closeCalls, 1);
+  assert.equal(result.appliedChanges, 2);
+  assert.deepEqual(events, [
+    "applying:rollout-order-a.jsonl",
+    "rewrite:rollout-order-a.jsonl",
+    "applied:rollout-order-a.jsonl",
+    "applying:rollout-order-b.jsonl",
+    "rewrite:rollout-order-b.jsonl",
+    "applied:rollout-order-b.jsonl"
+  ]);
+});
+
+test("real Windows worker handles sequential Unicode and literal wildcard paths", {
+  skip: process.platform !== "win32"
+}, async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "provider-worker-test-"));
+  try {
+    const changes = [];
+    for (let index = 0; index < 2; index += 1) {
+      const filePath = path.join(root, `rollout-[测试 ${index}].jsonl`);
+      const originalFirstLine = JSON.stringify({
+        type: "session_meta",
+        payload: { id: `thread-${index}`, model_provider: "old" }
+      });
+      await fs.writeFile(filePath, `${originalFirstLine}\n{"type":"event_msg","payload":{}}\n`, "utf8");
+      const stat = await fs.stat(filePath);
+      changes.push({
+        path: filePath,
+        originalFirstLine,
+        originalSeparator: "\n",
+        originalOffset: Buffer.byteLength(originalFirstLine) + 1,
+        originalSize: stat.size,
+        updatedFirstLine: JSON.stringify({
+          type: "session_meta",
+          payload: { id: `thread-${index}`, model_provider: "new" }
+        })
+      });
+    }
+
+    const worker = await createWindowsExclusiveRewriteWorker();
+    const results = [];
+    try {
+      for (const change of changes) {
+        results.push(await worker.rewrite(change, { requireOriginalMatch: true }));
+      }
+    } finally {
+      await worker.close();
+    }
+
+    assert.deepEqual(results, ["APPLIED", "APPLIED"]);
+    for (const change of changes) {
+      const [firstLine] = (await fs.readFile(change.path, "utf8")).split(/\r?\n/);
+      assert.equal(JSON.parse(firstLine).payload.model_provider, "new");
+    }
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- reuse one persistent PowerShell worker for Windows Node rollout rewrites
- preserve per-target transaction journal ordering and crash recovery
- stop rewriting the complete backup manifest after every rollout on all Node platforms
- keep legacy backup restore compatibility and non-Windows rewrite behavior unchanged

## Verification

- npm test: 207/207 passed
- Windows worker protocol and special-path integration tests passed
- crash windows before acknowledgement and before journal applied are covered
- 100-file local benchmark used one worker and completed in about 1.1 seconds