### PR TITLE
fix(node): avoid classifying filesystem EBUSY as SQLite busy

### DIFF
--- a/src/sqlite-state.js
+++ b/src/sqlite-state.js
@@ -197,8 +197,14 @@ export function configureSqliteWriteDurability(db) {
 }
 
 function isSqliteBusyError(error) {
-  const message = `${error?.code ?? ""} ${error?.message ?? ""}`.toLowerCase();
-  return message.includes("database is locked") || message.includes("sqlite_busy") || message.includes("busy");
+  const code = String(error?.code ?? "").toUpperCase();
+  const message = String(error?.message ?? "").toLowerCase();
+  return code === "SQLITE_BUSY"
+    || code.startsWith("SQLITE_BUSY_")
+    || code === "SQLITE_LOCKED"
+    || code.startsWith("SQLITE_LOCKED_")
+    || message.includes("database is locked")
+    || message.includes("database table is locked");
 }
 
 function isSqliteMalformedError(error) {

--- a/test/sqlite-error-classification.test.js
+++ b/test/sqlite-error-classification.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { wrapSqliteBusyError } from "../src/sqlite-state.js";
+
+test("filesystem EBUSY is not classified as SQLite busy", () => {
+  const error = Object.assign(
+    new Error("EBUSY: resource busy or locked, open 'transaction-journal.jsonl'"),
+    { code: "EBUSY" }
+  );
+
+  assert.equal(wrapSqliteBusyError(error, "update session provider metadata"), error);
+});
+
+test("explicit SQLite busy and locked codes retain the existing guidance", () => {
+  for (const code of ["SQLITE_BUSY", "SQLITE_BUSY_SNAPSHOT", "SQLITE_LOCKED", "SQLITE_LOCKED_SHAREDCACHE"]) {
+    const error = Object.assign(new Error("SQLite write failed"), { code });
+    const wrapped = wrapSqliteBusyError(error, "update session provider metadata");
+
+    assert.notEqual(wrapped, error);
+    assert.match(wrapped.message, /state_5\.sqlite is currently in use/);
+  }
+});
+
+test("SQLite lock messages retain the existing guidance when a driver omits the SQLite code", () => {
+  for (const message of ["database is locked", "database table is locked: threads"]) {
+    const error = new Error(message);
+    const wrapped = wrapSqliteBusyError(error, "update session provider metadata");
+
+    assert.notEqual(wrapped, error);
+    assert.match(wrapped.message, /state_5\.sqlite is currently in use/);
+  }
+});


### PR DESCRIPTION
## Summary

Prevent filesystem `EBUSY` failures from being misclassified as SQLite busy/locked errors in the Node CLI.

## Root cause

`isSqliteBusyError()` used a generic `message.includes("busy")` check. Node filesystem errors such as:

```text
EBUSY: resource busy or locked, open '...\transaction-journal.jsonl'
```

therefore received the misleading `state_5.sqlite is currently in use` guidance.

## Changes

- Match explicit `SQLITE_BUSY*` and `SQLITE_LOCKED*` codes.
- Retain SQLite's `database is locked` and `database table is locked` messages.
- Preserve unrelated filesystem `EBUSY` errors unchanged.
- Add focused regression tests for both filesystem and SQLite cases.

## User impact

Journal/file sharing failures now retain their real filesystem diagnostic instead of telling users to close Codex because SQLite is busy.

## Validation

- `node --test test/sqlite-error-classification.test.js`
- `npm test` — 210 passed

## Non-goals and follow-up draft

This PR intentionally does not change rollback or recovery behavior.

A separate follow-up should investigate and design:

1. cross-process coordination between the Node CLI and Windows GUI for one Codex Home;
2. read/write sharing or bounded retry behavior for `transaction-journal.jsonl`;
3. resumable, idempotent recovery for journals left in `rollingBack`;
4. a one-click GUI recovery action bound to the transaction backup;
5. integration tests covering a GUI status scan racing a Node journal append.

That work should remain separate because it changes concurrency and data-integrity behavior beyond this error-classification fix.