### PR TITLE
Clarify the real provider sync workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ### 切换 Provider 后，让 Codex 历史会话重新可见
 
 [![CI](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync)](https://github.com/Dailin521/codex-provider-sync/releases/latest)
+[![CLI / Web](https://img.shields.io/npm/v/%40dailin521%2Fcodex-provider-sync?label=CLI%20%2F%20Web)](https://www.npmjs.com/package/@dailin521/codex-provider-sync)
+[![Windows GUI](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync?label=Windows%20GUI)](https://github.com/Dailin521/codex-provider-sync/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
@@ -17,9 +18,15 @@
 
 ## 它解决什么
 
-切换 `model_provider` 后，旧会话可能从 Codex Desktop 或 `/resume` 中消失。数据通常仍在磁盘上，只是会话文件和 SQLite 索引中的 Provider 信息没有同步。
+切换 `model_provider` 后，旧会话可能从 Codex Desktop 或 `/resume` 中消失。**数据通常仍在磁盘上**，只是会话文件和 SQLite 索引中的 Provider 信息没有同步。
 
 本工具会同步会话文件和 SQLite 索引，恢复会话可见性，并在写入前创建备份。它不负责登录、账号切换，也不修改 `auth.json` 或消息正文。
+
+> **什么时候需要同步？**
+>
+> - **通常情况：**在官方 OpenAI 与自定义中转之间切换。官方固定使用 `openai`，Provider ID 会发生变化，需要同步历史。
+> - **已有历史混用：**旧会话已经记录为不同的 Provider ID，需要同步到当前 Provider。
+> - **无需同步：**只在共用同一 Provider ID 的自定义中转之间切换，或者 CCSwitch 等工具已经同步了历史。
 
 ## 快速开始
 
@@ -61,7 +68,16 @@ codex-provider web --port 8792     # 指定端口
 codex-provider web --reset-access  # 重新配对浏览器
 ```
 
-Web UI 默认只监听 `127.0.0.1`，并自动打开浏览器完成配对。存储路径由页面顶部的存储配置（Profile）管理，写操作需要确认；存储配置发生变化时必须重新确认。
+Web UI 默认只监听 `127.0.0.1`，并自动打开浏览器完成配对。存储路径由页面顶部的存储配置（Profile）管理，写操作需要确认；按 `Ctrl+C` 停止服务。
+
+#### 切换 Provider 后同步历史
+
+1. 使用 CCSwitch 等常用工具切换 Provider。
+2. 在 Web UI 点击“读取状态”（可跳过）。
+3. 保持“仅同步元数据”，选择目标 Provider（供应商），确认执行同步。
+4. 显示“Provider 元数据已对齐”即完成。
+
+> **注意：** 元数据同步只能恢复历史可见性。跨供应商继续旧会话时，目标后端可能无法解密会话中的 `encrypted_content` 推理内容，导致继续对话或压缩（compact）失败。
 
 [Web UI 完整说明](docs/README_WEB_UI_ZH.md)
 
@@ -118,7 +134,7 @@ flowchart LR
 - 不修改消息正文、会话标题、认证信息、`auth.json` 或 `updated_at`。
 - SQLite 被占用时，请关闭 Codex、Codex App 和 app-server 后重试。
 - 活跃会话锁住 rollout 时，其余文件继续处理；结束会话后再次同步即可。
-- 跨 Provider/account 的 `encrypted_content` 可能只能恢复列表可见性。
+- 跨 Provider/account 继续旧会话时，目标后端可能无法解密 `encrypted_content`，导致继续对话或 compact 失败；遇到这种情况请切回原 Provider/account，或新建会话。
 - Windows 不能直接写入 WSL UNC SQLite Home；请进入 WSL 并使用 Linux 路径运行 CLI。
 
 ## 文档

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -5,7 +5,8 @@
 ### Make Codex history visible again after switching providers
 
 [![CI](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync)](https://github.com/Dailin521/codex-provider-sync/releases/latest)
+[![CLI / Web](https://img.shields.io/npm/v/%40dailin521%2Fcodex-provider-sync?label=CLI%20%2F%20Web)](https://www.npmjs.com/package/@dailin521/codex-provider-sync)
+[![Windows GUI](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync?label=Windows%20GUI)](https://github.com/Dailin521/codex-provider-sync/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 [![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
@@ -17,9 +18,15 @@ Language: [中文](../README.md) · **English** · [日本語](README_JA.md) · 
 
 ## What it solves
 
-After switching `model_provider`, older sessions may disappear from Codex Desktop or `/resume`. The data usually remains on disk, but provider information in session files and the SQLite index is no longer synchronized.
+After switching `model_provider`, older sessions may disappear from Codex Desktop or `/resume`. **The data usually remains on disk**; only the provider information in session files and the SQLite index is out of sync.
 
 This tool synchronizes session files and the SQLite index, restoring session visibility and creating a backup before writing. It does not sign in, switch accounts, or modify `auth.json` or message content.
+
+> **When is synchronization needed?**
+>
+> - **Typical case:** Switching between official OpenAI and a custom relay. Official OpenAI always uses `openai`, so the Provider ID changes and history needs to be synchronized.
+> - **Existing mixed history:** Older sessions already contain different Provider IDs and need to be aligned with the current provider.
+> - **No synchronization needed:** Switching only among custom relays that share one Provider ID, or when CCSwitch or another tool has already synchronized history.
 
 ## Quick Start
 
@@ -63,7 +70,16 @@ codex-provider web --port 8792     # Use a specific port
 codex-provider web --reset-access  # Pair a browser again
 ```
 
-The Web UI listens on `127.0.0.1` by default and opens a browser to pair automatically. Storage paths are managed by the storage configuration (profile) at the top of the page. Write operations require confirmation, and confirmation is required again if that configuration changes.
+The Web UI listens on `127.0.0.1` by default and opens a browser to pair automatically. Storage paths are managed by the storage configuration (profile) at the top of the page. Write operations require confirmation; press `Ctrl+C` to stop the service.
+
+#### Synchronize history after switching providers
+
+1. Switch providers with CCSwitch or your usual tool.
+2. Click `读取状态` (Read Status) in the Web UI if needed (optional).
+3. Keep `仅同步元数据` (Metadata Only), select the target provider, and confirm the sync.
+4. You are done when the page shows `Provider 元数据已对齐` (Provider Metadata Aligned).
+
+> **Note:** Metadata sync restores history visibility only. When continuing an old session across providers, the target backend may be unable to decrypt its `encrypted_content` reasoning data, causing continuation or compaction to fail.
 
 [Full Web UI guide (Chinese)](README_WEB_UI_ZH.md)
 
@@ -120,7 +136,7 @@ flowchart LR
 - Does not modify message content, session titles, authentication data, `auth.json`, or `updated_at`.
 - If SQLite is in use, close Codex, Codex App, and app-server, then retry.
 - If an active session locks rollout files, other files continue; sync again after that session ends.
-- Across providers or accounts, `encrypted_content` may restore list visibility only.
+- When continuing an old session across providers or accounts, the target backend may be unable to decrypt `encrypted_content`, causing continuation or compaction to fail. Return to the original provider/account or start a new session.
 - Windows cannot write directly to a WSL UNC SQLite Home; enter WSL and run the CLI with Linux paths.
 
 ## Documentation

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -5,7 +5,8 @@
 ### Provider 切り替え後も Codex の過去セッションを再表示する
 
 [![CI](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync)](https://github.com/Dailin521/codex-provider-sync/releases/latest)
+[![CLI / Web](https://img.shields.io/npm/v/%40dailin521%2Fcodex-provider-sync?label=CLI%20%2F%20Web)](https://www.npmjs.com/package/@dailin521/codex-provider-sync)
+[![Windows GUI](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync?label=Windows%20GUI)](https://github.com/Dailin521/codex-provider-sync/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 [![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
@@ -17,9 +18,15 @@
 
 ## 解決すること
 
-`model_provider` を切り替えた後、既存セッションが Codex Desktop や `/resume` から消えることがあります。データ自体は通常ディスク上に残っていますが、セッションファイルと SQLite インデックス内の Provider 情報が同期されていません。
+`model_provider` を切り替えた後、既存セッションが Codex Desktop や `/resume` から消えることがあります。**データ自体は通常ディスク上に残っています**。セッションファイルと SQLite インデックス内の Provider 情報だけが同期されていません。
 
 このツールはセッションファイルと SQLite インデックスを同期してセッションの可視性を復元し、書き込み前にバックアップを作成します。ログイン、アカウント切り替え、`auth.json`、メッセージ本文は扱いません。
+
+> **同期が必要なのはいつですか？**
+>
+> - **通常のケース：**公式 OpenAI とカスタム中継先を切り替える場合。公式 OpenAI は常に `openai` を使用するため Provider ID が変わり、履歴の同期が必要です。
+> - **既存履歴で ID が混在している場合：**旧セッションに異なる Provider ID が記録されているため、現在の Provider に揃える必要があります。
+> - **同期が不要なケース：**同じ Provider ID を共有するカスタム中継先だけを切り替える場合、または CCSwitch などがすでに履歴を同期している場合です。
 
 ## クイックスタート
 
@@ -63,7 +70,16 @@ codex-provider web --port 8792     # ポートを指定する
 codex-provider web --reset-access  # ブラウザを再ペアリングする
 ```
 
-Web UI はデフォルトで `127.0.0.1` のみで待ち受け、ブラウザを自動で開いてペアリングします。保存先はページ上部の保存設定（Profile）で管理します。書き込み操作には確認が必要で、保存設定が変更された場合は再確認が必要です。
+Web UI はデフォルトで `127.0.0.1` のみで待ち受け、ブラウザを自動で開いてペアリングします。保存先はページ上部の保存設定（Profile）で管理します。書き込み操作には確認が必要です。サービスは `Ctrl+C` で停止します。
+
+#### Provider 切り替え後に履歴を同期する
+
+1. CCSwitch など普段使用しているツールで Provider を切り替えます。
+2. 必要に応じて Web UI で「读取状态」（Read Status）をクリックします（省略可）。
+3. 「仅同步元数据」（Metadata Only）のまま対象 Provider を選択し、同期の実行を確認します。
+4. 「Provider 元数据已对齐」（Provider Metadata Aligned）が表示されれば完了です。
+
+> **注意：** メタデータ同期で復元されるのは履歴の可視性だけです。Provider をまたいで旧セッションを続行すると、切り替え先のバックエンドが `encrypted_content` の推論内容を復号できず、続行や compact に失敗する場合があります。
 
 [Web UI の詳細（中国語）](README_WEB_UI_ZH.md)
 
@@ -120,7 +136,7 @@ flowchart LR
 - メッセージ本文、セッションタイトル、認証情報、`auth.json`、`updated_at` は変更しません。
 - SQLite が使用中の場合は、Codex、Codex App、app-server を閉じてから再試行してください。
 - アクティブなセッションが rollout をロックしている場合、他のファイルは続行します。セッション終了後にもう一度同期してください。
-- Provider またはアカウントをまたぐ `encrypted_content` は、一覧の可視性しか復元できない場合があります。
+- Provider またはアカウントをまたいで旧セッションを続行すると、切り替え先のバックエンドが `encrypted_content` を復号できず、続行や compact に失敗する場合があります。その場合は元の Provider／アカウントに戻すか、新しいセッションを開始してください。
 - Windows から WSL UNC SQLite Home に直接書き込むことはできません。WSL に入り、Linux パスで CLI を実行してください。
 
 ## ドキュメント

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -5,7 +5,8 @@
 ### Provider 전환 후 Codex의 이전 세션을 다시 표시합니다
 
 [![CI](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/Dailin521/codex-provider-sync/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync)](https://github.com/Dailin521/codex-provider-sync/releases/latest)
+[![CLI / Web](https://img.shields.io/npm/v/%40dailin521%2Fcodex-provider-sync?label=CLI%20%2F%20Web)](https://www.npmjs.com/package/@dailin521/codex-provider-sync)
+[![Windows GUI](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync?label=Windows%20GUI)](https://github.com/Dailin521/codex-provider-sync/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 [![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
@@ -17,9 +18,15 @@
 
 ## 해결하는 문제
 
-`model_provider`를 전환하면 이전 세션이 Codex Desktop 또는 `/resume`에서 사라질 수 있습니다. 데이터는 보통 디스크에 남아 있지만 세션 파일과 SQLite 인덱스의 Provider 정보가 동기화되지 않은 상태입니다.
+`model_provider`를 전환하면 이전 세션이 Codex Desktop 또는 `/resume`에서 사라질 수 있습니다. **데이터는 보통 디스크에 그대로 남아 있으며**, 세션 파일과 SQLite 인덱스의 Provider 정보만 동기화되지 않은 상태입니다.
 
 이 도구는 세션 파일과 SQLite 인덱스를 동기화하여 세션 표시를 복원하고, 쓰기 전에 백업을 만듭니다. 로그인이나 계정 전환은 처리하지 않으며 `auth.json`이나 메시지 본문도 수정하지 않습니다.
+
+> **언제 동기화가 필요한가요?**
+>
+> - **일반적인 경우:** 공식 OpenAI와 사용자 지정 릴레이 사이에서 전환합니다. 공식 OpenAI는 항상 `openai`를 사용하므로 Provider ID가 바뀌며 기록을 동기화해야 합니다.
+> - **기존 기록에 ID가 섞인 경우:** 이전 세션에 서로 다른 Provider ID가 기록되어 있으므로 현재 Provider에 맞춰야 합니다.
+> - **동기화가 필요 없는 경우:** 같은 Provider ID를 공유하는 사용자 지정 릴레이 사이에서만 전환하거나 CCSwitch 같은 도구가 이미 기록을 동기화한 경우입니다.
 
 ## 빠른 시작
 
@@ -63,7 +70,16 @@ codex-provider web --port 8792     # 포트 지정
 codex-provider web --reset-access  # 브라우저 재페어링
 ```
 
-Web UI는 기본적으로 `127.0.0.1`에서만 수신하며, 브라우저를 자동으로 열어 페어링을 진행합니다. 저장 경로는 페이지 상단의 저장 구성(Profile)에서 관리합니다. 쓰기 작업에는 확인이 필요하며, 저장 구성이 변경되면 다시 확인해야 합니다.
+Web UI는 기본적으로 `127.0.0.1`에서만 수신하며, 브라우저를 자동으로 열어 페어링을 진행합니다. 저장 경로는 페이지 상단의 저장 구성(Profile)에서 관리하며 쓰기 작업에는 확인이 필요합니다. 서비스는 `Ctrl+C`로 종료합니다.
+
+#### Provider 전환 후 기록 동기화
+
+1. CCSwitch 등 평소 사용하는 도구로 Provider를 전환합니다.
+2. 필요한 경우 Web UI에서 `读取状态`(상태 읽기)를 클릭합니다(생략 가능).
+3. `仅同步元数据`(메타데이터만 동기화)를 유지한 채 대상 Provider를 선택하고 동기화 실행을 확인합니다.
+4. `Provider 元数据已对齐`(Provider 메타데이터 정렬 완료)가 표시되면 완료입니다.
+
+> **주의:** 메타데이터 동기화는 기록의 표시만 복원합니다. Provider를 바꾼 뒤 이전 세션을 계속하면 대상 백엔드가 `encrypted_content`의 추론 내용을 복호화하지 못해 대화 계속 또는 compact가 실패할 수 있습니다.
 
 [Web UI 전체 안내 (중국어)](README_WEB_UI_ZH.md)
 
@@ -120,7 +136,7 @@ flowchart LR
 - 메시지 본문, 세션 제목, 인증 정보, `auth.json`, `updated_at`은 수정하지 않습니다.
 - SQLite가 사용 중이면 Codex, Codex App, app-server를 닫은 뒤 다시 시도하세요.
 - 활성 세션이 rollout을 잠그면 나머지 파일은 계속 처리합니다. 세션 종료 후 다시 동기화하면 됩니다.
-- Provider/account 간 `encrypted_content`는 목록 표시만 복원할 수 있습니다.
+- Provider 또는 계정을 바꾼 뒤 이전 세션을 계속하면 대상 백엔드가 `encrypted_content`를 복호화하지 못해 대화 계속 또는 compact가 실패할 수 있습니다. 이 경우 원래 Provider/계정으로 돌아가거나 새 세션을 시작하세요.
 - Windows에서는 WSL UNC SQLite Home에 직접 쓸 수 없습니다. WSL에서 Linux 경로로 CLI를 실행하세요.
 
 ## 문서

--- a/docs/README_WEB_UI_ZH.md
+++ b/docs/README_WEB_UI_ZH.md
@@ -26,6 +26,12 @@ codex-provider web --reset-access
 codex-provider web --codex-home /path/to/.codex --sqlite-home /path/to/sqlite
 ```
 
+运行中的服务按 `Ctrl+C` 停止。升级已安装的 CLI/Web UI：
+
+```bash
+npm install -g @dailin521/codex-provider-sync@latest
+```
+
 从仓库开发时也可以运行：
 
 ```bash
@@ -33,6 +39,21 @@ npm install
 npm run web:build
 npm run web:start
 ```
+
+## 典型同步流程
+
+本工具只同步本地元数据，不负责登录或切换账号。已经通过其他工具切换 Provider 时：
+
+1. 使用 CCSwitch 等常用工具切换 Provider，并确认 Codex 可以正常对话。
+2. 在 Web UI 点击“读取状态”（可跳过）。
+3. 在“执行同步”中保持“仅同步元数据”，选择目标 Provider（供应商）。
+4. 核对确认页中的 Codex Home、SQLite Home 和目标 Provider，然后点击“确认执行同步”。
+5. 完成后再次读取状态。两侧元数据都归到当前 Provider，并显示“Provider 元数据已对齐”即为成功。
+6. 以后切回原 Provider 时重复相同步骤；`openai → 自定义 Provider → openai` 两个方向没有区别。
+
+rollout 与 SQLite 的会话总数可能因活动会话写入和索引时序短暂相差 1；这不表示 Provider 元数据未对齐。以两侧的 Provider 分布和页面对齐状态为准。
+
+> **注意：** 元数据同步只能恢复历史可见性。跨供应商继续旧会话时，目标后端可能无法解密会话中的 `encrypted_content` 推理内容，导致继续对话或压缩（compact）失败。遇到这种情况请切回原 Provider/account，或新建会话。
 
 ## 页面功能
 
@@ -89,6 +110,4 @@ Windows 桌面用户默认推荐原生 GUI；Web UI 适合需要浏览器界面�
 
 ## 注意事项
 
-Web UI 不能替代操作系统级关闭 Codex 的要求。执行同步或恢复前仍应关闭 Codex CLI、Codex App、app-server 和相关终端。
-
-如果输出报告锁定的 rollout，操作属于部分成功；会话结束后再次执行同步即可。如果 SQLite 正在使用，核心服务会在修改 rollout 前停止。
+建议在同步或恢复前关闭 Codex CLI、Codex App、app-server 和相关终端。保持会话运行时，未锁定的数据仍可正常同步；如果报告跳过锁定的 rollout，操作属于部分成功，请在该会话结束后再次同步。SQLite 正在使用时，核心服务会在修改 rollout 前停止，此时必须关闭占用进程后重试。


### PR DESCRIPTION
## Summary

- add a concise, real-world Web UI workflow for syncing history after switching providers
- explain when synchronization is needed: official OpenAI ↔ custom relays, existing mixed Provider IDs, and cases that need no extra sync
- call out the cross-provider `encrypted_content` continuation limitation near the workflow
- distinguish npm CLI/Web versions from Windows GUI releases with separate badges
- document npm upgrades, service shutdown, active-session count differences, and locked-resource behavior in the detailed guide
- keep Chinese, English, Japanese, and Korean README pages aligned

## Why

The README explained installation and individual features but did not clearly describe the common user path validated on a real machine. Earlier wording also conflated the `model_provider` field with its Provider ID value and buried the `encrypted_content` limitation.

## User impact

Users now get a short four-step path:

1. switch with CCSwitch or another provider tool
2. optionally read status
3. keep metadata-only mode, select the target provider, and confirm
4. verify that provider metadata is aligned

The detailed guide retains edge-case explanations without making the quick start dense.

## Validation

- `git diff --check` passed
- all four language pages contain the same workflow and decision order
- ambiguous `model_provider / Provider ID` wording was removed
- npm badge endpoint returned HTTP 200

Documentation-only change; no runtime behavior is modified.