### PR TITLE
fix: preserve reparse fingerprints in checked sync

### DIFF
--- a/desktop/CodexProviderSync.Core.Tests/CoreWritePlanningTests.cs
+++ b/desktop/CodexProviderSync.Core.Tests/CoreWritePlanningTests.cs
@@ -45,6 +45,53 @@ public sealed class CoreWritePlanningTests
     }
 
     [Fact]
+    public async Task ContentFingerprintHint_DoesNotOverrideReparseFingerprint_OnUnix()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        string root = Path.Combine(Path.GetTempPath(), $"codex-provider-reparse-hint-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        string targetPath = Path.Combine(root, "rollout-target.jsonl");
+        string linkPath = Path.Combine(root, "rollout-link.jsonl");
+        await File.WriteAllTextAsync(targetPath, "{\"type\":\"session_meta\"}\n");
+        File.CreateSymbolicLink(linkPath, targetPath);
+        try
+        {
+            FileInfo linkInfo = new(linkPath);
+            string contentDigest = "sha256:" + Convert.ToHexString(
+                    SHA256.HashData(await File.ReadAllBytesAsync(linkPath)))
+                .ToLowerInvariant()
+                + $":{linkInfo.Length}:{linkInfo.LastWriteTimeUtc.Ticks}";
+            CoreWritePlanSnapshot hinted = await CoreWriteSnapshotBuilder.BuildAsync(
+                "sync",
+                "hinted-reparse",
+                [new CoreWriteTargetSpec(linkPath, "replace")],
+                contentFingerprintHints:
+                [
+                    new CoreWriteContentFingerprintHint(
+                        linkPath,
+                        contentDigest,
+                        linkInfo.Length,
+                        linkInfo.LastWriteTimeUtc.Ticks)
+                ]);
+            CoreWritePlanSnapshot fresh = await CoreWriteSnapshotBuilder.BuildAsync(
+                "sync",
+                "hinted-reparse",
+                [new CoreWriteTargetSpec(linkPath, "replace")]);
+
+            CoreWriteSnapshotBuilder.AssertExactMatch(hinted, fresh);
+            Assert.NotEqual(contentDigest, Assert.Single(hinted.Targets).Fingerprint);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task CheckedSync_RejectsDriftBeforeBackupOrMutation()
     {
         TestCodexHomeFixture fixture = await TestCodexHomeFixture.CreateAsync();

--- a/desktop/CodexProviderSync.Core/CoreWritePlanning.cs
+++ b/desktop/CodexProviderSync.Core/CoreWritePlanning.cs
@@ -88,6 +88,10 @@ internal static class CoreWriteSnapshotBuilder
             {
                 throw new CoreWritePlanStaleException();
             }
+            if ((File.GetAttributes(fullPath) & FileAttributes.ReparsePoint) != 0)
+            {
+                continue;
+            }
             fingerprintCache[(fullPath, CoreWriteFingerprintMode.Content)] = hint.Fingerprint;
         }
         IReadOnlyList<CoreWritePlanTarget> capturedTargets = await CaptureTargetsAsync(


### PR DESCRIPTION
## 目的 / Why

Checked sync builds its preview with content fingerprint hints, but rebuilds the snapshot without those hints immediately before writing. A hint for a symlink currently wins before the reparse-point check, so the two snapshots use different fingerprints and an unchanged rollout is rejected as stale.

## 关联 Issue / Related issue

Closes #77

## 改动 / Changes

- Ignore content fingerprint hints for reparse-point paths so both snapshots use the existing canonical reparse fingerprint.
- Add a regression test with a real Unix symlink that compares hinted and freshly computed snapshots.

## 影响范围 / Impact

- [ ] Node.js CLI
- [x] Shared .NET Core
- [x] Windows GUI
- [x] macOS GUI
- [ ] WSL / SQLite paths
- [ ] Backup / restore
- [ ] CI / GitHub Actions
- [ ] Documentation

### 数据写入 / Data writes

No new write path or data format. Checked sync still uses the existing Core transaction after the snapshot match succeeds.

## 验证 / Validation

### Automated

- Windows, .NET 10: `dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj --configuration Release --disable-build-servers --verbosity minimal` — 207 passed, 1 existing skip.
- WSL Ubuntu 24.04, .NET 10: the focused reparse regression passed (1/1).
- The regression failed before the production change with `CoreWritePlanStaleException`, then passed after the fix.
- A full WSL run reached 206 passed and 1 skipped; its single failure was the unrelated locked-file test and reproduces on unmodified `main`.

### Manual

None.

### Not run

None.

## 检查清单 / Checklist

- [x] PR 只包含相关修改 / This PR contains only related changes
- [x] 已补充相关测试，或说明不需要测试的原因 / Tests were added or the reason they are unnecessary is explained
- [x] 如有用户可见变化，已更新相关文档 / Relevant documentation was updated for user-facing changes
- [x] 未提交未脱敏的凭据、会话、SQLite、备份、日志或个人信息 / No unredacted credentials, sessions, databases, backups, logs, or personal data are included