### PR TITLE
Publish the official scoped npm package and refresh documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,8 +13,8 @@ body:
     id: version
     attributes:
       label: codex-provider-sync 版本
-      description: 例如 v0.2.4。GUI 版本请填写 Release 版本；CLI 版本请填写 `npm list -g codex-provider-sync` 或安装来源。
-      placeholder: v0.2.4
+      description: 例如 v0.5.0。GUI 版本请填写 Release 版本；CLI 版本请填写 `npm list -g @dailin521/codex-provider-sync` 或安装来源。
+      placeholder: v0.5.0
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
+      - run: npm run web:build
       - run: npm test
 
   desktop-test:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,41 @@
+name: publish npm
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - name: Require the main branch
+        shell: bash
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "npm packages may only be published from main."
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - run: npm ci
+      - run: npm run web:build
+      - run: npm test
+      - run: npm pack --dry-run --json
+      - run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
           dotnet-version: "10.0.x"
 
       - run: npm ci
+      - run: npm run web:build
       - run: npm test
       - run: dotnet build CodexProviderSync.sln --configuration Release
       - run: dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj --configuration Release --no-build

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
-[下载 Windows GUI](https://github.com/Dailin521/codex-provider-sync/releases/latest) · 中文 · [English](docs/README_EN.md) · [日本語](docs/README_JA.md) · [한국어](docs/README_KO.md)
+[**下载 Windows GUI**](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [使用本地 Web UI（需 CLI）](#本地-web-ui)
+
+语言：**中文** · [English](docs/README_EN.md) · [日本語](docs/README_JA.md) · [한국어](docs/README_KO.md)
 
 </div>
 
@@ -23,9 +25,9 @@
 
 | 场景 | 推荐入口 |
 | --- | --- |
-| Windows 桌面 | [原生 Windows GUI](#windows-gui) |
-| macOS 桌面 | [本地 Web UI](#本地-web-ui)；[原生 GUI 构建说明](docs/README_MAC_GUI_ZH.md) |
-| 需要浏览器界面或跨平台使用 | [本地 Web UI](#本地-web-ui) |
+| Windows 桌面 | [下载 Windows GUI](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [使用说明](#windows-gui) |
+| macOS 桌面 | [本地 Web UI（需 CLI）](#本地-web-ui)；[原生 GUI 构建说明](docs/README_MAC_GUI_ZH.md) |
+| 需要浏览器界面或跨平台使用 | [本地 Web UI（需 CLI）](#本地-web-ui) |
 | 脚本、CI 或 WSL | [CLI](#cli) |
 
 ### Windows GUI
@@ -42,9 +44,10 @@
 
 ### 本地 Web UI
 
-已安装 CLI 后运行：
+本地 Web UI 由 CLI 提供。安装 Node.js `16.20.2+` 后，安装本项目官方 npm 包并启动：
 
 ```bash
+npm install -g @dailin521/codex-provider-sync
 codex-provider web
 ```
 
@@ -58,16 +61,16 @@ codex-provider web --port 8792     # 指定端口
 codex-provider web --reset-access  # 重新配对浏览器
 ```
 
-Web UI 默认只监听 `127.0.0.1`，并自动打开浏览器完成配对。存储路径由 Profile 管理，写操作需要确认；Profile 发生变化时必须重新确认。
+Web UI 默认只监听 `127.0.0.1`，并自动打开浏览器完成配对。存储路径由页面顶部的存储配置（Profile）管理，写操作需要确认；存储配置发生变化时必须重新确认。
 
 [Web UI 完整说明](docs/README_WEB_UI_ZH.md)
 
 ### CLI
 
-CLI 支持 Node.js `16.20.2+`。未安装时运行：
+CLI 支持 Node.js `16.20.2+`。安装 Node.js 后，安装本项目官方 npm 包：
 
 ```bash
-npm install -g git+https://github.com/Dailin521/codex-provider-sync.git
+npm install -g @dailin521/codex-provider-sync
 codex-provider status
 codex-provider sync
 ```
@@ -80,6 +83,8 @@ codex-provider sync
 | `codex-provider restore <backup-dir>` | 恢复备份 |
 | `codex-provider watch` | 监听配置和 SQLite 变化 |
 
+`switch` 默认会在目标 Provider section 定义了 `model` 时同步根级 `model`。使用 `--keep-root-model` 保留当前值，或使用 `--model <name>` 显式指定。
+
 SQLite Home 解析顺序：`--sqlite-home` → `config.toml` 根级 `sqlite_home` → `CODEX_SQLITE_HOME` → `<Codex Home>/sqlite`。只有默认布局会回退到 `<Codex Home>/state_5.sqlite`。
 
 ## 当前架构
@@ -90,8 +95,9 @@ flowchart LR
     WebServer --> NodeService["Node Service"]
     CLI["Node CLI"] --> NodeService
 
-    DesktopGUI["Desktop GUI<br/>Windows / macOS"] --> Application[".NET Application"]
+    WindowsGUI["Windows GUI"] --> Application[".NET Application"]
     Application --> DotNetCore[".NET Core"]
+    MacGUI["macOS GUI"] --> DotNetCore
 
     NodeService --> Storage["Codex Storage"]
     DotNetCore --> Storage
@@ -103,12 +109,12 @@ flowchart LR
 ```
 
 - Web UI 和 CLI 使用同一套 Node 服务逻辑。
-- Windows 和 macOS GUI 通过 Application 层调用 .NET Core。
-- 两条路径处理相同的配置、rollout、SQLite 和备份安全边界。
+- Windows GUI 通过 Application 层调用 .NET Core；macOS GUI 当前直接调用 .NET Core。
+- Node 服务和 .NET Core 处理相同的配置、rollout、SQLite 和备份安全边界。
 
 ## 安全边界
 
-- 每次 `sync` / `switch` 前备份到 `~/.codex/backups_state/provider-sync/<timestamp>`。
+- 每次 `sync` / `switch` 前备份到 `<Codex Home>/backups_state/provider-sync/<timestamp>`；使用默认 Codex Home 时即为 `~/.codex/backups_state/provider-sync/<timestamp>`。
 - 不修改消息正文、会话标题、认证信息、`auth.json` 或 `updated_at`。
 - SQLite 被占用时，请关闭 Codex、Codex App 和 app-server 后重试。
 - 活跃会话锁住 rollout 时，其余文件继续处理；结束会话后再次同步即可。
@@ -134,6 +140,8 @@ npm run web:start
 npm test
 dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
 ```
+
+npm 包发布维护流程见 [npm 发布维护指南](docs/NPM_PUBLISHING.md)。CLI/Web 包可以独立发布，不要求同步创建 Windows GUI Release。
 
 ## License
 

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -1,0 +1,36 @@
+# npm 发布维护指南
+
+官方 CLI/Web 包名为 `@dailin521/codex-provider-sync`，公开安装命令为：
+
+```bash
+npm install -g @dailin521/codex-provider-sync
+```
+
+npm 包只包含 Node CLI、Web UI 和相关文档。它与 Windows GUI 的 GitHub Release 独立发布；仅更新 CLI/Web 时，不需要创建 Git tag 或 GUI Release。
+
+## 首次发布
+
+首次发布需要拥有 npm 用户 `dailin521`，并在本机完成 npm 登录和双重验证：
+
+```bash
+npm login
+npm whoami
+npm run publish:npm -- --dry-run
+npm run publish:npm
+```
+
+发布脚本会依次构建 Web UI、运行 Node 测试、预览 npm 包内容，并以公开包发布。不要把 npm token、密码或一次性验证码写入仓库。
+
+## 后续发布
+
+首次发布成功后，在 npm 包设置中为 GitHub Actions 配置 Trusted Publisher：
+
+- GitHub 用户或组织：`Dailin521`
+- 仓库：`codex-provider-sync`
+- 工作流文件：`publish-npm.yml`
+- Environment：`npm`
+- Allowed actions：`npm publish`
+
+之后可在 GitHub Actions 中手动运行 `publish npm`。工作流只允许从 `main` 分支运行，使用短期 OIDC 凭据发布，不需要在 GitHub 保存长期 npm token。
+
+每次发布前先更新 `package.json` 和 `package-lock.json` 中的版本号，并确保目标版本尚未发布。npm 不允许覆盖已经发布的同名同版本包。

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -10,7 +10,7 @@ npm 包只包含 Node CLI、Web UI 和相关文档。它与 Windows GUI 的 GitH
 
 ## 首次发布
 
-首次发布需要 npm 用户 `codexsync` 拥有 `dailin521` 组织，并在本机完成 npm 登录和双重验证：
+首次发布需要 npm 用户 `dailin521` 是同名组织的 owner，并在本机完成 npm 登录和双重验证：
 
 ```bash
 npm login

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -10,7 +10,7 @@ npm 包只包含 Node CLI、Web UI 和相关文档。它与 Windows GUI 的 GitH
 
 ## 首次发布
 
-首次发布需要拥有 npm 用户 `dailin521`，并在本机完成 npm 登录和双重验证：
+首次发布需要 npm 用户 `codexsync` 拥有 `dailin521` 组织，并在本机完成 npm 登录和双重验证：
 
 ```bash
 npm login

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -9,7 +9,9 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 [![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
-[Download Windows GUI](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [中文](../README.md) · English · [日本語](README_JA.md) · [한국어](README_KO.md)
+[**Download Windows GUI**](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [Use the Local Web UI (CLI required)](#local-web-ui)
+
+Language: [中文](../README.md) · **English** · [日本語](README_JA.md) · [한국어](README_KO.md)
 
 </div>
 
@@ -21,30 +23,33 @@ This tool synchronizes session files and the SQLite index, restoring session vis
 
 ## Quick Start
 
+> The Windows GUI and Local Web UI currently use a Simplified Chinese interface.
+
 | Scenario | Recommended interface |
 | --- | --- |
-| Windows desktop | [Native Windows GUI](#windows-gui) |
-| macOS desktop | [Local Web UI](#local-web-ui); [native GUI build guide](README_MAC_GUI_EN.md) |
-| Browser interface or cross-platform use | [Local Web UI](#local-web-ui) |
+| Windows desktop | [Download Windows GUI](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [Usage guide](#windows-gui) |
+| macOS desktop | [Local Web UI (CLI required)](#local-web-ui); [native GUI build guide](README_MAC_GUI_EN.md) |
+| Browser interface or cross-platform use | [Local Web UI (CLI required)](#local-web-ui) |
 | Scripts, CI, or WSL | [CLI](#cli) |
 
 ### Windows GUI
 
 Download `CodexProviderSync.exe` from [Releases](https://github.com/Dailin521/codex-provider-sync/releases/latest):
 
-1. Click Refresh.
+1. Click `刷新` (Refresh).
 2. Select the target provider.
-3. Click Sync Now.
+3. Click `立即同步` (Sync Now).
 
 The application is not code-signed, so Windows may show a security warning. Download only from this project's Releases.
 
-[Full Windows GUI guide](README_GUI_ZH.md)
+[Full Windows GUI guide (Chinese)](README_GUI_ZH.md)
 
 ### Local Web UI
 
-With the CLI installed, run:
+The Local Web UI is provided by the CLI. Install Node.js `16.20.2+`, then install this project's official npm package and start it:
 
 ```bash
+npm install -g @dailin521/codex-provider-sync
 codex-provider web
 ```
 
@@ -58,16 +63,16 @@ codex-provider web --port 8792     # Use a specific port
 codex-provider web --reset-access  # Pair a browser again
 ```
 
-The Web UI listens on `127.0.0.1` by default and opens a browser to pair automatically. Storage paths are managed by profiles, write operations require confirmation, and confirmation is required again if a profile changes.
+The Web UI listens on `127.0.0.1` by default and opens a browser to pair automatically. Storage paths are managed by the storage configuration (profile) at the top of the page. Write operations require confirmation, and confirmation is required again if that configuration changes.
 
-[Full Web UI guide](README_WEB_UI_ZH.md)
+[Full Web UI guide (Chinese)](README_WEB_UI_ZH.md)
 
 ### CLI
 
-The CLI supports Node.js `16.20.2+`. If it is not installed, run:
+The CLI supports Node.js `16.20.2+`. After installing Node.js, install this project's official npm package:
 
 ```bash
-npm install -g git+https://github.com/Dailin521/codex-provider-sync.git
+npm install -g @dailin521/codex-provider-sync
 codex-provider status
 codex-provider sync
 ```
@@ -80,6 +85,8 @@ codex-provider sync
 | `codex-provider restore <backup-dir>` | Restore a backup |
 | `codex-provider watch` | Watch configuration and SQLite changes |
 
+By default, `switch` also updates the root-level `model` when the target provider section defines one. Use `--keep-root-model` to preserve the current value, or `--model <name>` to set it explicitly.
+
 SQLite Home resolution order: `--sqlite-home` → root-level `sqlite_home` in `config.toml` → `CODEX_SQLITE_HOME` → `<Codex Home>/sqlite`. Only the default layout falls back to `<Codex Home>/state_5.sqlite`.
 
 ## Current Architecture
@@ -90,8 +97,9 @@ flowchart LR
     WebServer --> NodeService["Node Service"]
     CLI["Node CLI"] --> NodeService
 
-    DesktopGUI["Desktop GUI<br/>Windows / macOS"] --> Application[".NET Application"]
+    WindowsGUI["Windows GUI"] --> Application[".NET Application"]
     Application --> DotNetCore[".NET Core"]
+    MacGUI["macOS GUI"] --> DotNetCore
 
     NodeService --> Storage["Codex Storage"]
     DotNetCore --> Storage
@@ -103,12 +111,12 @@ flowchart LR
 ```
 
 - The Web UI and CLI share the same Node service logic.
-- The Windows and macOS GUIs call .NET Core through the Application layer.
-- Both paths enforce the same configuration, rollout, SQLite, and backup safety boundaries.
+- The Windows GUI calls .NET Core through the Application layer; the macOS GUI currently calls .NET Core directly.
+- The Node service and .NET Core enforce the same configuration, rollout, SQLite, and backup safety boundaries.
 
 ## Safety boundaries
 
-- Before every `sync` or `switch`, a backup is created at `~/.codex/backups_state/provider-sync/<timestamp>`.
+- Before every `sync` or `switch`, a backup is created at `<Codex Home>/backups_state/provider-sync/<timestamp>`; with the default Codex Home, this is `~/.codex/backups_state/provider-sync/<timestamp>`.
 - Does not modify message content, session titles, authentication data, `auth.json`, or `updated_at`.
 - If SQLite is in use, close Codex, Codex App, and app-server, then retry.
 - If an active session locks rollout files, other files continue; sync again after that session ends.
@@ -119,11 +127,11 @@ flowchart LR
 
 - [AI / Agent Guide](../AGENTS.md)
 
-- [Windows GUI](README_GUI_ZH.md)
-- [Web UI](README_WEB_UI_ZH.md)
+- [Windows GUI guide (Chinese)](README_GUI_ZH.md)
+- [Web UI guide (Chinese)](README_WEB_UI_ZH.md)
 - [中文](../README.md) · [日本語](README_JA.md) · [한국어](README_KO.md)
 - [macOS GUI: 中文](README_MAC_GUI_ZH.md) · [English](README_MAC_GUI_EN.md)
-- [How it works](WORKING_PRINCIPLE_ZH.md) · [Changelog](../CHANGELOG.md) · [Contributing](../CONTRIBUTING.md)
+- [How it works (Chinese)](WORKING_PRINCIPLE_ZH.md) · [Changelog](../CHANGELOG.md) · [Contributing](../CONTRIBUTING.md)
 
 ## Development
 
@@ -134,6 +142,8 @@ npm run web:start
 npm test
 dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
 ```
+
+Maintainers can publish the CLI/Web package independently of Windows GUI releases. See the [npm publishing guide (Chinese)](NPM_PUBLISHING.md).
 
 ## License
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -9,7 +9,9 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 [![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
-[Windows GUI をダウンロード](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [中文](../README.md) · [English](README_EN.md) · 日本語 · [한국어](README_KO.md)
+[**Windows GUI をダウンロード**](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [ローカル Web UI を使う（CLI が必要）](#ローカル-web-ui)
+
+言語：[中文](../README.md) · [English](README_EN.md) · **日本語** · [한국어](README_KO.md)
 
 </div>
 
@@ -21,30 +23,33 @@
 
 ## クイックスタート
 
+> Windows GUI とローカル Web UI の画面表示は現在、簡体字中国語のみです。
+
 | 利用場面 | 推奨する入口 |
 | --- | --- |
-| Windows デスクトップ | [ネイティブ Windows GUI](#windows-gui) |
-| macOS デスクトップ | [ローカル Web UI](#ローカル-web-ui)・[ネイティブ GUI のビルド手順](README_MAC_GUI_EN.md) |
-| ブラウザ UI またはクロスプラットフォーム利用 | [ローカル Web UI](#ローカル-web-ui) |
+| Windows デスクトップ | [Windows GUI をダウンロード](https://github.com/Dailin521/codex-provider-sync/releases/latest)・[使い方](#windows-gui) |
+| macOS デスクトップ | [ローカル Web UI（CLI が必要）](#ローカル-web-ui)・[ネイティブ GUI のビルド手順（英語）](README_MAC_GUI_EN.md) |
+| ブラウザ UI またはクロスプラットフォーム利用 | [ローカル Web UI（CLI が必要）](#ローカル-web-ui) |
 | スクリプト、CI、または WSL | [CLI](#cli) |
 
 ### Windows GUI
 
 [Releases](https://github.com/Dailin521/codex-provider-sync/releases/latest) から `CodexProviderSync.exe` をダウンロードします。
 
-1. 「Refresh」をクリックします。
+1. 「刷新」（Refresh）をクリックします。
 2. 対象の Provider を選択します。
-3. 「Sync Now」をクリックします。
+3. 「立即同步」（Sync Now）をクリックします。
 
 コード署名は付与していないため、Windows でセキュリティ警告が表示される場合があります。本プロジェクトの Releases からのみダウンロードしてください。
 
-[Windows GUI の詳細](README_GUI_ZH.md)
+[Windows GUI の詳細（中国語）](README_GUI_ZH.md)
 
 ### ローカル Web UI
 
-CLI のインストール後に実行します。
+ローカル Web UI は CLI に含まれています。Node.js `16.20.2+` をインストールし、本プロジェクトの公式 npm パッケージをインストールして起動します。
 
 ```bash
+npm install -g @dailin521/codex-provider-sync
 codex-provider web
 ```
 
@@ -58,16 +63,16 @@ codex-provider web --port 8792     # ポートを指定する
 codex-provider web --reset-access  # ブラウザを再ペアリングする
 ```
 
-Web UI はデフォルトで `127.0.0.1` のみで待ち受け、ブラウザを自動で開いてペアリングします。保存先は Profile で管理し、書き込み操作には確認が必要です。Profile が変更された場合は再確認が必要です。
+Web UI はデフォルトで `127.0.0.1` のみで待ち受け、ブラウザを自動で開いてペアリングします。保存先はページ上部の保存設定（Profile）で管理します。書き込み操作には確認が必要で、保存設定が変更された場合は再確認が必要です。
 
-[Web UI の詳細](README_WEB_UI_ZH.md)
+[Web UI の詳細（中国語）](README_WEB_UI_ZH.md)
 
 ### CLI
 
-CLI は Node.js `16.20.2+` をサポートします。未インストールの場合は次を実行します。
+CLI は Node.js `16.20.2+` をサポートします。Node.js のインストール後、本プロジェクトの公式 npm パッケージをインストールします。
 
 ```bash
-npm install -g git+https://github.com/Dailin521/codex-provider-sync.git
+npm install -g @dailin521/codex-provider-sync
 codex-provider status
 codex-provider sync
 ```
@@ -80,6 +85,8 @@ codex-provider sync
 | `codex-provider restore <backup-dir>` | バックアップを復元する |
 | `codex-provider watch` | 設定と SQLite の変更を監視する |
 
+`switch` は、対象 Provider section に `model` が定義されている場合、デフォルトでルートレベルの `model` も更新します。現在の値を保持するには `--keep-root-model`、明示的に指定するには `--model <name>` を使用します。
+
 SQLite Home の解決順序: `--sqlite-home` → `config.toml` ルートの `sqlite_home` → `CODEX_SQLITE_HOME` → `<Codex Home>/sqlite`。デフォルトレイアウトだけが `<Codex Home>/state_5.sqlite` にフォールバックします。
 
 ## 現在のアーキテクチャ
@@ -90,8 +97,9 @@ flowchart LR
     WebServer --> NodeService["Node Service"]
     CLI["Node CLI"] --> NodeService
 
-    DesktopGUI["Desktop GUI<br/>Windows / macOS"] --> Application[".NET Application"]
+    WindowsGUI["Windows GUI"] --> Application[".NET Application"]
     Application --> DotNetCore[".NET Core"]
+    MacGUI["macOS GUI"] --> DotNetCore
 
     NodeService --> Storage["Codex Storage"]
     DotNetCore --> Storage
@@ -103,12 +111,12 @@ flowchart LR
 ```
 
 - Web UI と CLI は同じ Node サービスロジックを使用します。
-- Windows/macOS の GUI は Application 層を通じて .NET Core を呼び出します。
-- 両方の経路で同じ設定、rollout、SQLite、バックアップの安全境界を扱います。
+- Windows GUI は Application 層を通じて .NET Core を呼び出し、macOS GUI は現在 .NET Core を直接呼び出します。
+- Node サービスと .NET Core は同じ設定、rollout、SQLite、バックアップの安全境界を扱います。
 
 ## 安全上の境界
 
-- `sync` / `switch` の前に、毎回 `~/.codex/backups_state/provider-sync/<timestamp>` へバックアップします。
+- `sync` / `switch` の前に、毎回 `<Codex Home>/backups_state/provider-sync/<timestamp>` へバックアップします。デフォルトの Codex Home では `~/.codex/backups_state/provider-sync/<timestamp>` です。
 - メッセージ本文、セッションタイトル、認証情報、`auth.json`、`updated_at` は変更しません。
 - SQLite が使用中の場合は、Codex、Codex App、app-server を閉じてから再試行してください。
 - アクティブなセッションが rollout をロックしている場合、他のファイルは続行します。セッション終了後にもう一度同期してください。
@@ -119,11 +127,11 @@ flowchart LR
 
 - [AI / Agent ガイド](../AGENTS.md)
 
-- [Windows GUI](README_GUI_ZH.md)
-- [Web UI](README_WEB_UI_ZH.md)
+- [Windows GUI（中国語）](README_GUI_ZH.md)
+- [Web UI（中国語）](README_WEB_UI_ZH.md)
 - [中文](../README.md) · [English](README_EN.md) · 日本語 · [한국어](README_KO.md)
 - [macOS GUI: 中文](README_MAC_GUI_ZH.md) · [English](README_MAC_GUI_EN.md)
-- [仕組み](WORKING_PRINCIPLE_ZH.md) · [変更履歴](../CHANGELOG.md) · [コントリビューションガイド](../CONTRIBUTING.md)
+- [仕組み（中国語）](WORKING_PRINCIPLE_ZH.md) · [変更履歴](../CHANGELOG.md) · [コントリビューションガイド](../CONTRIBUTING.md)
 
 ## 開発
 
@@ -134,6 +142,8 @@ npm run web:start
 npm test
 dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
 ```
+
+メンテナーは、Windows GUI の Release とは独立して CLI/Web パッケージを公開できます。[npm 公開ガイド（中国語）](NPM_PUBLISHING.md)を参照してください。
 
 ## License
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -9,7 +9,9 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 [![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
-[Windows GUI 다운로드](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [中文](../README.md) · [English](README_EN.md) · [日本語](README_JA.md) · 한국어
+[**Windows GUI 다운로드**](https://github.com/Dailin521/codex-provider-sync/releases/latest) · [로컬 Web UI 사용 (CLI 필요)](#로컬-web-ui)
+
+언어: [中文](../README.md) · [English](README_EN.md) · [日本語](README_JA.md) · **한국어**
 
 </div>
 
@@ -21,30 +23,33 @@
 
 ## 빠른 시작
 
+> Windows GUI와 로컬 Web UI의 화면 언어는 현재 중국어 간체만 지원합니다.
+
 | 상황 | 권장 방법 |
 | --- | --- |
-| Windows 데스크톱 | [네이티브 Windows GUI](#windows-gui) |
-| macOS 데스크톱 | [로컬 Web UI](#로컬-web-ui) / [네이티브 GUI 빌드 안내](README_MAC_GUI_EN.md) |
-| 브라우저 UI 또는 크로스 플랫폼 사용 | [로컬 Web UI](#로컬-web-ui) |
+| Windows 데스크톱 | [Windows GUI 다운로드](https://github.com/Dailin521/codex-provider-sync/releases/latest) / [사용 방법](#windows-gui) |
+| macOS 데스크톱 | [로컬 Web UI (CLI 필요)](#로컬-web-ui) / [네이티브 GUI 빌드 안내 (영문)](README_MAC_GUI_EN.md) |
+| 브라우저 UI 또는 크로스 플랫폼 사용 | [로컬 Web UI (CLI 필요)](#로컬-web-ui) |
 | 스크립트, CI 또는 WSL | [CLI](#cli) |
 
 ### Windows GUI
 
 [Releases](https://github.com/Dailin521/codex-provider-sync/releases/latest)에서 `CodexProviderSync.exe`를 다운로드합니다.
 
-1. "새로 고침"을 클릭합니다.
+1. `刷新`(새로 고침)을 클릭합니다.
 2. 대상 Provider를 선택합니다.
-3. "지금 동기화"를 클릭합니다.
+3. `立即同步`(지금 동기화)를 클릭합니다.
 
 프로그램은 코드 서명되지 않았으므로 Windows에서 보안 경고가 표시될 수 있습니다. 이 프로젝트의 Releases에서만 다운로드하세요.
 
-[Windows GUI 전체 안내](README_GUI_ZH.md)
+[Windows GUI 전체 안내 (중국어)](README_GUI_ZH.md)
 
 ### 로컬 Web UI
 
-CLI를 설치한 뒤 실행합니다.
+로컬 Web UI는 CLI에 포함되어 있습니다. Node.js `16.20.2+`를 설치한 다음 이 프로젝트의 공식 npm 패키지를 설치하고 실행하세요.
 
 ```bash
+npm install -g @dailin521/codex-provider-sync
 codex-provider web
 ```
 
@@ -58,16 +63,16 @@ codex-provider web --port 8792     # 포트 지정
 codex-provider web --reset-access  # 브라우저 재페어링
 ```
 
-Web UI는 기본적으로 `127.0.0.1`에서만 수신하며, 브라우저를 자동으로 열어 페어링을 진행합니다. 저장 경로는 Profile로 관리하고 쓰기 작업에는 확인이 필요합니다. Profile이 변경되면 다시 확인해야 합니다.
+Web UI는 기본적으로 `127.0.0.1`에서만 수신하며, 브라우저를 자동으로 열어 페어링을 진행합니다. 저장 경로는 페이지 상단의 저장 구성(Profile)에서 관리합니다. 쓰기 작업에는 확인이 필요하며, 저장 구성이 변경되면 다시 확인해야 합니다.
 
-[Web UI 전체 안내](README_WEB_UI_ZH.md)
+[Web UI 전체 안내 (중국어)](README_WEB_UI_ZH.md)
 
 ### CLI
 
-CLI는 Node.js `16.20.2+`를 지원합니다. 설치하지 않았다면 다음을 실행합니다.
+CLI는 Node.js `16.20.2+`를 지원합니다. Node.js를 설치한 후 이 프로젝트의 공식 npm 패키지를 설치합니다.
 
 ```bash
-npm install -g git+https://github.com/Dailin521/codex-provider-sync.git
+npm install -g @dailin521/codex-provider-sync
 codex-provider status
 codex-provider sync
 ```
@@ -80,6 +85,8 @@ codex-provider sync
 | `codex-provider restore <backup-dir>` | 백업 복원 |
 | `codex-provider watch` | 설정과 SQLite 변경 감시 |
 
+대상 Provider section에 `model`이 정의되어 있으면 `switch`는 기본적으로 루트 수준의 `model`도 업데이트합니다. 현재 값을 유지하려면 `--keep-root-model`, 명시적으로 지정하려면 `--model <name>`을 사용하세요.
+
 SQLite Home 해석 순서: `--sqlite-home` → `config.toml` 루트의 `sqlite_home` → `CODEX_SQLITE_HOME` → `<Codex Home>/sqlite`. 기본 레이아웃에서만 `<Codex Home>/state_5.sqlite`로 대체합니다.
 
 ## 현재 아키텍처
@@ -90,8 +97,9 @@ flowchart LR
     WebServer --> NodeService["Node Service"]
     CLI["Node CLI"] --> NodeService
 
-    DesktopGUI["Desktop GUI<br/>Windows / macOS"] --> Application[".NET Application"]
+    WindowsGUI["Windows GUI"] --> Application[".NET Application"]
     Application --> DotNetCore[".NET Core"]
+    MacGUI["macOS GUI"] --> DotNetCore
 
     NodeService --> Storage["Codex Storage"]
     DotNetCore --> Storage
@@ -103,12 +111,12 @@ flowchart LR
 ```
 
 - Web UI와 CLI는 동일한 Node 서비스 로직을 사용합니다.
-- Windows/macOS GUI는 Application 계층을 통해 .NET Core를 호출합니다.
-- 두 경로는 동일한 설정, rollout, SQLite, 백업 안전 범위를 처리합니다.
+- Windows GUI는 Application 계층을 통해 .NET Core를 호출하고, macOS GUI는 현재 .NET Core를 직접 호출합니다.
+- Node 서비스와 .NET Core는 동일한 설정, rollout, SQLite, 백업 안전 범위를 처리합니다.
 
 ## 안전 범위
 
-- 매 `sync` / `switch` 전 `~/.codex/backups_state/provider-sync/<timestamp>`에 백업합니다.
+- 매 `sync` / `switch` 전 `<Codex Home>/backups_state/provider-sync/<timestamp>`에 백업합니다. 기본 Codex Home에서는 `~/.codex/backups_state/provider-sync/<timestamp>`입니다.
 - 메시지 본문, 세션 제목, 인증 정보, `auth.json`, `updated_at`은 수정하지 않습니다.
 - SQLite가 사용 중이면 Codex, Codex App, app-server를 닫은 뒤 다시 시도하세요.
 - 활성 세션이 rollout을 잠그면 나머지 파일은 계속 처리합니다. 세션 종료 후 다시 동기화하면 됩니다.
@@ -119,11 +127,11 @@ flowchart LR
 
 - [AI / Agent 가이드](../AGENTS.md)
 
-- [Windows GUI](README_GUI_ZH.md)
-- [Web UI](README_WEB_UI_ZH.md)
+- [Windows GUI (중국어)](README_GUI_ZH.md)
+- [Web UI (중국어)](README_WEB_UI_ZH.md)
 - [中文](../README.md) · [English](README_EN.md) · [日本語](README_JA.md)
 - [macOS GUI: 中文](README_MAC_GUI_ZH.md) · [English](README_MAC_GUI_EN.md)
-- [작동 원리](WORKING_PRINCIPLE_ZH.md) · [변경 이력](../CHANGELOG.md) · [기여 안내](../CONTRIBUTING.md)
+- [작동 원리 (중국어)](WORKING_PRINCIPLE_ZH.md) · [변경 이력](../CHANGELOG.md) · [기여 안내](../CONTRIBUTING.md)
 
 ## 개발
 
@@ -134,6 +142,8 @@ npm run web:start
 npm test
 dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
 ```
+
+유지관리자는 Windows GUI Release와 별도로 CLI/Web 패키지를 게시할 수 있습니다. [npm 게시 안내(중국어)](NPM_PUBLISHING.md)를 참조하세요.
 
 ## License
 

--- a/docs/README_WEB_UI_ZH.md
+++ b/docs/README_WEB_UI_ZH.md
@@ -4,9 +4,10 @@ Web UI 是现有 CLI 和 Desktop GUI 的浏览器界面。它不会在浏览器�
 
 ## 启动
 
-安装依赖时会自动构建 Web 资源。之后运行：
+Web UI 由 CLI 提供。安装 Node.js `16.20.2+` 后，安装本项目官方 npm 包并启动：
 
 ```bash
+npm install -g @dailin521/codex-provider-sync
 codex-provider web
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "codex-provider-sync",
+  "name": "@dailin521/codex-provider-sync",
   "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "codex-provider-sync",
+      "name": "@dailin521/codex-provider-sync",
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "codex-provider-sync",
+  "name": "@dailin521/codex-provider-sync",
   "version": "0.5.0",
   "description": "Synchronize Codex session provider metadata across rollout files and SQLite state.",
   "type": "module",
@@ -18,8 +18,7 @@
     "test": "node --test",
     "web:build": "vite build --config web/vite.config.js",
     "web:start": "node src/cli.js web",
-    "publish:npm": "node scripts/publish-npm.js",
-    "prepare": "npm run web:build"
+    "publish:npm": "node scripts/publish-npm.js"
   },
   "engines": {
     "node": ">=16.20.2"
@@ -30,7 +29,19 @@
     "sessions",
     "provider"
   ],
+  "author": "Dailin521",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Dailin521/codex-provider-sync.git"
+  },
+  "homepage": "https://github.com/Dailin521/codex-provider-sync#readme",
+  "bugs": {
+    "url": "https://github.com/Dailin521/codex-provider-sync/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "optionalDependencies": {
     "better-sqlite3": "8.7.0"
   },

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -39,13 +39,31 @@ function parseArgs(argv) {
   return options;
 }
 
-function npmCommand() {
-  return process.platform === "win32" ? "npm.cmd" : "npm";
+function npmInvocation(args) {
+  const candidates = [
+    process.env.npm_execpath?.trim(),
+    path.resolve(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js"),
+    path.resolve(path.dirname(process.execPath), "..", "lib", "node_modules", "npm", "bin", "npm-cli.js"),
+    ...(process.env.PATH ?? "")
+      .split(path.delimiter)
+      .filter(Boolean)
+      .map((directory) => path.resolve(directory.replace(/^"|"$/g, ""), "node_modules", "npm", "bin", "npm-cli.js")),
+  ];
+  const npmCli = candidates.find((candidate) => candidate && fs.existsSync(candidate));
+  if (npmCli) {
+    return { command: process.execPath, args: [npmCli, ...args] };
+  }
+
+  if (process.platform === "win32") {
+    throw new Error("Could not locate npm-cli.js. Run this script through `npm run publish:npm` or repair the Node.js/npm installation.");
+  }
+  return { command: "npm", args };
 }
 
 function runNpm(args, { env = process.env } = {}) {
   console.log(`\n$ npm ${args.map((value) => value === env.NPM_OTP ? "--otp ******" : value).join(" ")}`);
-  const result = spawnSync(npmCommand(), args, { cwd: rootDir, env, stdio: "inherit" });
+  const invocation = npmInvocation(args);
+  const result = spawnSync(invocation.command, invocation.args, { cwd: rootDir, env, stdio: "inherit" });
   if (result.error) throw result.error;
   if (result.status !== 0) throw new Error(`npm ${args[0]} failed with exit code ${result.status}.`);
 }
@@ -66,7 +84,7 @@ function main() {
   console.log(`Preparing ${manifest.name}@${manifest.version} for npm.`);
 
   const registryArgs = ["--registry", options.registry];
-  runNpm(["whoami", ...registryArgs]);
+  if (!options.dryRun) runNpm(["whoami", ...registryArgs]);
   runNpm(["run", "web:build"]);
   if (!options.skipTests) runNpm(["test"]);
   runNpm(["pack", "--dry-run", "--json", ...registryArgs]);


### PR DESCRIPTION
## Summary

- migrate the CLI package to the project-owned `@dailin521/codex-provider-sync` npm scope
- add an independent, manually triggered npm publishing workflow and maintainer guide
- make CI and GUI release builds explicitly produce the Web UI bundle
- refresh Chinese, English, Japanese, and Korean installation and architecture documentation
- fix backup-path, Windows GUI link, Web UI prerequisite, and provider-switch guidance

## Why

The Git-based global install path ran the package lifecycle in a temporary clone and could fail because the Web build toolchain was unavailable. A project-owned public npm package provides a simpler and reproducible installation command while keeping npm releases independent from GUI releases.

## User impact

Users can install the CLI and local Web UI with:

```powershell
npm install -g @dailin521/codex-provider-sync
codex-provider web
```

The package is already publicly available as `@dailin521/codex-provider-sync@0.5.0`, so the documented command is live.

## Validation

- production Web UI build passed
- Node test suite passed: 259/259
- npm pack and publish dry run passed
- public registry install of `@dailin521/codex-provider-sync@0.5.0` passed in a clean prefix
- installed CLI exposes `web`, `restore`, and `--reset-access`
- `git diff --check` passed

## Release scope

This PR does not create a Git tag or GUI/PC release. Future npm versions are published independently through the manual `publish-npm.yml` workflow.