### PR TITLE
docs: freeze vNext phase 0 contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ The accepted target architecture and staged migration plan is [vNext Electron + 
 
 It defines the target, not the current implementation. Existing code, tests, and released compatibility contracts remain authoritative until the relevant migration-stage exit criteria pass. Do not delete the .NET implementation, break the CLI/Web contract, or perform a big-bang rewrite ahead of those gates.
 
+Phase 0 decisions and frozen behavior are indexed in the [vNext migration execution index](docs/migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md). Before changing an external behavior, read the applicable [Core behavior contract](docs/architecture/contracts/CORE_EXTERNAL_BEHAVIOR_ZH.md), [CLI contract](docs/architecture/contracts/CLI_CONTRACT_ZH.md), [error-code contract](docs/architecture/contracts/ERROR_CODES_ZH.md), and [behavior fixture catalog](docs/migration/BEHAVIOR_FIXTURES_ZH.md), plus the Accepted ADRs in `docs/adr/`.
+
+An external behavior change must update its contract and add or update a fixture/test in the same PR. Target-state text is not proof that a feature exists: keep current behavior, transitional adapter behavior, and the vNext target explicitly separated.
+
 ## Goal
 
 Restore Codex session visibility after `model_provider` changes by keeping rollout metadata and the resolved SQLite thread index aligned. Do not treat this as an authentication or account-management tool.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ flowchart LR
 ## 文档
 
 - [vNext 架构基线（Electron + Node 单核心）](docs/VNEXT_ELECTRON_NODE_ARCHITECTURE_ZH.md)
+- [vNext 分阶段迁移执行索引](docs/migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md)
 - [AI / Agent 操作指南](AGENTS.md)
 - [Windows GUI](docs/README_GUI_ZH.md)
 - [Web UI](docs/README_WEB_UI_ZH.md)

--- a/docs/ADR-0001-v0.4-automation-architecture.md
+++ b/docs/ADR-0001-v0.4-automation-architecture.md
@@ -1,10 +1,11 @@
 # ADR-0001: v0.4 Application, transaction, and Automation architecture
 
+- Legacy-ID: v0.4/ADR-0001 (pre-vNext namespace)
 - Status: accepted for implementation after independent adversarial review
 - Date: 2026-08-03
 - Scope: v0.4.0
 
-> Historical ADR: this records the v0.4 decision and is not a current user guide or a stable protocol guarantee.
+> Historical ADR: this records the v0.4 decision and is not a current user guide or a stable protocol guarantee. The Accepted vNext series uses the separate `vNext/ADR-0001` through `vNext/ADR-0010` namespace under [`docs/adr/`](adr/0001-electron-over-tauri.md).
 
 ## Context
 

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -12,6 +12,9 @@
 开发与维护：
 
 - [vNext 架构基线（Electron + Node 单核心）](VNEXT_ELECTRON_NODE_ARCHITECTURE_ZH.md)
+- [vNext 迁移执行索引](migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md) · [行为 Fixtures](migration/BEHAVIOR_FIXTURES_ZH.md)
+- vNext 合同：[Core 外部行为](architecture/contracts/CORE_EXTERNAL_BEHAVIOR_ZH.md) · [CLI](architecture/contracts/CLI_CONTRACT_ZH.md) · [错误码](architecture/contracts/ERROR_CODES_ZH.md)
+- vNext ADR：[0001 Electron](adr/0001-electron-over-tauri.md) · [0002 Node Core](adr/0002-node-core-as-single-authority.md) · [0003 CLI](adr/0003-preserve-node-cli-contract.md) · [0004 Renderer](adr/0004-renderer-has-no-node-access.md) · [0005 Utility Process](adr/0005-run-core-in-electron-utility-process.md) · [0006 无应用数据库](adr/0006-no-application-database.md) · [0007 CoreClient](adr/0007-shared-ui-through-core-client.md) · [0008 渐进迁移](adr/0008-incremental-migration-no-big-bang-rewrite.md) · [0009 Plan/Apply](adr/0009-plan-confirm-apply-for-writes.md) · [0010 构建工具](adr/0010-electron-vite-and-electron-builder.md)
 - [贡献指南](../CONTRIBUTING.md) · [AI / Agent 操作指南](../AGENTS.md)
 - [npm 发布维护指南](NPM_PUBLISHING.md)
 - Automation：[快速开始](AUTOMATION_QUICKSTART_ZH.md) · [设计说明](AUTOMATION_DESIGN_NOTES.md)

--- a/docs/VNEXT_ELECTRON_NODE_ARCHITECTURE_ZH.md
+++ b/docs/VNEXT_ELECTRON_NODE_ARCHITECTURE_ZH.md
@@ -7,7 +7,7 @@
 > **最后修订：2026-08-24**  
 > **适用仓库：`Dailin521/codex-provider-sync`**  
 > **目标版本：vNext / 1.0 架构演进**  
-> **配套 ADR：阶段 0 待落地**
+> **配套 ADR：vNext/ADR-0001～0010 已 Accepted；导航见 [迁移执行索引](migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md)**
 
 > 本文定义目标架构与分阶段迁移基线，不代表 `main` 已经完成该架构。迁移期间，当前代码、既有测试与已发布兼容合同仍是现状事实；只有达到对应阶段退出条件后，目标实现才能替代旧实现。
 
@@ -1436,7 +1436,7 @@ Core Runtime 使用 `OperationCoordinator`：
 - 状态读取在写操作完成后刷新；
 - Watch 触发的同步不能抢占用户主动操作；
 - Restore 优先于普通 Sync；
-- Recovery Required 时禁止所有非恢复写操作。
+- Recovery Required 时禁止 Sync、Switch、Watch 自动同步等普通业务写；允许执行 recovery-safe 的 Prune，但不得删除任何 Pending Journal 引用的备份。
 
 ### 18.2 跨进程锁
 

--- a/docs/adr/0001-electron-over-tauri.md
+++ b/docs/adr/0001-electron-over-tauri.md
@@ -1,0 +1,47 @@
+# vNext/ADR-0001：桌面技术路线采用 Electron，而非 Tauri
+
+- Status: Accepted
+- Date: 2026-08-24
+- Scope: vNext
+
+## Context
+
+仓库已经有经过大量故障注入、备份、锁、回滚、WSL 和路径边界测试的 Node 实现。Tauri 会要求以 Rust 重写或长期桥接这套高风险数据核心，使桌面迁移同时承担 UI、运行时和业务语义三类变化。
+
+## Decision
+
+vNext 桌面端采用 Electron。React + TypeScript 负责界面，Electron 负责桌面生命周期和安全 IPC，现有 Node Core 演进为所有正式入口共享的唯一业务核心。
+
+## Decision Drivers
+
+- 最大限度复用已有 Node 安全行为和测试证据；
+- CLI、Local Web UI 与桌面端可以调用同一 Core；
+- 允许以小 PR 迁移，而不是一次性替换；
+- 降低 Windows、macOS、Linux 三平台业务语义漂移。
+
+## Invariants
+
+- 选择 Electron 不授权把业务逻辑放进 Main、Preload 或 Renderer；
+- Renderer 不获得 Node 能力，见 [ADR-0004](0004-renderer-has-no-node-access.md)；
+- Electron 不得解析 CLI 人类文本；
+- Node CLI 继续作为独立、轻量且受支持的入口；
+- 不因为桌面技术选型而改变 Codex 数据格式、备份格式或安全边界。
+
+## Consequences
+
+正面结果是业务核心复用和迁移可逆。代价是安装包与运行内存增加，并需要持续跟进 Electron 安全版本、原生模块 ABI 和三平台打包验证。
+
+## Rejected Alternatives
+
+- **Tauri + Rust Core**：当前会扩大重写风险；未来若要采用，必须有独立 ADR 和等价安全证据。
+- **Electron + .NET Core**：保留双核心，不能解决行为漂移。
+- **继续分别维护原生 GUI**：长期重复实现同一业务规则。
+
+## Migration and Validation
+
+Electron 写能力只能在 Node Public API、结构化合同和共享 Fixtures 建立后开放。三平台 packaged smoke test、Renderer 隔离和 SQLite 驱动矩阵是 Stable 的硬门槛。
+
+## Related
+
+- [vNext 架构基线](../VNEXT_ELECTRON_NODE_ARCHITECTURE_ZH.md)
+- [迁移执行索引](../migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md)

--- a/docs/adr/0002-node-core-as-single-authority.md
+++ b/docs/adr/0002-node-core-as-single-authority.md
@@ -1,0 +1,47 @@
+# vNext/ADR-0002：Node Core 是唯一业务权威
+
+- Status: Accepted
+- Date: 2026-08-24
+- Scope: vNext
+
+## Context
+
+当前 Node CLI/Web 与 .NET Desktop 都能操作 Codex 数据，但重复实现会使锁、备份、恢复、SQLite 和 rollout 规则漂移。Node 路径拥有更完整的跨平台能力，并且是 npm CLI 的既有实现。
+
+## Decision
+
+vNext 以 Node Core 作为唯一业务权威。CLI、Local Web UI 和 Electron Desktop 必须通过稳定 Public API 调用同一 Core；.NET 仅在分阶段迁移门槛通过前作为 Legacy 实现保留。
+
+## Decision Drivers
+
+- 一套数据安全规则、一套错误分类和一套测试语料；
+- 保留现有 CLI 和 WSL 支持；
+- 消除跨 UI 的行为差异；
+- 让 Electron 只承担桌面适配职责。
+
+## Invariants
+
+- Core 不依赖 Electron、React、DOM 或具体 Presenter；
+- CLI/Web 不得绕过 Public API 深导入内部业务模块；
+- .NET 在替代门槛通过前仍是当前桌面行为证据，不得提前删除；
+- 迁移期差异必须记录、选择权威语义并补充 Fixture，不能静默以新实现为准；
+- 锁、备份、Journal、恢复与路径边界只能由 Core 决定。
+
+## Consequences
+
+所有入口最终共享修复和测试。短期内需要维护 Node/.NET 对照测试，并限制 .NET 只修严重缺陷，避免继续增加重复能力。
+
+## Rejected Alternatives
+
+- **Node 与 .NET 双核心长期并存**：维护成本和数据风险不可接受。
+- **以 Electron Main 作为新核心**：绑定运行时并阻塞可测试性。
+- **直接整体翻译为 TypeScript**：把结构迁移和行为改动混在一起。
+
+## Migration and Validation
+
+先建立 `src/public-api.js`，再按模块迁移到 `packages/core`。每次权威转移都必须通过原测试、跨运行时锁/备份/Journal Fixtures 和对应阶段退出条件。
+
+## Related
+
+- [Core 外部行为合同](../architecture/contracts/CORE_EXTERNAL_BEHAVIOR_ZH.md)
+- [渐进迁移 ADR](0008-incremental-migration-no-big-bang-rewrite.md)

--- a/docs/adr/0003-preserve-node-cli-contract.md
+++ b/docs/adr/0003-preserve-node-cli-contract.md
@@ -1,0 +1,50 @@
+# vNext/ADR-0003：保留 Node CLI 兼容合同
+
+- Status: Accepted
+- Date: 2026-08-24
+- Scope: vNext
+
+## Context
+
+`codex-provider` 是现有 npm、自动化、诊断和 WSL 用户的正式入口。Electron 不能成为使用 Core 的前置条件，也不能以桌面迁移为理由破坏脚本。
+
+## Decision
+
+保留现有命令名称、参数语义、默认值和主要人类输出。CLI 与 Electron 调用同一 Core，但各自拥有 Presenter。后续 `--json` 是 opt-in 加法，不替换默认文本模式。
+
+完整冻结面见 [CLI 合同](../architecture/contracts/CLI_CONTRACT_ZH.md)。
+
+## Decision Drivers
+
+- 保护 npm/脚本/WSL 用户；
+- 避免 Electron 依赖进入 CLI 安装；
+- 为自动化提供可版本化的结构化输出；
+- 让人类输出和机器协议独立演进。
+
+## Invariants
+
+- `status`、`sync`、`switch`、`watch`、`web`、`prune-backups`、`restore`、`install-windows-launcher` 不得无迁移方案地移除或改名；
+- 当前 v0.5 退出码只有成功 `0` 与失败 `1`；架构建议的细分退出码尚未实现；
+- 新增 `--json` 时 stdout 必须是单一机器文档，诊断写 stderr；
+- 默认人类文本不是 Electron 或第三方可以解析的 IPC；
+- WSL SQLite 操作继续由运行在 WSL 内的 CLI 支持；
+- npm CLI 不能要求用户安装 Electron。
+
+## Consequences
+
+兼容变化必须有契约测试、SemVer 判断和发布说明。当前解析器对未知 flag 等宽松行为只记为 legacy tolerated，不自动升级为永久 API。
+
+## Rejected Alternatives
+
+- **桌面端执行 CLI 并解析文本**：脆弱且丢失结构化错误/进度。
+- **Electron 替代 npm 包**：破坏服务器、脚本和 WSL 场景。
+- **直接改变默认输出为 JSON**：会破坏现有人类使用和脚本。
+
+## Migration and Validation
+
+Public API 提取阶段保持命令快照与行为测试；结构化错误和 `--json` 分别通过独立 PR 落地。任何新退出码都必须先更新合同并提供兼容说明。
+
+## Related
+
+- [CLI 合同](../architecture/contracts/CLI_CONTRACT_ZH.md)
+- [错误码合同](../architecture/contracts/ERROR_CODES_ZH.md)

--- a/docs/adr/0004-renderer-has-no-node-access.md
+++ b/docs/adr/0004-renderer-has-no-node-access.md
@@ -1,0 +1,48 @@
+# vNext/ADR-0004：Renderer 不拥有 Node 访问能力
+
+- Status: Accepted
+- Date: 2026-08-24
+- Scope: vNext
+
+## Context
+
+Renderer 展示来自本地 Codex 数据的内容。若页面可直接访问文件系统、进程或原始 IPC，渲染层漏洞会直接越过 Core 的路径、认证和事务边界。
+
+## Decision
+
+所有 BrowserWindow 必须启用 `nodeIntegration: false`、`contextIsolation: true`、`sandbox: true` 和 `webSecurity: true`。Preload 只暴露按版本命名、按用途收窄并校验 Schema 的接口。
+
+## Decision Drivers
+
+- 把不可信展示面与本地文件写能力隔离；
+- 让 IPC 能够审计、测试和版本化；
+- 防止 UI 绕过 Core 的 Plan、Lock 和 Backup；
+- 避免 React 代码与 Electron 运行时耦合。
+
+## Invariants
+
+- Renderer 禁止导入 `node:*`、Electron 或 Core 内部模块；
+- 禁止暴露原始 `ipcRenderer`、通用 `send/invoke/on` 或任意文件路径写入；
+- IPC Handler 必须校验 sender、payload、长度、枚举和版本；
+- 只加载本地打包内容，启用严格 CSP，导航/新窗口/权限默认拒绝；
+- 消息正文仅在用户主动打开 History 时本地展示，不进入日志、遥测或诊断包；
+- `auth.json`、令牌和凭据永远不通过 IPC。
+
+## Consequences
+
+桌面功能需要显式 Preload/IPC 合同，开发成本略增；换来边界清晰、测试可替换以及 Renderer 被攻破时更小的影响范围。
+
+## Rejected Alternatives
+
+- **在 Renderer 开启 Node**：风险不可接受。
+- **暴露通用 IPC 包装器**：接口表面不可审计。
+- **Renderer 直接调用 Core**：破坏进程隔离和运行时监督。
+
+## Migration and Validation
+
+Electron Alpha 必须有静态依赖检查、安全配置测试、未知 IPC 拒绝测试和 packaged E2E；写能力开放前还必须验证 Renderer 只能提交 profileId、planId 或 managed backup ID。
+
+## Related
+
+- [Utility Process ADR](0005-run-core-in-electron-utility-process.md)
+- [Shared UI ADR](0007-shared-ui-through-core-client.md)

--- a/docs/adr/0005-run-core-in-electron-utility-process.md
+++ b/docs/adr/0005-run-core-in-electron-utility-process.md
@@ -1,0 +1,51 @@
+# vNext/ADR-0005：Electron 通过 Utility Process 运行 Core
+
+- Status: Accepted
+- Date: 2026-08-24
+- Scope: vNext
+
+## Context
+
+rollout 扫描、SQLite、备份、恢复和 Watch 可能长时间运行。把它们放在 Electron Main 会阻塞窗口生命周期；放在 Renderer 会破坏安全边界。
+
+## Decision
+
+Electron 使用 `utilityProcess` 承载与 CLI 相同的 Node Core。Main 中的 Supervisor 负责懒启动、版本握手、请求路由、进度转发、取消、崩溃归类和优雅关闭。
+
+Utility Process 是 Core 的执行位置，不是第二套业务核心。
+
+## Decision Drivers
+
+- Main 保持响应；
+- 进程崩溃与 UI 崩溃相互隔离；
+- 复用同一 Node Runtime 与模块；
+- 建立可版本化的异步消息边界。
+
+## Invariants
+
+- Main 不实现同步算法、SQL、备份或恢复规则；
+- Runtime 启动先握手 protocol/app/core 版本；
+- 所有请求有 requestId，写操作有 operationId；
+- Utility Process 崩溃时 pending 请求归类为 `CORE_RUNTIME_CRASHED`；
+- 不无限自动重启；下一次用户重试至多重启一次，并先检查 Pending Transaction；
+- 进度观察器失败不得改变事务结果；
+- 取消只能发生在 Core 定义的安全点。
+
+## Consequences
+
+需要 Runtime Schema、Supervisor 状态机和崩溃 E2E，但避免 Main 阻塞，也让桌面和 CLI 共享真正的业务实现。
+
+## Rejected Alternatives
+
+- **在 Main 直接执行长任务**：影响窗口和更新生命周期。
+- **Worker Thread 作为唯一隔离**：不能提供同等级进程崩溃隔离。
+- **独立常驻本地服务**：增加安装、认证和生命周期复杂度。
+
+## Migration and Validation
+
+阶段 3 先开放只读调用，验证握手、并发、崩溃和关闭；阶段 4 才允许写操作。协议不兼容必须 fail closed。
+
+## Related
+
+- [Renderer 安全 ADR](0004-renderer-has-no-node-access.md)
+- [错误码合同](../architecture/contracts/ERROR_CODES_ZH.md)

--- a/docs/adr/0006-no-application-database.md
+++ b/docs/adr/0006-no-application-database.md
@@ -1,0 +1,48 @@
+# vNext/ADR-0006：不引入应用业务数据库
+
+- Status: Accepted
+- Date: 2026-08-24
+- Scope: vNext
+
+## Context
+
+Codex 的 config、rollout、SQLite、global state 与 managed backups 已是业务事实来源。再复制到应用数据库会产生同步、迁移、隐私、恢复和“哪份数据权威”的新问题。
+
+## Decision
+
+vNext 不创建保存 Provider、历史正文、备份索引或操作结果的应用业务数据库。Core 每次从 Codex 存储和 managed backups 读取权威状态。
+
+## Decision Drivers
+
+- 避免双份状态和 Schema Migration；
+- 缩小敏感数据持久化范围；
+- 保持 CLI 与 Desktop 看到同一事实；
+- 让备份/恢复仍由现有格式定义。
+
+## Invariants
+
+- Plan 只在 Core 内短期保存，默认有 TTL，重启后失效；
+- 允许以普通配置文件保存窗口位置、主题、语言和 server-managed profile，不得把它们当业务事实；
+- Backup inventory 只是可重建缓存，不是完整性证明；
+- History 正文不得进入持久缓存、日志、诊断包或遥测；
+- 不读取、复制、记录或修改 `auth.json`、凭据和令牌；
+- 不用新数据库包装或镜像 `state_5.sqlite`。
+
+## Consequences
+
+状态页面可能需要重新扫描，需通过流式扫描和短期内存缓存控制性能；同时避免了新的数据迁移和隐私责任。
+
+## Rejected Alternatives
+
+- **SQLite 应用数据库镜像 Codex 状态**：一致性和隐私成本过高。
+- **长期持久化 Operation Plan**：扩大重放和过期写风险。
+- **缓存 History 正文以加速 UI**：违反最小数据原则。
+
+## Migration and Validation
+
+代码评审和依赖检查必须阻止新 ORM/业务数据库。性能优化先使用可丢弃内存缓存；任何持久化扩展都需要新的 ADR 和数据生命周期说明。
+
+## Related
+
+- [Plan/Confirm/Apply ADR](0009-plan-confirm-apply-for-writes.md)
+- [Core 外部行为合同](../architecture/contracts/CORE_EXTERNAL_BEHAVIOR_ZH.md)

--- a/docs/adr/0007-shared-ui-through-core-client.md
+++ b/docs/adr/0007-shared-ui-through-core-client.md
@@ -1,0 +1,48 @@
+# vNext/ADR-0007：通过 CoreClient 共享 UI
+
+- Status: Accepted
+- Date: 2026-08-24
+- Scope: vNext
+
+## Context
+
+Local Web UI 与 Electron 需要共享 React 功能，但传输方式不同。若页面直接调用 `fetch`、`window` IPC 或 Core，组件会绑定平台并复制数据映射。
+
+## Decision
+
+共享 `packages/app-ui` 只依赖版本化的 `CoreClient` 接口。提供 `HttpCoreClient`、`DesktopCoreClient` 和 `MockCoreClient`，分别适配 Local Web、Electron 和测试。
+
+## Decision Drivers
+
+- 一套 Feature UI 与状态语义；
+- 传输和业务模型分离；
+- 页面可在无 Electron/真实 Codex Home 时测试；
+- 避免 Web 与 Desktop 功能漂移。
+
+## Invariants
+
+- 页面和 feature 禁止直接调用 `fetch('/api/...')` 或 `window.codexProvider`；
+- `app-ui` 不依赖 Electron、Node 或 DOM 之外的桌面能力；
+- CoreClient DTO 与 `packages/contracts` 共享 Schema Version；
+- Client 只做传输、序列化和错误映射，不复制业务规则；
+- 测试通过 MockClient 和临时 Fixtures，不访问真实 `~/.codex`；
+- App Shell 不承载页面专属业务状态。
+
+## Consequences
+
+需要维护客户端适配层和契约测试，但 React 功能可以复用、独立开发和跨入口一致验证。
+
+## Rejected Alternatives
+
+- **Web 与 Desktop 两套 UI**：长期漂移。
+- **页面直接调用平台 API**：难以测试并绕过边界。
+- **统一走 localhost HTTP**：Electron 写能力仍需额外认证和服务生命周期。
+
+## Migration and Validation
+
+先用 HttpCoreClient 包装现有 Web API并保持行为，再逐 feature 拆 UI；Electron Alpha 通过 DesktopCoreClient 接入同一页面。契约测试必须对两个实现运行。
+
+## Related
+
+- [Renderer 安全 ADR](0004-renderer-has-no-node-access.md)
+- [Node Core 单一权威 ADR](0002-node-core-as-single-authority.md)

--- a/docs/adr/0008-incremental-migration-no-big-bang-rewrite.md
+++ b/docs/adr/0008-incremental-migration-no-big-bang-rewrite.md
@@ -1,0 +1,49 @@
+# vNext/ADR-0008：渐进迁移，禁止 Big Bang Rewrite
+
+- Status: Accepted
+- Date: 2026-08-24
+- Scope: vNext
+
+## Context
+
+核心包含文件锁、SQLite 在线备份、原子写、Transaction Journal、崩溃补偿、WSL 和跨运行时兼容。一次性移动目录、改语言、换 UI 并修改行为会让回归无法定位和回滚。
+
+## Decision
+
+迁移按阶段 0～7 和小型 PR 执行。每个 PR 只改变一个主要维度，具有可验证入口/退出门槛，并保持上一正式入口可用。
+
+## Decision Drivers
+
+- 控制数据破坏风险；
+- 让审查、CI 和回滚有明确边界；
+- 用事实解决 Node/.NET 差异；
+- 避免长期不可合并的大分支。
+
+## Invariants
+
+- 不在同一 PR 同时大规模搬迁 Core、翻译 TypeScript 和改变算法；
+- 先建立 Public API，再建立 workspaces，再逐模块迁移；
+- 原测试、故障注入和契约测试必须持续通过；
+- .NET 在替代门槛前不得删除或停止关键 CI；
+- 不宣称跨运行时锁/备份兼容，除非真实双向进程测试通过；
+- 新入口先只读，再分阶段开放 Sync/Switch、Restore/Watch；
+- 每个发现的语义差异要有记录、选择和 Fixture。
+
+## Consequences
+
+迁移提交数量增加，短期存在适配层；但每一步可独立验证、合并、发布和回退。
+
+## Rejected Alternatives
+
+- **长期 rewrite 分支**：漂移大且难审查。
+- **先搭完整 Electron 再补 Core 合同**：会把错误边界固化进 UI。
+- **以新实现输出为准批量更新测试**：丢失既有安全证据。
+
+## Migration and Validation
+
+执行顺序与门槛由 [迁移执行索引](../migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md) 跟踪。跨阶段变更需要更新索引或新 ADR，不能在普通重构 PR 中隐式完成。
+
+## Related
+
+- [迁移执行索引](../migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md)
+- [行为 Fixtures](../migration/BEHAVIOR_FIXTURES_ZH.md)

--- a/docs/adr/0009-plan-confirm-apply-for-writes.md
+++ b/docs/adr/0009-plan-confirm-apply-for-writes.md
@@ -1,0 +1,50 @@
+# vNext/ADR-0009：写操作采用 Plan / Confirm / Apply
+
+- Status: Accepted
+- Date: 2026-08-24
+- Scope: vNext
+
+## Context
+
+Sync、Switch 和 Restore 的目标状态可能在用户查看影响与真正执行之间变化。桌面 UI 不能把几秒前的扫描结果当作当前事实，也不能把任意路径和写参数直接交给 Renderer 重放。
+
+## Decision
+
+所有交互式写操作先由 Core 生成短期 Plan Summary，用户确认后只用 `planId` Apply。Core 在持有正式操作锁后重新校验 Revision 与目标，再创建备份并执行事务。
+
+## Decision Drivers
+
+- 阻止 TOCTOU 和过期确认；
+- 让用户看到真实影响与警告；
+- 把可执行细节留在可信 Core；
+- 为 Desktop/Web 提供一致写状态机。
+
+## Invariants
+
+- Plan 包含 schemaVersion、planId、createdAt、expiresAt、profile/config/storage revision、目标与影响摘要；
+- Plan 短期、单次使用、仅在 Core 内保存，重启即失效；
+- Apply 在锁内重新解析 storage，并校验 profile、config、SQLite DB、rollout snapshot、pending transaction 和可写性；
+- 变化必须返回结构化 stale/changed 错误，要求重新 Prepare；
+- 备份在任何业务目标变更之前完成；
+- Renderer 只能提交 planId，不能提交任意目标路径；
+- CLI 可在同一进程内 Prepare 后立即 Apply，以保持现有单命令体验；
+- Restore 也必须进入该模型，并在开放 Electron Restore 前补齐自身故障补偿合同。
+
+## Consequences
+
+写操作多一个确认阶段并需要 Plan Ledger；换来明确的影响预览、过期控制和统一并发语义。
+
+## Rejected Alternatives
+
+- **Renderer 提交完整执行参数**：容易篡改或过期。
+- **只在 UI 比较 Revision**：CLI 或其他适配器可以绕过。
+- **确认后不重新扫描**：保留 TOCTOU 风险。
+
+## Migration and Validation
+
+先把现有 Web Profile/Storage Revision 下沉到 Core，再实现 Prepare/Apply。需覆盖 expiry、single-use、锁内变更、foreign pending transaction、共享 SQLite Home 和所有崩溃点。
+
+## Related
+
+- [错误码合同](../architecture/contracts/ERROR_CODES_ZH.md)
+- [无应用数据库 ADR](0006-no-application-database.md)

--- a/docs/adr/0010-electron-vite-and-electron-builder.md
+++ b/docs/adr/0010-electron-vite-and-electron-builder.md
@@ -1,0 +1,48 @@
+# vNext/ADR-0010：采用 electron-vite 与 electron-builder
+
+- Status: Accepted
+- Date: 2026-08-24
+- Scope: vNext
+
+## Context
+
+Electron 需要统一构建 Main、Preload、Renderer 和 Core Runtime，并为三平台生成可安装产物。工具链还必须正确处理 ESM、Source Map、原生 SQLite 模块、asar 和发布元数据。
+
+## Decision
+
+采用 `electron-vite` 组织 Electron 构建，采用 `electron-builder` 生成安装包与发布产物。阶段 0 只冻结工具组合，不锁定尚未引入仓库的具体版本号。
+
+## Decision Drivers
+
+- Main/Preload/Renderer 多入口配置清晰；
+- 与 React + TypeScript + Vite 生态一致；
+- 支持 Windows、macOS 和 Linux 打包；
+- 能显式配置 asar、native module 和签名产物。
+
+## Invariants
+
+- 构建产物不得把 Node 能力注入 Renderer；
+- Preload 和 Runtime 只打包允许的依赖；
+- 若需要 `better-sqlite3`，必须针对 Electron ABI 重编译并放入 `asarUnpack`；
+- 构建不得把测试 Fixtures、真实用户数据、凭据或开发密钥打入产物；
+- Electron Major 升级必须运行 SQLite 驱动与 packaged smoke matrix；
+- 版本、签名、公证、更新通道和回滚策略由 Release 门槛验证。
+
+## Consequences
+
+仓库会增加桌面专用构建和平台 CI；同时获得可重复、多入口且可审计的打包路径。
+
+## Rejected Alternatives
+
+- **手写 Vite/Webpack + 平台脚本**：配置面和维护成本更高。
+- **Electron Forge**：可行，但当前路线选择 builder 的产物配置模型；改变需要新 ADR。
+- **把 CLI 打入完整 Electron 包作为核心**：形成文本适配并增加 CLI 依赖。
+
+## Migration and Validation
+
+阶段 3 引入固定版本与 lockfile，并在 Windows x64、macOS x64/arm64、Linux x64 上验证安装/启动、SQLite、Utility Process 和 Renderer 隔离。版本选择必须处于 Electron 官方支持线。
+
+## Related
+
+- [Electron 选型 ADR](0001-electron-over-tauri.md)
+- [Utility Process ADR](0005-run-core-in-electron-utility-process.md)

--- a/docs/architecture/contracts/CLI_CONTRACT_ZH.md
+++ b/docs/architecture/contracts/CLI_CONTRACT_ZH.md
@@ -1,0 +1,477 @@
+# CLI 命令兼容合同
+
+> 状态：Phase 0 兼容基线
+>
+> 基线版本：`@dailin521/codex-provider-sync` v0.5.0
+>
+> 冻结日期：2026-08-24
+>
+> 适用入口：`codex-provider`
+
+## 1. 文档目的
+
+本文冻结 vNext 迁移开始时已经存在的 Node CLI 外部行为，防止提取 Node Core、增加 Electron、重组仓库或迁移到 TypeScript 时无意破坏现有用户和自动化脚本。
+
+本文同时明确区分三类内容：
+
+- **v0.5 当前合同**：当前已发布且迁移期间必须兼容的行为；
+- **legacy tolerated 行为**：当前宽松实现碰巧接受，但不升级为长期公开承诺的行为；
+- **vNext 目标**：需要后续独立设计、测试和发布说明才能生效的新增合同。
+
+目标架构文档中的建议不自动覆盖本文记录的 v0.5 事实。只有对应迁移阶段通过退出条件并更新合同测试后，才能修改当前合同。
+
+## 2. npm 与运行时入口
+
+### 2.1 v0.5 当前合同
+
+| 项目 | 当前值 |
+| --- | --- |
+| npm 包 | `@dailin521/codex-provider-sync` |
+| CLI 命令 | `codex-provider` |
+| 可执行文件 | `src/cli.js` |
+| 模块类型 | ESM，`"type": "module"` |
+| 最低 Node.js | `16.20.2` |
+| npm engine | `>=16.20.2` |
+
+除帮助路径外，CLI 在执行命令前检查 Node.js 版本。不满足最低版本时，向 stderr 输出一行升级提示并以失败退出。
+
+包级脚本的当前名称与含义如下：
+
+| 脚本 | 当前命令 |
+| --- | --- |
+| `npm test` | `node --test` |
+| `npm run web:build` | `vite build --config web/vite.config.js` |
+| `npm run web:start` | `node src/cli.js web` |
+| `npm run publish:npm` | `node scripts/publish-npm.js` |
+
+当前包没有声明 `main` 或 `exports`。正式用户入口是 `bin` 中的 `codex-provider`；包内 `src/*.js` 可以被物理深导入不等于这些内部路径已经成为稳定 npm Public API。
+
+### 2.2 兼容要求
+
+- vNext 引入 Electron 不得迫使现有 CLI 用户额外安装 Electron。
+- 在 v0.x 兼容期内，不得仅因 Electron 构建工具需要更高版本 Node.js，就提高 CLI 的最低 Node.js 版本。
+- 若未来提高最低 Node.js 版本，必须独立评估 SemVer、发布说明和安装失败体验。
+- npm 包仍应提供可直接运行的 JavaScript；CLI 用户不需要安装 TypeScript。
+
+## 3. Codex Home 与 SQLite Home
+
+### 3.1 Codex Home
+
+CLI 解析 Codex Home 的优先级固定为：
+
+1. 当前命令的 `--codex-home PATH`；
+2. 环境变量 `CODEX_HOME`；
+3. 当前用户主目录下的 `~/.codex`。
+
+相对路径按当前工作目录解析为绝对路径。
+
+### 3.2 SQLite Home
+
+CLI 和共享 Core 解析 SQLite Home 的优先级固定为：
+
+1. 当前命令的 `--sqlite-home PATH`；
+2. `config.toml` 根级 `sqlite_home`；
+3. 环境变量 `CODEX_SQLITE_HOME`；
+4. `<Codex Home>/sqlite`。
+
+只有第 4 种默认布局可以回退到旧位置 `<Codex Home>/state_5.sqlite`。显式参数、配置或环境变量选中的 SQLite Home 中缺少 `state_5.sqlite` 时，写操作必须失败，不得静默改用 Codex Home 下的旧数据库。
+
+Windows 下的 `\\wsl.localhost\...` 和 `\\wsl$\...` SQLite Home 仅用于诊断。涉及 SQLite 的操作必须阻止写入，并提示在相应 WSL 发行版内使用 Linux 路径运行 CLI。
+
+## 4. 命令总表
+
+### 4.1 v0.5 当前合同
+
+| 命令 | 主要作用 | 写入 | 关键默认值 |
+| --- | --- | --- | --- |
+| `status` | 检查 Provider、rollout、SQLite、备份与恢复状态 | 否 | 当前存储布局 |
+| `sync` | 将历史元数据同步到目标 Provider | 是 | 当前 Provider；保留 5 份备份 |
+| `switch` | 修改根级 Provider，并同步历史元数据 | 是 | 跟随目标 Provider 的 model；保留 5 份备份 |
+| `watch` | 监听配置和 SQLite 变化并自动同步 | 是 | 750 ms；监听 state DB；持续运行 |
+| `web` | 启动本地 Web UI | Web 操作可写 | 端口 8791；自动打开浏览器 |
+| `prune-backups` | 清理较旧的托管备份 | 是，删除托管备份 | 保留 5 份 |
+| `restore` | 从托管备份恢复 | 是 | 恢复配置、数据库和 rollout |
+| `install-windows-launcher` | 安装 Windows 双击启动脚本 | 是 | 当前用户 Desktop |
+
+### 4.2 帮助
+
+以下调用打印帮助到 stdout，并以 `0` 退出：
+
+```text
+codex-provider
+codex-provider help
+codex-provider --help
+codex-provider <command> --help
+```
+
+当前没有稳定的 `--version` 或短选项 `-h` 合同。
+
+## 5. `status`
+
+### 5.1 语法
+
+```text
+codex-provider status [--codex-home PATH] [--sqlite-home PATH]
+```
+
+### 5.2 当前行为
+
+- 读取 `config.toml`、rollout 元数据、选中的 SQLite state DB、托管备份摘要和未完成事务；
+- 不修改配置、rollout、SQLite 或备份；
+- 根级 `model_provider` 缺失时，将当前 Provider 报告为 `openai`，并标记为隐式默认；
+- 状态扫描遇到锁定 rollout 时跳过该文件，并在结果中报告数量；
+- SQLite 缺失、损坏、不可读或暂时 busy 时尽量降级为诊断结果，而不是把状态读取变成写操作；
+- 配置明确选中的 SQLite Home 缺少数据库时，报告所检查的位置，不回退到其他数据库。
+
+### 5.3 人类可读输出
+
+成功输出保持以下顶层顺序：
+
+1. `Codex home`；
+2. `SQLite home` 及其来源；
+3. `Current provider`；
+4. `Configured providers`；
+5. 托管备份数量、大小与根目录；
+6. 可选的 `Recovery required`；
+7. `Rollout files`；
+8. `SQLite state`；
+9. 可选的 `Project visibility`。
+
+动态诊断行可以按实际数据缺省，但不得把错误堆栈写入普通输出。
+
+## 6. `sync`
+
+### 6.1 语法
+
+```text
+codex-provider sync [--provider ID] [--keep N] [--codex-home PATH] [--sqlite-home PATH]
+```
+
+### 6.2 参数与默认值
+
+| 参数 | 当前含义 | 默认值 |
+| --- | --- | --- |
+| `--provider ID` | 显式指定目标 Provider | 根级 `model_provider`；缺失时 `openai` |
+| `--keep N` | 成功后保留最近 N 份托管备份 | `5` |
+| `--codex-home PATH` | 覆盖 Codex Home | 第 3 节规则 |
+| `--sqlite-home PATH` | 覆盖 SQLite Home | 第 3 节规则 |
+
+`--keep` 必须是十进制整数且 `N >= 1`。
+
+### 6.3 当前行为
+
+- CLI 每次执行前读取 `config.toml` 的根级 `model`，并把它传给 Core；
+- 根级 `model` 读取失败时继续同步 Provider，且不要求重写每线程 model；
+- `sync` 不修改根级 `model_provider`；
+- 写入前获取同一 Codex Home 的跨进程锁；
+- 未完成事务存在时阻止新的写操作；
+- SQLite 可写检查发生在创建备份和重写 rollout 之前；
+- 每次执行都先创建托管备份，再进行写入；
+- 锁定的 rollout 可以被跳过，其他可写 rollout 和 SQLite 仍继续处理；
+- 锁定 rollout 导致的是部分成功，而不是事务整体失败；
+- 成功提交后自动按 `--keep` 清理旧托管备份；
+- 备份 inventory 刷新或自动清理失败，在主事务已提交后降级为 warning。
+
+### 6.4 成功时的进度输出
+
+CLI 使用以下六个编号阶段：
+
+```text
+[1/6] Scanning rollout files...
+[2/6] Checking locked rollout files...
+[3/6] Creating backup...
+[4/6] Updating SQLite...
+[5/6] Rewriting rollout files...
+[6/6] Cleaning backups...
+```
+
+备份完成后还会输出备份路径和耗时。
+
+### 6.5 成功摘要
+
+摘要的稳定核心标签为：
+
+- `Synchronized provider`；
+- `Codex home`；
+- `SQLite home` 及来源；
+- `Backup`；
+- `Backup creation time`；
+- `Updated rollout files`；
+- `Updated SQLite rows`。
+
+以下信息按实际结果出现：
+
+- SQLite user-event 修复数量；
+- SQLite cwd 修复数量；
+- workspace roots 更新数量；
+- 被跳过的锁定 rollout 数量和路径预览；
+- encrypted content 警告；
+- 自动备份清理结果或 warning。
+
+## 7. `switch`
+
+### 7.1 语法
+
+```text
+codex-provider switch <provider-id> [--model NAME] [--keep-root-model] [--keep N] [--codex-home PATH] [--sqlite-home PATH]
+```
+
+### 7.2 参数与默认值
+
+| 参数 | 当前含义 | 默认值 |
+| --- | --- | --- |
+| `<provider-id>` | 目标 Provider | 必填 |
+| `--model NAME` | 显式设置根级 model，并同步每线程 model | 未设置 |
+| `--keep-root-model` | 保留现有根级 model | `false` |
+| `--keep N` | 成功后保留最近 N 份托管备份 | `5` |
+
+`--model` 与 `--keep-root-model` 互斥。`--model` 必须是非空字符串。
+
+### 7.3 Provider 校验
+
+- 内置 `openai` 始终是可选 Provider；
+- 自定义 Provider 必须在 `config.toml` 的 `[model_providers.<id>]` 中声明；
+- 未声明 Provider 必须在任何配置写入之前失败。
+
+### 7.4 model 规则
+
+优先级固定为：
+
+1. 指定 `--model NAME` 时使用显式值；
+2. 指定 `--keep-root-model` 时保留根级值；
+3. 否则，自定义 Provider section 中存在 `model` 时，将其复制到根级；
+4. 自定义 Provider section 没有 `model` 时，保留根级值并输出 warning；
+5. 切换到内置 `openai` 时，没有 Provider section model 可自动复制，保留根级值。
+
+最终根级 model 也是本次 rollout 与 SQLite 每线程 model 同步所使用的目标 model。根级 model 缺失时不强制新增线程 model。
+
+### 7.5 事务边界
+
+- 切换前先创建包含原始 `config.toml` 的备份；
+- 备份成功后才允许修改根级 Provider/model；
+- 配置更新与后续同步处于同一补偿流程；
+- 后续失败时恢复原始配置和已观察到的其他变更；
+- 成功结果在 `sync` 摘要后输出根级 model 的应用来源、保留原因或 warning。
+
+## 8. `watch`
+
+### 8.1 语法
+
+```text
+codex-provider watch [--codex-home PATH] [--sqlite-home PATH] [--debounce-ms N] [--once] [--no-state-db]
+```
+
+### 8.2 参数与默认值
+
+| 参数 | 当前含义 | 默认值 |
+| --- | --- | --- |
+| `--debounce-ms N` | 变化后等待 N 毫秒再同步 | `750` |
+| `--once` | 第一次成功同步后退出 | `false` |
+| `--no-state-db` | 仅监听 `config.toml` | `false` |
+
+`--debounce-ms` 必须是非负整数，允许 `0`。
+
+### 8.3 当前行为
+
+- 启动时要求 Codex Home 与 `config.toml` 已存在；
+- 默认监听 `config.toml`、当前活动 `state_5.sqlite` 以及 `-wal`、`-shm` sidecar；
+- 配置变化后重新解析 SQLite Home，并重新绑定 DB watcher；
+- 每次触发同步时重新读取根级 model；
+- SQLite busy 是暂态软跳过，等待下一次变化重试；
+- 明确配置的 SQLite Home 暂时缺 DB 时暂停同步，等待配置修复；
+- 连续 5 次非 busy 同步失败后自动停止 watcher；
+- `--once` 只在第一次成功同步后停止，不在 busy、暂停或普通失败后停止；
+- 停止时等待正在执行的同步到达完成状态；
+- `SIGINT`、`SIGTERM`、`--once` 和内部自动停止都走清理流程。
+
+## 9. `web`
+
+### 9.1 语法
+
+```text
+codex-provider web [--port N] [--no-open] [--reset-access] [--codex-home PATH] [--sqlite-home PATH]
+```
+
+### 9.2 参数与默认值
+
+| 参数 | 当前含义 | 默认值 |
+| --- | --- | --- |
+| `--port N` | 回环监听端口 | `8791` |
+| `--no-open` | 不自动打开系统浏览器 | `false` |
+| `--reset-access` | 使已配对浏览器失效并创建新配对 | `false` |
+
+端口必须是 `0..65535` 的整数；`0` 表示由操作系统选择可用端口。
+
+### 9.3 当前行为
+
+- 服务只监听 `127.0.0.1`；
+- 默认尝试打开带一次性配对 token 的 URL；
+- 无桌面 Linux 环境或浏览器打开失败时，服务继续运行并输出配对 URL；
+- 输出 Web UI URL；在 `--no-open` 或打开失败时输出一次性配对链接；
+- 同一状态文件记录的现有实例只有在 effective Codex Home 与 SQLite Home 一致且内部认证通过时才能复用；
+- 复用成功后当前 CLI 进程退出，已有服务继续运行；
+- 非复用实例输出仅监听回环和按 `Ctrl+C` 停止的提示；
+- 默认状态文件为 `<Codex Home>/provider-sync-web.json`；
+- 默认运行时描述文件为 `<Codex Home>/provider-sync-web.runtime.json`。
+
+## 10. `prune-backups`
+
+### 10.1 语法
+
+```text
+codex-provider prune-backups [--keep N] [--codex-home PATH]
+```
+
+### 10.2 当前行为
+
+- `--keep` 默认 `5`，必须是非负整数，允许 `0`；
+- 只处理 `<Codex Home>/backups_state/provider-sync` 中具有本工具 metadata namespace 的托管备份；
+- 忽略不具有托管 metadata 的手工目录；
+- 永不删除未完成事务正在引用的恢复备份；
+- 使用同一 Codex Home 的跨进程锁；
+- 输出 backup root、删除数量、剩余数量和释放空间。
+
+## 11. `restore`
+
+### 11.1 语法
+
+```text
+codex-provider restore <backup-dir> [--no-config] [--no-db] [--no-sessions] [--allow-sqlite-home-relocation] [--codex-home PATH] [--sqlite-home PATH]
+```
+
+### 11.2 默认值
+
+| 内容 | 默认是否恢复 | 关闭参数 |
+| --- | --- | --- |
+| `config.toml` 与 global state | 是 | `--no-config` |
+| SQLite state DB | 是 | `--no-db` |
+| rollout 元数据 | 是 | `--no-sessions` |
+
+### 11.3 当前行为
+
+- 备份路径必填；
+- 使用同一 Codex Home 的 restore 锁；
+- 备份 metadata 与 session manifest 必须合法并绑定当前 Codex Home；
+- 恢复 SQLite 时校验备份 SQLite Home 与当前目标；
+- `--allow-sqlite-home-relocation` 必须与显式 `--sqlite-home PATH` 一起使用；
+- 真正跨 SQLite Home 恢复时禁止同时恢复旧 `config.toml`，必须使用 `--no-config`；
+- 未完成事务需要的内容不得通过 `--no-*` 形成不完整恢复；
+- 成功恢复后标记相应 transaction journal 已回滚；
+- 输出备份绝对路径、Codex Home、备份时 Provider，以及可选 inventory warning。
+
+## 12. `install-windows-launcher`
+
+### 12.1 语法
+
+```text
+codex-provider install-windows-launcher [--dir PATH] [--codex-home PATH] [--sqlite-home PATH]
+```
+
+### 12.2 当前行为
+
+- `--dir` 缺失时使用当前用户 Desktop；
+- 创建 `Codex Provider Sync.cmd`；
+- 创建 `Codex Provider Sync.vbs`；
+- 两个启动器最终执行 `codex-provider sync`；
+- 显式 Codex Home 与 SQLite Home 被固化到启动器；
+- cmd 保留 CLI 退出码；
+- vbs 以消息框显示成功或失败，并限制展示文本长度。
+
+## 13. stdout、stderr 与退出码
+
+### 13.1 v0.5 当前合同
+
+当前 CLI 是人类可读接口，没有 `--json`。
+
+| 场景 | stdout | stderr | Exit Code |
+| --- | --- | --- | --- |
+| 帮助 | 帮助文本 | 空 | `0` |
+| 命令成功 | 进度和/或摘要 | 空 | `0` |
+| 无需修改 | 正常摘要 | 空 | `0` |
+| 锁定 rollout 导致部分成功 | 摘要含 skipped locked | 空 | `0` |
+| 参数、存储、busy、锁、恢复或普通失败 | 可能已有提交前进度 | 单行错误 message | `1` |
+| Web/Watch 在信号处理器安装后收到 SIGINT/SIGTERM | 正常清理输出 | 空 | `0` |
+| Watch 连续 5 次非 busy 失败后自动停止 | 失败与停止日志 | 空 | `0` |
+
+错误默认不输出 JavaScript stack。
+
+**当前不存在 `2`、`3`、`4`、`5`、`130` 的稳定退出码。** 目标架构中关于参数错误、partial、recovery、busy 和取消的细分退出码是 vNext 建议，不是 v0.5 事实。
+
+### 13.2 vNext 变更规则
+
+新增细分退出码前必须：
+
+1. 调查现有脚本是否依赖 `0/1`；
+2. 明确旧人类模式与新 `--json` 模式是否共享退出码；
+3. 增加真实子进程 Contract Test；
+4. 在 CHANGELOG 和发布说明中声明；
+5. 不把 partial、busy 或 recovery 的退出码变化混入无关重构。
+
+## 14. legacy tolerated 行为
+
+以下行为由当前手写参数解析器接受，但不属于长期稳定命令合同：
+
+- `switch --provider ID` 可代替位置参数；
+- `restore --backup PATH` 可代替位置参数；
+- 使用 `--flag=value`；
+- 重复 flag 时最后一个值覆盖前值；
+- 未识别 flag 被静默保留或忽略；
+- 多余位置参数在多数命令中被忽略；
+- 布尔 flag 后的普通 token 可能被当作该 flag 的值吞掉；
+- `--no-open=false` 等非空字符串仍会被解释为启用；
+- 没有标准 `--` 参数终止符。
+
+这些行为的处理原则：
+
+- 不为它们新增长期快照测试；
+- vNext 不能在不知情的情况下依赖它们；
+- 未来改用严格参数解析器时，应先保留所有已文档化语法；
+- 若决定移除被真实用户使用的 tolerated 形式，应给出兼容警告或版本化迁移说明；
+- 安全修复可以拒绝危险或歧义输入，但必须单独说明。
+
+## 15. vNext 目标合同
+
+以下内容是目标，不是 v0.5 当前合同：
+
+- CLI、Local Web UI 与 Electron Desktop 调用同一个 Core Public API；
+- Desktop 不启动 CLI，也不解析 CLI 人类文本；
+- 新增 opt-in `--json`；
+- JSON stdout 使用稳定的 `schemaVersion`；
+- JSON 模式 stdout 只含一个结构化结果，日志和进度进入 stderr；
+- 建立明确的参数错误、partial、recovery required、busy 和取消退出码；
+- 使用稳定 Error Code，同时保留现有人类错误提示的核心语义；
+- 支持取消时使用安全取消点，而不是强制中止事务。
+
+任何目标行为只有在实现、测试和本文更新后才成为当前合同。
+
+## 16. 最低 Contract Test 清单
+
+Phase 0 之后的 CLI 改造至少必须覆盖：
+
+- 帮助文本可运行且 exit `0`；
+- 未知命令和非法 `--keep` 的 stderr 与 exit `1`；
+- `status` 的顶层输出顺序；
+- `sync` 默认 Provider、默认 keep=5 与六阶段进度；
+- `switch` 的三种 model 策略与互斥校验；
+- partial sync 当前仍 exit `0`；
+- recovery/busy/lock 当前仍 exit `1`；
+- restore 三类默认恢复和三个 `--no-*`；
+- SQLite Home 优先级与 default-only legacy fallback；
+- Web 默认端口、回环绑定与复用；
+- Watch 默认 750 ms、once 成功退出与连续失败停止；
+- npm `bin`、`engines` 与发布包包含 CLI/Web 运行所需文件。
+
+## 17. 变更控制
+
+修改以下任一内容，必须同时更新本文、Contract Test 和发布说明：
+
+- 命令名称或参数名称；
+- 参数默认值；
+- Provider/model 选择规则；
+- Codex Home 或 SQLite Home 优先级；
+- 人类输出的稳定核心标签；
+- stdout/stderr 分工；
+- 退出码；
+- partial、busy、recovery 或取消语义；
+- 备份、锁和恢复边界；
+- npm bin 或最低 Node.js 版本。

--- a/docs/architecture/contracts/CORE_EXTERNAL_BEHAVIOR_ZH.md
+++ b/docs/architecture/contracts/CORE_EXTERNAL_BEHAVIOR_ZH.md
@@ -1,0 +1,977 @@
+# Node Core 外部行为兼容合同
+
+> 状态：Phase 0 兼容基线
+>
+> 基线版本：`@dailin521/codex-provider-sync` v0.5.0
+>
+> 冻结日期：2026-08-24
+>
+> 适用范围：当前 Node service、CLI/Web adapter 依赖及 vNext Core 提取
+
+## 1. 文档目的
+
+本文冻结 vNext 迁移开始时 Node 实现已经提供的外部行为。这里的“外部”不仅指 npm 最终用户，也包括当前 CLI 与 Local Web UI 对 Node service 的真实依赖。
+
+本文解决三个问题：
+
+1. 当前哪些行为已经是事实，提取 Core 时不能改变；
+2. 当前哪些能力散落在 `service.js` 之外，不能在重组时漏掉；
+3. 哪些设计是 vNext 目标，尚不能反向描述为 v0.5 已实现。
+
+本文不把所有内部函数、测试注入点和物理深导入路径升级为永久 Public API。
+
+## 2. 合同层级
+
+### 2.1 v0.5 当前合同
+
+当前 `src/service.js` 导出：
+
+```text
+SyncTransactionError
+getStatus
+renderStatus
+runSync
+runSwitch
+runRestore
+runPruneBackups
+```
+
+这些导出构成当前 CLI/Web 迁移所依赖的 service 边界，但 npm 包尚未通过 `exports` 声明正式可供第三方导入的 Core 包入口。
+
+### 2.2 当前散落但必须纳入 vNext Core 的能力
+
+Local Web UI 和 CLI 还直接依赖：
+
+| 当前模块 | 能力 |
+| --- | --- |
+| `backup.js` | `listBackups` |
+| `history.js` | `listHistory`、`getHistorySession` |
+| `watch.js` | `runWatch` |
+| `config-file.js` | Web adapter 读取 config 与根级 model |
+| `storage-layout.js`、`sqlite-state.js` | Web adapter 在确认操作前解析并固定 storage |
+
+因此，不能把 `service.js` 的当前导出列表误写成“完整 Core 已经存在”。Phase 1 的 Public API 必须覆盖 CLI、Web 和未来 Desktop 所需的完整能力。
+
+### 2.3 internal / test-only
+
+以下选项当前存在于实现或测试中，但不自动成为长期外部合同：
+
+- `faultInjector`；
+- `sqliteBusyTimeoutMs`；
+- 预构造的底层 storage 对象本身的全部内部字段；
+- 测试替身 `services`；
+- 自定义时间、环境、文件系统或 URL opener；
+- transaction journal 内部事件格式之外未明确发布的实现细节。
+
+其中 `signal` 代表未来取消能力的基础，但 v0.5 CLI 尚未形成稳定的取消结果合同。
+
+## 3. 统一存储解析合同
+
+### 3.1 Codex Home
+
+优先级：
+
+1. 调用输入中的显式 `codexHome`；
+2. `CODEX_HOME`；
+3. `~/.codex`。
+
+所有路径最终解析为绝对路径。
+
+### 3.2 SQLite Home
+
+优先级：
+
+1. 调用输入或已确认 Storage Profile 中的显式 `sqliteHome`；
+2. `config.toml` 根级 `sqlite_home`；
+3. `CODEX_SQLITE_HOME`；
+4. `<Codex Home>/sqlite`。
+
+结果必须携带来源：
+
+```text
+cli | config | env | default
+```
+
+Web Profile 虽然不是 CLI，其显式 SQLite Home 仍沿用现有来源值 `cli`；vNext 可以在新 DTO 中使用更准确的来源枚举，但不得改变存储优先级或兼容判断。
+
+### 3.3 state DB 选择
+
+- 只处理一个被解析为当前活动状态数据库的 `state_5.sqlite`；
+- 只有 `default` SQLite Home 可以回退到 `<Codex Home>/state_5.sqlite`；
+- 显式、配置或环境 SQLite Home 缺少数据库时，写操作失败；
+- status 可以报告数据库缺失而不失败；
+- Windows WSL UNC SQLite Home 不允许安全读写，写操作必须在备份和其他 mutation 之前失败；
+- 不得因为某个候选 DB 存在，就同时改写多个数据库。
+
+## 4. `getStatus`
+
+### 4.1 当前输入
+
+```text
+codexHome?
+sqliteHome?
+storage?      # Web adapter 已确认的 storage
+configText?   # 与 storage 同一确认快照的 config
+platform?
+```
+
+CLI 通常提供路径；Web adapter 提供 server-resolved storage 与同一时刻读取的 configText。
+
+### 4.2 当前返回字段
+
+以下字段构成 v0.5 状态快照合同：
+
+```text
+codexHome
+sqliteHome
+sqliteHomeSource
+sqliteAccess
+checkedStateDbPaths
+currentProvider
+currentProviderImplicit
+configuredProviders
+rolloutCounts
+lockedRolloutFiles
+encryptedContentCounts
+encryptedContentWarning
+sqliteCounts
+stateDbLocation
+sqliteRepairStats
+projectThreadVisibility
+backupRoot
+backupSummary
+pendingTransactions
+```
+
+关键嵌套结构：
+
+```text
+rolloutCounts.sessions
+rolloutCounts.archived_sessions
+
+sqliteCounts.sessions
+sqliteCounts.archived_sessions
+
+backupSummary.count
+backupSummary.totalBytes
+
+pendingTransactions[].operationId
+pendingTransactions[].state
+pendingTransactions[].backupDir
+pendingTransactions[].journalPath
+```
+
+`sqliteCounts` 在数据库不存在时可以为 `null`；数据库损坏或 busy 时可以返回带 `unreadable` 和 `error` 的诊断对象。
+
+### 4.3 状态语义
+
+- 根级 `model_provider` 缺失时，`currentProvider="openai"` 且 `currentProviderImplicit=true`；
+- `configuredProviders` 至少包含内置 `openai`；
+- rollout 分布分别统计 `sessions` 和 `archived_sessions`；
+- status 扫描读取不到锁定 rollout 时，记录 `lockedRolloutFiles`，不把它当成写失败；
+- status 不通过修改 `updated_at` 或其他数据来推断可见性；
+- status 报告 pending transaction，后续写操作必须要求恢复；
+- encrypted content warning 只解释继续会话风险，不修改或导出加密内容。
+
+### 4.4 `renderStatus`
+
+`renderStatus(status)` 是当前 CLI presenter，不是未来 Core Domain API。Phase 1 可以把它移动到 CLI adapter，但迁移时必须保持 CLI 人类输出合同。
+
+## 5. `runSync`
+
+### 5.1 当前 adapter 依赖输入
+
+```text
+codexHome?
+sqliteHome?
+storage?
+provider?
+expectedConfigText?
+keepCount = 5
+model = null
+onProgress?
+platform?
+signal?
+```
+
+`configBackupText` 是 `runSwitch` 编排时使用的内部输入，不应由普通外部调用者构造。
+
+### 5.2 目标 Provider 与 model
+
+Provider 选择顺序：
+
+1. 显式 `provider`；
+2. 当前根级 `model_provider`；
+3. `openai`。
+
+`runSync` 自身默认 `model=null`，表示不要求重写每线程 model。当前 CLI 与 Web 会读取根级 model 后显式传入；提取 Public API 时必须保留“入口使用根级 model 同步线程”的现有用户行为。
+
+### 5.3 前置条件
+
+- `keepCount` 必须是整数且 `>=1`；
+- Codex Home 与 `config.toml` 必须可读；
+- 获取同一 Codex Home 的 provider-sync 锁；
+- 不存在未完成 provider-sync transaction；
+- `expectedConfigText` 提供时，磁盘 config 必须完全一致；
+- Windows WSL UNC storage 不支持 sync；
+- 非 default SQLite Home 必须存在目标 `state_5.sqlite`；
+- SQLite 必须在 rollout mutation 和备份之前通过可写性检查。
+
+### 5.4 写入流程与安全顺序
+
+以下顺序属于兼容安全合同：
+
+1. 获取锁；
+2. 检查 pending transaction；
+3. 读取并校验 config；
+4. 解析唯一 storage/state DB；
+5. 扫描 rollout 与修复信息；
+6. 识别不可写或读取锁定的 rollout；
+7. 验证 SQLite 可写；
+8. 创建不可变原始备份；
+9. 创建 transaction journal；
+10. 在受控事务中应用 rollout、global state/workspace roots 与 SQLite 更新；
+11. 持久化 committed terminal；
+12. 刷新 backup inventory；
+13. 自动清理旧托管备份；
+14. 释放锁。
+
+不得把 rollout mutation 移到 SQLite 可写检查或备份之前。
+
+### 5.5 部分成功
+
+- 启动/活动进程锁定的 rollout 可以被跳过；
+- 可写 rollout、SQLite provider、user-event、cwd 和 workspace roots 仍可提交；
+- 所有跳过路径必须出现在 `skippedLockedRolloutFiles`；
+- v0.5 service 以正常结果表示 partial，不抛出异常；
+- Web adapter 根据该数组非空添加 `outcome="partial"`；
+- v0.5 CLI 仍以 exit `0` 返回 partial。
+
+### 5.6 当前结果字段
+
+成功结果冻结为以下字段集合：
+
+```text
+codexHome
+sqliteHome
+sqliteHomeSource
+targetProvider
+previousProvider
+backupDir
+backupDurationMs
+changedSessionFiles
+skippedLockedRolloutFiles
+sqliteRowsUpdated
+sqliteProviderRowsUpdated
+sqliteUserEventRowsUpdated
+sqliteCwdRowsUpdated
+updatedWorkspaceRoots
+savedWorkspaceRootCount
+sqlitePresent
+rolloutCountsBefore
+encryptedContentCounts
+encryptedContentWarning
+autoPruneResult
+autoPruneWarning
+```
+
+其中：
+
+```text
+autoPruneResult.backupRoot
+autoPruneResult.deletedCount
+autoPruneResult.remainingCount
+autoPruneResult.freedBytes
+```
+
+`autoPruneResult` 可以为 `null`；主事务提交后的 inventory/prune 失败通过 `autoPruneWarning` 报告，不得把已提交成功伪装成整体失败。
+
+### 5.7 进度事件
+
+成功 sync 的 start stage 顺序固定为：
+
+```text
+scan_rollout_files
+check_locked_rollout_files
+create_backup
+update_sqlite
+rewrite_rollout_files
+clean_backups
+```
+
+每个事件至少具有：
+
+```text
+stage
+status = start | complete
+```
+
+现有 complete 事件可包含：
+
+- 扫描变化数与锁定读取数；
+- 可写和锁定数量；
+- backupDir 与 durationMs；
+- rollout applied/skipped 数量；
+- SQLite updatedRows；
+- prune deletedCount 与 warning。
+
+`onProgress` 是非权威观察通道。同步或异步 observer 抛错不得改变事务状态、触发补偿或把已提交操作报告为失败。
+
+## 6. `runSwitch`
+
+### 6.1 当前输入
+
+```text
+codexHome?
+sqliteHome?
+storage?
+expectedConfigText?
+provider             # 必填
+model?
+keepRootModel=false
+keepCount=5
+onProgress?
+platform?
+signal?
+```
+
+### 6.2 Provider 和 model 规则
+
+- `provider` 缺失时失败；
+- 内置 `openai` 始终有效；
+- 自定义 Provider 必须在 config 声明；
+- `model` 与 `keepRootModel` 互斥；
+- 显式 model 优先；
+- 否则 `keepRootModel=true` 时保留根级 model；
+- 否则从目标 Provider section 读取 model；
+- 自定义 Provider section 没有 model 时保留根级 model，并返回 warning；
+- 最终根级 model 用于本次线程 model 同步。
+
+### 6.3 事务行为
+
+- 在修改 config 前完成备份；
+- 备份保存切换前的原始 config；
+- config mutation 纳入 transaction journal 与补偿；
+- 后续写入失败时恢复原始 config；
+- 额外进度 stage 为 `update_config`，发生在 `create_backup complete` 之后；
+- config 在等待锁期间被其他进程改变时必须失败，而不是覆盖新内容。
+
+### 6.4 结果扩展
+
+`runSwitch` 返回完整 SyncResult，并增加：
+
+```text
+configUpdated = true
+modelSync.applied
+modelSync.source = explicit | provider-section | none
+modelSync.model
+modelSync.warning
+```
+
+## 7. `runRestore`
+
+### 7.1 当前输入与默认值
+
+```text
+codexHome?
+sqliteHome?
+storage?
+expectedConfigText?
+backupDir                         # 必填
+restoreConfig=true
+restoreDatabase=true
+restoreSessions=true
+allowSqliteHomeRelocation=false
+platform?
+```
+
+### 7.2 安全合同
+
+- 获取同一 Codex Home 的 restore 锁；
+- `expectedConfigText` 提供时必须与磁盘完全一致；
+- WSL UNC storage 在读取或修改备份目标前失败；
+- 备份 namespace、版本、Codex Home 与 manifest 必须通过校验；
+- session restore 路径必须位于允许的 rollout roots，拒绝路径逃逸、符号链接和重复目标；
+- restoreDatabase 时，配置选中的 SQLite Home 缺 DB 必须失败；
+- SQLite Home 与备份记录不一致时，默认拒绝 relocation；
+- relocation 必须由显式 SQLite Home 和 `allowSqliteHomeRelocation=true` 共同授权；
+- relocation 时禁止同时恢复旧 config；
+- 未完成 transaction 所需的 rollout、SQLite、config 或 global state 不能被部分关闭；
+- 恢复目标完成后尝试把绑定 journal 标记为 rolledBack；
+- 当前 journal terminal 标记失败会使 `runRestore` 整体 reject，即使部分恢复结果已经持久化；只有 inventory 刷新失败会降级为 warning。
+
+### 7.3 当前 Restore 安全债
+
+`runRestore` 当前会获取正式 operation lock，也会校验被选中备份及其 journal，但**恢复操作自身不会先创建新的恢复前备份，也没有独立的 restore transaction journal**。因此，若 restore 在 config、global state、SQLite 或 rollout 已部分落盘后发生进程崩溃，当前实现没有与 sync/switch 同等级的自动补偿证据。
+
+这属于 v0.5 已知安全债，不是允许 vNext 继续保留的目标合同：
+
+- Phase 0 必须如实记录，不能宣称 restore 已具备完整事务性；
+- 在补齐 restore backup/journal 前，不得扩大 restore 自动化或无人值守使用范围；
+- vNext 必须为 restore 建立恢复前 snapshot、目标清单、持久 journal 和崩溃恢复测试；
+- 当前恢复目标已落盘但 rolledBack terminal 标记失败时，调用方只会收到失败，不能据此证明目标未恢复或 Journal 已收敛；vNext 必须增加 commit/terminal acknowledgement reconciliation；
+- 补齐安全机制时必须继续兼容 v1/v2 旧备份格式和现有 restore 选项。
+
+### 7.4 当前结果
+
+成功时返回经过验证的备份 `metadata.json` payload。v2 托管备份通常包含：
+
+```text
+version
+namespace
+codexHome
+sqliteHome
+targetProvider
+createdAt
+dbFiles
+sqliteDbFiles
+globalStateFiles
+changedSessionFiles
+sizeBytes
+fileCount
+```
+
+兼容 v1 备份时字段会有所不同。inventory 刷新失败时增加：
+
+```text
+backupInventoryWarning
+```
+
+调用者不得假定 restore 结果与 SyncResult 同构。
+
+## 8. `runPruneBackups`
+
+### 8.1 当前输入
+
+```text
+codexHome?
+keepCount=5
+```
+
+`keepCount` 必须是非负整数，允许 `0`。
+
+### 8.2 当前行为
+
+- 确认 Codex Home 存在；
+- 获取同一 Codex Home 的 prune 锁；
+- 只删除具有 `provider-sync` namespace 的托管备份；
+- 由新到旧保留前 N 份；
+- 未完成 transaction 引用的备份受到保护，即使 N 为 0 也不删除；
+- 非托管目录不参与计数和删除。
+
+### 8.3 当前结果
+
+```text
+backupRoot
+deletedCount
+remainingCount
+freedBytes
+```
+
+## 9. 备份、历史与 Watch 能力
+
+这些能力当前不全部位于 `service.js`，但已被 Web/CLI 使用，迁移时必须保留。
+
+### 9.1 `listBackups`
+
+输入：Codex Home。
+
+结果：
+
+```text
+backupRoot
+backups[].id
+backups[].path
+backups[].sizeBytes
+backups[].metadata
+```
+
+只列出托管 backup namespace，顺序为目录名由新到旧。
+
+### 9.2 `listHistory`
+
+当前输入：
+
+```text
+codexHome
+page=1
+pageSize=50
+query=""
+project=""
+provider=""
+archived=all | active | archived
+```
+
+约束：
+
+- page 是正整数；
+- pageSize 为 `10..100`；
+- 搜索从 rollout 只读读取；
+- 相同 thread id 保留 mtime 更新的文件；
+- 无 thread id 的会话使用基于 rollout 绝对路径 Hash 的稳定有界 ID；
+- 结果按 updatedAt、mtime 由新到旧；
+- 搜索可以匹配会话标题、cwd、Provider 和安全抽取的用户/助手消息文本。
+
+结果：
+
+```text
+page
+pageSize
+total
+hasNextPage
+sessions[]
+```
+
+每个公开 session 包含：
+
+```text
+id
+rolloutPath
+title
+cwd
+provider
+model
+archived
+createdAt
+updatedAt
+messageCount
+firstUserMessage
+```
+
+### 9.3 `getHistorySession`
+
+- sessionId 必填；
+- 默认最多返回最后 200 条安全抽取的用户/助手消息；
+- 不返回认证信息、token、推理内容或任意原始 JSONL；
+- 结果包含 `session`、`messages`、`truncated`、`returnedMessageCount`。
+
+### 9.4 `runWatch`
+
+当前行为需保留：
+
+- 默认 debounce 750 ms；
+- 默认监听 config 和当前唯一 state DB/WAL/SHM；
+- 配置变化后重新解析 storage；
+- SQLite busy 软跳过；
+- 连续 5 次非 busy 失败后停止；
+- once 在首次成功 sync 后停止；
+- 返回 handle：Codex Home、config path、动态 state DB path、动态 SQLite Home、`stop()`、`done` 和可选 `signalPromise`。
+
+## 10. 跨进程锁与恢复状态
+
+### 10.1 锁位置
+
+当前同一 Codex Home 的写操作使用：
+
+```text
+<Codex Home>/tmp/provider-sync.lock
+```
+
+这是正式 Core operation lock。当前协议为 protocol v2，并使用 canonical lock directory、`owner.json`、独立 claims 目录、不可变 instance identity 和有界 stale reclaim。锁 owner 记录 Node/.NET 跨运行时识别所需的 PID、进程启动身份、instance id、label 和工作目录。
+
+.NET GUI 的 SingleInstanceGuard 只负责阻止同一 GUI 重复启动，**不是 Core operation lock**，不能用于证明 CLI、Web、旧 GUI 或 Electron 之间互斥。未来 Electron 的应用单实例锁同样只能负责 UX，不能替代上述 storage operation lock。
+
+### 10.2 必须冻结的语义
+
+- sync、switch、restore、prune 在完整操作周期持锁；
+- 活跃、无法验证或未来协议的锁 fail closed；
+- 只有能够证明 owner 已不存在时才回收 stale lock；
+- 不得要求用户常规手工删除锁；
+- 释放时必须确认仍是同一 owner/generation；
+- 同一 Codex Home 的 CLI、旧 GUI、Web 与未来 Electron 必须使用兼容锁合同；
+- 不能以 UI 层“避免同时点击”代替跨进程互斥。
+
+### 10.3 锁内重解析
+
+执行写操作时，Plan 或 Web status 阶段解析出的 storage 只能作为待确认快照。获得正式 operation lock 后，Core 必须重新读取 config，并重新解析：
+
+- Codex Home；
+- SQLite Home 与来源；
+- legacy fallback 资格；
+- 当前活动 `state_5.sqlite` 路径；
+- pending transaction；
+- SQLite 可写性。
+
+重解析结果与确认快照不一致时必须返回 stale/changed，不得继续使用锁外缓存的 storage 对象。
+
+当前 direct CLI sync/restore 的主要路径会在锁内读取 config；但 Web 会传入预解析 storage，switch 也存在锁外准备再交给 sync 的路径。`expectedConfigText` 能防止部分 config 漂移，却不能证明所有 DB 选择和文件系统状态均未改变。这是 Phase 1/Plan-Apply 下沉时必须关闭的 TOCTOU 缺口。
+
+### 10.4 跨 Codex Home 共享 SQLite Home 盲区
+
+正式 operation lock 当前按 Codex Home 定位。因此，两个不同 Codex Home 如果显式解析到同一个 SQLite Home/同一个 `state_5.sqlite`，会获得不同的 operation lock，当前实现不能阻止它们并发修改同一数据库。
+
+该行为是已知并发盲区，不是允许并发的合同。vNext 在宣称多 Profile 安全前必须二选一并形成 ADR：
+
+- 对规范化后的 SQLite 资源增加跨 Codex Home 的 resource lock；或
+- 检测共享目标并 fail closed，要求用户串行处理。
+
+在此问题解决前，测试和文档不得把“不同 Profile/Codex Home”直接等同于“不同存储资源”。
+
+### 10.5 pending transaction
+
+- 未持久化 terminal 的 journal 表示需要恢复；
+- status 必须报告；
+- sync/switch 必须阻止新写；
+- prune 必须保护绑定备份；
+- restore 必须覆盖 journal 已开始或无法安全排除的所有目标；
+- 完成恢复后持久化 rolledBack terminal。
+
+当前 Node 与 .NET 对“选择的恢复备份之外仍存在其他 pending transaction”的处理尚未形成经过跨运行时测试证明的一致合同。Node restore 主要检查并标记所选 backup 内绑定的 journal；这不能自动证明另一个 foreign pending 已被解决。
+
+vNext 统一规则必须是：
+
+- restore 只解决与所选备份明确绑定且恢复覆盖完整的 transaction；
+- 其他 foreign pending 保持 recovery blocker，不得被顺带清除或忽略；
+- Node/.NET 迁移期需要增加同一 Codex Home 下多 pending/foreign backup 的交叉 Contract Test；
+- 在测试证明一致之前，不得用任一运行时的当前行为替代正式合同。
+
+## 11. 当前错误合同
+
+### 11.1 已结构化的 Core 错误
+
+#### `SyncTransactionError`
+
+可能的 `code`：
+
+```text
+SYNC_FAILED_ROLLED_BACK
+RECOVERY_REQUIRED
+```
+
+公开诊断字段：
+
+```text
+name
+code
+originalError
+rollbackErrors
+backupDir
+completedTargets
+uncompletedTargets
+rollbackStatus
+recoveryRequired
+recoveryInstructions
+```
+
+`SYNC_FAILED_ROLLED_BACK` 表示观察到的变更已经自动恢复，不需要手工恢复。`RECOVERY_REQUIRED` 表示补偿不完整，必须保留备份和 journal 证据。
+
+#### pending recovery
+
+`RecoveryRequiredError` 使用：
+
+```text
+code = RECOVERY_REQUIRED
+pendingTransactions
+```
+
+#### abort
+
+安全取消点直接生成：
+
+```text
+name = AbortError
+code = ABORT_ERR
+```
+
+如果取消发生在已经开始写入的事务中，最终可能经过补偿后表现为 `SyncTransactionError`。v0.5 尚未保证单一的最终取消 code。
+
+### 11.2 当前 message-only 错误类别
+
+下列错误目前大多只是普通 `Error` 和稳定核心 message，没有统一 code：
+
+- 参数缺失或非法；
+- Provider 未配置；
+- config 在确认后改变；
+- Codex Home/config 缺失；
+- configured SQLite Home 缺少 DB；
+- Windows WSL UNC 不支持；
+- SQLite busy；
+- SQLite malformed/unreadable；
+- lock busy 或无法安全验证；
+- backup/manifest 不兼容；
+- SQLite Home relocation 未确认；
+- history 条目不存在；
+- 文件权限、空间和其他 I/O 错误。
+
+PR 3 引入结构化 Error Code 时必须保留现有人类提示的关键语义，并为 CLI、Web、Runtime/IPC 分别建立映射测试。
+
+### 11.3 vNext 不得假设的行为
+
+- 不得把所有普通 Error 通过字符串匹配长期分类；
+- 不得让 Desktop 解析 CLI stderr；
+- 不得让 Web 丢失 `RECOVERY_REQUIRED` 后仍显示成普通可重试失败；
+- 不得因 observer 或 inventory warning 把已提交操作改判为失败。
+
+## 12. Local Web UI Revision 合同
+
+当前 Web adapter 已实现的并发与确认保护必须在迁移时保留，并最终下沉到 Core 的 Plan/Revision/Apply 能力。
+
+### 12.1 Server-managed Profile
+
+- API 操作通过 `profileId` 选择路径；
+- 请求体不得直接提供 `codexHome` 或 `sqliteHome`；
+- default Profile 由 Web 启动参数控制，不可通过 Profile API 修改或删除；
+- Profile revision 是 Profile 内容 Hash；
+- 更新已有 Profile 和删除 Profile 需要当前 revision；
+- 创建新 Profile 不提供 revision。
+
+### 12.2 写操作 Revision 要求
+
+| Web 操作 | profileRevision | storageRevision |
+| --- | --- | --- |
+| sync | 必须 | 必须 |
+| switch | 必须 | 必须 |
+| restore | 必须 | 必须 |
+| prune | 必须 | 当前不要求 |
+
+`storageRevision` 当前覆盖：
+
+- profile id/revision；
+- config 内容 Hash；
+- Codex Home；
+- SQLite Home 与来源；
+- SQLite access 支持状态；
+- legacy fallback 资格；
+- 当前选中的 state DB 路径与来源。
+
+缺失或变化时返回 HTTP 409 和以下 code：
+
+```text
+PROFILE_REVISION_REQUIRED
+PROFILE_CHANGED
+STORAGE_REVISION_REQUIRED
+STORAGE_CHANGED
+```
+
+确认快照失效时，必须刷新并重新确认，不得静默重新解析后继续写入。
+
+### 12.3 Web 到 service 的调用映射
+
+| Endpoint | 当前调用 |
+| --- | --- |
+| `POST /api/status` | `getStatus({ storage, configText, ...profile })` |
+| `POST /api/backups` | `listBackups(codexHome)` |
+| `POST /api/history` | `listHistory(codexHome, body)` |
+| `POST /api/history/session` | `getHistorySession(codexHome, sessionId)` |
+| `POST /api/sync` | `runSync({ storage, expectedConfigText, provider, keepCount, model, onProgress })` |
+| `POST /api/switch` | `runSwitch({ storage, expectedConfigText, provider, keepCount, model, keepRootModel, onProgress })` |
+| `POST /api/restore` | `runRestore({ storage, expectedConfigText, backupDir, restore*, allowSqliteHomeRelocation })` |
+| `POST /api/prune` | `runPruneBackups({ codexHome, keepCount })` |
+
+### 12.4 单写操作
+
+- 一个 Web server 进程同时只允许一个 sync/switch/restore/prune；
+- 已有操作运行时返回 HTTP 409；
+- 该进程内活动日志记录 start、progress、success/partial/error；
+- activity 是内存态，不是持久审计日志。
+
+### 12.5 Web 结果映射
+
+成功写操作返回：
+
+```json
+{
+  "result": {
+    "outcome": "success"
+  }
+}
+```
+
+如果结果中的 `skippedLockedRolloutFiles` 非空：
+
+```json
+{
+  "result": {
+    "outcome": "partial"
+  }
+}
+```
+
+Web 的 `alignment.aligned` 当前要求：
+
+- target Provider 存在；
+- SQLite 可读；
+- status 未跳过锁定 rollout；
+- rollout 与 SQLite 两个 scope 中所有非零 Provider 都等于 target Provider。
+
+rollout 与 SQLite 总数不要求完全相等。
+
+### 12.6 当前兼容缺口
+
+Web `withOperation` 当前把 operation 异常映射为 HTTP 400 `{error}`，没有透传 Core `error.code`。这是已知缺口，不应被描述为理想合同。
+
+后续结构化错误改造需要：
+
+- 保留 409 revision code；
+- 让 recovery、busy、cancel 和普通失败有稳定映射；
+- 保持现有人类 message；
+- 不改变成功/partial payload；
+- 增加 HTTP Contract Test。
+
+## 13. Local Web UI 安全合同
+
+以下行为属于当前外部安全边界：
+
+- 只监听 `127.0.0.1`；
+- 健康检查不要求配对；
+- 其他业务 API 需要已配对 device credential；
+- pairing token 随机、一次性、默认 5 分钟过期；
+- 服务端只持久化 device credential Hash；
+- 非 GET 浏览器请求要求同一回环 Host/Origin；
+- JSON 请求体最大 64 KiB；
+- storage path 只能通过 server-managed Profile；
+- restore 只接受当前 Codex Home 的 managed `backupId`；
+- 同一运行时描述文件复用需要内部 challenge、HMAC proof、instance id 和 storage identity 一致；
+- runtime descriptor 权限尽可能设置为 `0600`；
+- History 明确只读，不得被 sync/switch 以外的页面路径修改。
+
+Electron 不需要复用浏览器 pairing，但不能削弱 Core 的 path、revision、backup 和 transaction 安全边界。
+
+## 14. 不得改变的业务边界
+
+迁移期间必须保持：
+
+- 只同步会话可见性所需的 Provider/model、SQLite flags/cwd 和 workspace root 元数据；
+- 不读取、复制、记录或修改 `auth.json`、token 或凭据；
+- 不修改消息正文；
+- History 仅在用户显式打开只读页面时抽取安全的用户/助手文本；
+- 不修改 thread `updated_at`，不通过重排历史制造可见性；
+- 不承诺跨 Provider 解密 `encrypted_content`；
+- 同步前备份；
+- SQLite busy 时在 rollout mutation 前停止；
+- 保留 transaction journal 与自动补偿；
+- 保留 default-only legacy DB fallback；
+- partial 必须列出 skipped rollout；
+- active session 导致 rollout/SQLite 数量短暂不同不等于 Provider 未对齐。
+
+## 15. legacy tolerated 行为
+
+以下事实存在，但不应直接升级为长期 Core API：
+
+- 第三方可通过 npm 安装目录物理深导入 `src/service.js`；
+- service 接受测试用 `faultInjector`、busy timeout 和预构造 storage；
+- Web 直接注入 service 替身；
+- 某些错误只能通过英文 message 区分；
+- Web API 的 validation 错误有时由外层 catch 映射为 HTTP 500，而 operation 内错误为 400；
+- Web prune 前端会多发送当前 server 不使用的 `storageRevision`；
+- sync Core 本身不限制 Provider 字符集，而 Web adapter 会限制为字母、数字、点、下划线和连字符。
+
+处理原则：
+
+- Public API 提取时只承诺明确列出的 DTO 和方法；
+- adapter 正在真实使用的参数必须先迁移再删除；
+- test-only hook 留在内部入口；
+- 收紧输入或统一 HTTP status 需要独立兼容说明和 Contract Test；
+- 不得借“清理内部 API”破坏 CLI/Web 当前正常路径。
+
+## 16. vNext 目标 Public API
+
+vNext 目标能力为：
+
+```text
+getStatus
+prepareSync
+applySync
+prepareSwitch
+applySwitch
+listBackups
+prepareRestore
+applyRestore
+pruneBackups
+listHistory
+getHistorySession
+startWatch
+```
+
+目标原则：
+
+- CLI、Web、Desktop 只从一个 `public-api` 导入；
+- Core 不依赖 Electron、React、DOM 或 CLI presenter；
+- 所有写操作采用 Plan/Revision/Confirm/Apply；
+- Web 已有 revision 保护下沉到 Core；
+- Core 返回结构化 Result/Error/Progress；
+- CLI human presenter、CLI JSON presenter、HTTP mapper 与 Electron IPC mapper 位于 adapter；
+- `--json` 是外部自动化合同，不是 Electron IPC；
+- Public API 可以新增 schemaVersion，但迁移适配器必须保持本文中的 v0.5 用户行为。
+
+这些目标在对应实现和测试完成前，不得用来否认当前一次性 `runSync/runSwitch/runRestore` 接口的兼容责任。
+
+## 17. Phase 1 提取要求
+
+Phase 1 只提取边界，不改变算法或结果：
+
+1. 新增唯一 `public-api`；
+2. 包装当前 `service.js` 能力；
+3. 把 `listBackups`、History 和 Watch 纳入公开边界；
+4. CLI 与 Web 改为只从 public-api 导入；
+5. `renderStatus` 和 CLI 文本格式留在 CLI adapter；
+6. Web DTO、alignment 与 HTTP status 映射留在 Web adapter；
+7. 保持所有现有测试通过；
+8. 增加 Public API 导出快照和结果字段 Contract Test；
+9. 不移动备份、锁、journal、rollout 或 SQLite 算法；
+10. 不删除 .NET 实现或改变跨运行时锁。
+
+## 18. 最低 Contract Test 清单
+
+### 18.1 Status
+
+- implicit `openai`；
+- configured Provider 列表；
+- default 与 legacy state DB 选择；
+- configured SQLite Home 缺 DB；
+- WSL UNC 诊断；
+- malformed/busy SQLite 降级；
+- locked rollout 降级；
+- pending transaction 与项目可见性字段。
+
+### 18.2 Sync/Switch
+
+- backup-first；
+- SQLite busy 时 rollout 不变；
+- locked rollout partial；
+- config/storage revision 变化阻断；
+- result 字段和 progress stage；
+- observer 失败不影响事务；
+- config、rollout、SQLite、global state 的完整补偿；
+- rolled-back 与 recovery-required 两类 SyncTransactionError；
+- default/custom keep 自动清理与 warning 降级；
+- switch Provider/model 三策略和未知 Provider。
+
+### 18.3 Restore/Prune
+
+- v1/v2 backup；
+- Codex Home 与 SQLite Home 绑定；
+- relocation 显式确认；
+- relocation 禁止 config restore；
+- manifest path boundary；
+- pending transaction 完整恢复；
+- pending backup 不被 prune；
+- 非托管目录不被删除。
+
+### 18.4 Web
+
+- pairing、Origin 和 device credential；
+- raw storage path 拒绝；
+- profile/storage revision required/changed；
+- 单写操作；
+- managed backupId；
+- success/partial mapping；
+- alignment 不要求总数相等；
+- runtime storage identity 与安全复用；
+- History 只读与分页边界。
+
+## 19. 变更控制
+
+修改以下任一内容，必须同时更新本文、相关 ADR、Contract Test 和发布说明：
+
+- Public API 方法或 DTO；
+- Core 结果字段；
+- progress stage 或顺序；
+- Storage Profile/Revision 语义；
+- SQLite Home 优先级或 DB 选择；
+- 锁路径、协议、持有周期或 stale reclaim；
+- backup metadata、journal 或补偿语义；
+- partial、busy、recovery、cancel 分类；
+- Web revision、pairing 或回环边界；
+- History 可读取的数据范围；
+- auth/message body 安全边界。

--- a/docs/architecture/contracts/ERROR_CODES_ZH.md
+++ b/docs/architecture/contracts/ERROR_CODES_ZH.md
@@ -1,0 +1,176 @@
+# vNext Error Code 合同
+
+> **状态：Accepted（阶段 0 合同；代码适配尚未实施）**
+>
+> **日期：2026-08-24**
+>
+> **适用范围：Node Core、CLI、Local Web UI、Electron 与迁移期 .NET 适配层**
+>
+> **架构基线：[vNext Electron + Node 单核心架构](../../VNEXT_ELECTRON_NODE_ARCHITECTURE_ZH.md)**
+
+## 1. 目的
+
+本文冻结 vNext 的错误分类、兼容映射和演进规则，使调用方依据稳定的 `code` 决策，而不是解析自然语言 `message`、异常类型名或堆栈。
+
+本文不表示当前代码已经完成统一。当前 Node、Web 与 .NET 仍存在不同大小写、命名和结构；这些现状被列为 Legacy Surface，由后续结构化错误 PR 通过 Adapter 渐进收口。
+
+## 2. 稳定边界
+
+vNext Core 对外错误 DTO 采用以下语义：
+
+```ts
+interface CoreErrorDto {
+  code: CoreErrorCode;
+  message: string;
+  severity: "info" | "warning" | "error" | "fatal";
+  retryable: boolean;
+  recoveryRequired: boolean;
+  operationId?: string;
+  details?: Record<string, unknown>;
+  suggestedAction?: string;
+}
+```
+
+稳定性规则：
+
+- `code` 是程序判断依据；Canonical Code 使用大写蛇形命名。
+- `message`、`suggestedAction` 可以改进、翻译或因平台而不同，不是机器合同。
+- `details` 只承载结构化诊断，不得包含认证信息、Token、消息正文或未脱敏的敏感内容。
+- 普通用户默认不接收 Error Stack；诊断日志也必须遵守相同的隐私边界。
+- 一个失败只选择一个最能指导恢复动作的顶层 Canonical Code；底层 OS/SQLite Code 可放入安全的 `details.causeCode`。
+- Partial Result 可以携带 warning 级错误码，但不能把未完成写入伪装成完整成功。
+
+## 3. Canonical vNext CoreErrorCode
+
+### 3.1 正式集合
+
+| Code | 触发语义 | Severity | Retryable | Recovery Required |
+| --- | --- | --- | --- | --- |
+| `INVALID_INPUT` | 输入缺失、互斥参数、格式或范围无效 | error | 修改输入后是 | 否 |
+| `PROFILE_CHANGED` | 已确认的 Profile Revision 已变化 | warning | 重新读取并确认后是 | 否 |
+| `STORAGE_CHANGED` | 已确认的存储解析结果或 Revision 已变化 | warning | 重新准备 Plan 后是 | 否 |
+| `PLAN_STALE` | Plan 绑定的文件、目标或指纹已变化 | warning | 重新准备 Plan 后是 | 否 |
+| `CODEX_HOME_NOT_FOUND` | Codex Home 不存在或不可解析 | error | 修正路径后是 | 否 |
+| `STATE_DB_NOT_FOUND` | 权威 SQLite Home 中缺少要求存在的 `state_5.sqlite` | error | 修复目标后是 | 否 |
+| `SQLITE_UNSUPPORTED_PATH` | 当前平台不能安全访问该 SQLite 路径，例如 Windows WSL UNC | error | 更换执行环境或路径后是 | 否 |
+| `SQLITE_BUSY` | SQLite 被其他进程占用，无法安全获得写能力 | warning | 关闭占用方后是 | 否 |
+| `SQLITE_UNREADABLE` | SQLite 损坏、格式不受支持或无法可靠读取 | error | 修复或恢复数据库后是 | 否 |
+| `ROLLOUT_LOCKED` | rollout 被活动进程锁定；可形成 Partial Result | warning | 活动会话结束后是 | 否 |
+| `ROLLOUT_CHANGED` | rollout 在扫描与应用之间变化，当前写入被跳过或 Plan 失效 | warning | 重新扫描后是 | 否 |
+| `PENDING_TRANSACTION` | 发现未终结 Transaction Journal，普通写操作必须停止 | error | 完成显式恢复后是 | 是 |
+| `BACKUP_FAILED` | 备份未完成；mutation boundary 尚未跨越 | error | 修复空间或权限后是 | 否 |
+| `SYNC_FAILED_ROLLED_BACK` | 同步失败，但所有已观察变更已完整回滚 | error | 修复原始原因后是 | 否 |
+| `RECOVERY_REQUIRED` | 自动回滚不完整或状态无法证明一致，必须人工恢复 | error | 完成显式恢复后是 | 是 |
+| `RESTORE_VALIDATION_FAILED` | 备份、清单、目标边界或 relocation 校验失败 | error | 修复选择或备份后是 | 否 |
+| `PERMISSION_DENIED` | 文件、目录、锁或数据库权限不足 | error | 修复权限后是 | 否 |
+| `OPERATION_BUSY` | 已证明存在活跃的冲突操作或同一目标写者 | warning | 活跃操作结束后是 | 否 |
+| `OPERATION_CANCELLED` | 用户、Signal 或上层请求取消操作 | info | 是 | 仅在另有 Journal 证据时是 |
+| `CORE_RUNTIME_CRASHED` | Electron Core Runtime 非正常退出 | fatal | Runtime 可重启时是 | 由 Journal 检查决定 |
+| `PROTOCOL_VERSION_MISMATCH` | 调用方与 Core/IPC Schema 不兼容 | error | 升级兼容组件后是 | 否 |
+| `INTERNAL_ERROR` | 未被更具体类别覆盖的内部错误 | fatal | 默认否 | 由 Journal 检查决定 |
+
+### 3.2 阶段 0 补充项
+
+以下代码补充了架构基线已经描述、但初始错误码列表没有单独命名的语义。它们从本合同起属于 vNext Canonical Code；当前实现尚未统一发出这些代码。
+
+| Code | 补充原因 | Severity | Retryable | Recovery Required |
+| --- | --- | --- | --- | --- |
+| `PLAN_EXPIRED` | Plan 已有明确的过期时间和重新准备动作；它与存储内容变化导致的 `PLAN_STALE` 不同 | warning | 重新准备 Plan 后是 | 否 |
+| `LOCK_UNVERIFIABLE` | 无法可靠验证锁所有者、进程启动身份、协议版本或锁目录身份；不能误判为普通 Busy，也不能冒险删除 | error | 消除不确定状态后是 | 否 |
+
+`LOCK_UNVERIFIABLE` 必须 fail closed。只有确认存在活跃冲突所有者时才使用 `OPERATION_BUSY`；未来协议、损坏 owner、身份读取失败或 ABA/目录身份不确定均使用 `LOCK_UNVERIFIABLE`。用户提示不得建议盲目删除锁目录。
+
+## 4. Legacy Surface 现状
+
+### 4.1 Node Core / CLI
+
+| 当前标识 | 当前来源 | 说明 |
+| --- | --- | --- |
+| `RECOVERY_REQUIRED` | `RecoveryRequiredError`、部分 Restore 校验 | 已与 Canonical 同名 |
+| `SYNC_FAILED_ROLLED_BACK` | `SyncTransactionError` | 已与 Canonical 同名 |
+| `ABORT_ERR` | Node 取消路径 | Node 习惯码，不作为 vNext Canonical Code |
+| Node/OS `ENOENT`、`EACCES`、`EPERM` 等 | 普通 `Error` 或系统调用 | 只能作为底层 cause；当前大量错误还没有稳定业务码 |
+| 无稳定 code 的锁错误 | Node `locking.js` | 后续必须按“已证明 Busy”或“不可验证”结构化，禁止解析 message |
+
+当前 CLI 只把错误 `message` 写入 stderr 并以 `1` 退出。本文不把当前人类提示提升为机器协议。
+
+### 4.2 Local Web UI
+
+| 当前标识 | 分类 | vNext 处理 |
+| --- | --- | --- |
+| `PROFILE_CHANGED` | 业务并发/Revision | Canonical 同名 |
+| `STORAGE_CHANGED` | 业务并发/Revision | Canonical 同名 |
+| `PROFILE_REVISION_REQUIRED` | HTTP Profile 前置条件 | 保留为 Web Transport/Precondition Code，不加入 CoreErrorCode |
+| `STORAGE_REVISION_REQUIRED` | HTTP Storage 前置条件 | 保留为 Web Transport/Precondition Code，不加入 CoreErrorCode |
+| `PAIRING_REQUIRED` | Web 认证与配对 | Web Transport Code，不映射为 Core 错误 |
+| `INVALID_ORIGIN` | Web Origin 防护 | Web Transport Code，不映射为 Core 错误 |
+| `INTERNAL_CHALLENGE_REQUIRED`、`INVALID_INTERNAL_CHALLENGE`、`INVALID_INTERNAL_PROOF` | Web 内部配对握手 | 内部 Transport Code，不得泄漏握手材料 |
+
+### 4.3 .NET Application / Automation 0.4
+
+.NET Application 和实验性 Automation 0.4 主要使用小写蛇形码，例如：
+
+- `operation_busy`、`target_busy`；
+- `plan_stale`、`plan_expired`；
+- `cancelled`、`recovery_required`、`sync_failed_rolled_back`；
+- `operation_failed`；
+- `request_required`、`provider_required`、`retention_invalid` 等输入校验码。
+
+.NET Core Lock 还使用过 `TARGET_BUSY`。Automation protocol `0.4` 是实验性协议；其 casing、退出码和 Schema 不是 vNext Core/IPC/CLI JSON 的稳定合同。
+
+## 5. Adapter 映射
+
+| Legacy Code / 状态 | Canonical Code | 映射要求 |
+| --- | --- | --- |
+| `RECOVERY_REQUIRED`、`recovery_required` | `RECOVERY_REQUIRED` | 保留备份路径、operationId 与恢复要求 |
+| `SYNC_FAILED_ROLLED_BACK`、`sync_failed_rolled_back` | `SYNC_FAILED_ROLLED_BACK` | `recoveryRequired=false`，保留 rollback status |
+| `ABORT_ERR`、`cancelled` | `OPERATION_CANCELLED` | 映射前检查 Journal；不能仅凭取消认定无需恢复 |
+| `TARGET_BUSY`、`target_busy`、`operation_busy` | `OPERATION_BUSY` | 仅适用于已证明存在活跃竞争者；用 `details.busyScope` 区分 coordinator/target |
+| 锁 owner/协议/进程身份无法验证，未来协议或目录身份不确定 | `LOCK_UNVERIFIABLE` | 必须 fail closed，不得降级为 Busy 或自动清锁 |
+| `plan_stale` | `PLAN_STALE` | 调用方必须丢弃旧 Plan |
+| `plan_expired` | `PLAN_EXPIRED` | 调用方必须重新生成 Plan |
+| `PROFILE_CHANGED` | `PROFILE_CHANGED` | Web/Client 刷新 Profile 后重新确认 |
+| `STORAGE_CHANGED` | `STORAGE_CHANGED` | 重新解析 Storage 与 Revision |
+| `operation_failed` | 优先映射具体码，否则 `INTERNAL_ERROR` | 禁止把所有失败永久折叠为 `INTERNAL_ERROR` |
+| Node/OS `ENOENT` | 由操作上下文映射 | Codex Home、State DB、Backup 的缺失必须分别分类 |
+| Node/OS `EACCES`、`EPERM` | `PERMISSION_DENIED` | 原始系统码可放入安全 details |
+| SQLite busy/locked | `SQLITE_BUSY` | 不依赖英文 message；使用驱动错误码或 typed cause |
+
+Adapter 必须按 typed exception、明确属性和调用上下文映射。禁止使用 `message.includes(...)` 作为稳定分类方案。
+
+## 6. 各入口展示合同
+
+### Core / Core Runtime
+
+- 返回 Canonical Code 和稳定 DTO。
+- Runtime Crash 与业务失败分开；重启后首先检查 Pending Journal。
+- Progress Event 失败不能替换最终业务错误。
+
+### CLI
+
+- 当前 Human Mode 保留现有人类提示兼容性。
+- 未来 `--json` 只输出 Canonical Code；stdout 为单一 JSON，日志进入 stderr。
+- CLI Exit Code 与 Error Code 是两层合同，不一一等同。
+
+### Local Web UI
+
+- Core 业务失败映射 Canonical Code。
+- Pairing、Origin、Profile Revision Required 等仍属于 Web Transport Code。
+- 已发布的 Web Code 不因 Core 收口而被静默删除。
+
+### 迁移期 .NET
+
+- Adapter 将小写 Legacy Code 映射为 Canonical Code，原协议 0.4 可继续输出旧码直到其兼容窗口结束。
+- 对同一 Fixture 的 Node/.NET 差异必须登记并裁决，不能按字符串相似度自动合并。
+
+## 7. 变更规则
+
+- 新增 Canonical Code：更新本文、Contract Test 与至少一个行为 Fixture。
+- 删除或合并 Canonical Code：属于外部合同变更，必须有独立 ADR 和迁移说明。
+- 修改 `message`：通常不是破坏性变更，但不得改变 code 的恢复语义。
+- 修改 `retryable` 或 `recoveryRequired`：视为合同变更，必须补充故障注入测试。
+- Legacy Adapter 可新增映射；不得让已知 Legacy Code 回退为字符串解析。
+
+## 8. 阶段 0 验收边界
+
+阶段 0 只冻结分类与映射，不修改异常类、CLI 退出码、Web 响应或 .NET protocol 0.4。统一实现、`--json` 与 Contract Test 分别在后续 PR 完成。

--- a/docs/migration/BEHAVIOR_FIXTURES_ZH.md
+++ b/docs/migration/BEHAVIOR_FIXTURES_ZH.md
@@ -1,0 +1,135 @@
+# vNext 行为兼容 Fixture 清单
+
+> **状态：Accepted（阶段 0 语义清单；共享 Corpus 尚未创建）**
+>
+> **日期：2026-08-24**
+>
+> **适用范围：Node、迁移期 .NET、CLI、Web 与 Electron Core Runtime 的行为对照**
+>
+> **架构基线：[vNext Electron + Node 单核心架构](../VNEXT_ELECTRON_NODE_ARCHITECTURE_ZH.md)**
+
+## 1. 目的与边界
+
+本文冻结需要被共享 Fixture 表达的场景、输入语义和验收结果，用于迁移期间比较 Node 与 .NET，并为 Node 单核心提供长期回归证据。
+
+阶段 0 **不创建** `packages/test-fixtures/`，也不提交伪造的 SQLite、锁文件或平台专属二进制。当前 Node 测试使用临时目录动态构造输入，.NET 测试使用 `TestCodexHomeFixture` 和 GUI E2E `IsolatedFixture`；后续实现共享 Corpus 时应复用这些已验证的构造能力。
+
+Fixture 不是用户数据样本，严禁从真实 `~/.codex`、认证文件或私人会话复制内容。
+
+## 2. 通用 Fixture 合同
+
+未来每个 Fixture 必须声明：
+
+- `fixtureVersion`、稳定 ID、用途和适用平台；
+- 输入文件、SQLite Schema/Rows、路径布局和初始 Revision；
+- 预期 Status、Plan、Progress、Result 或 Error Code；
+- 允许写入的目标；
+- 必须保持不变的字段与文件 SHA-256；
+- 预期 Backup 内容、Metadata Version 和 Transaction Journal 状态；
+- Restore 后的语义状态与逐字节不变量；
+- Node/.NET 是否都应运行，以及已裁决的差异。
+
+运行规则：
+
+1. Corpus 永远只读；每次运行复制到新的临时目录。
+2. 所有可变绝对路径、时间、PID、operationId 和随机 ID 在比较前规范化。
+3. 比较语义结果、目标字段、备份覆盖、Journal 状态和 Canonical Error Code，不比较本地化 message。
+4. `auth.json`、Token、凭据和真实消息正文不得进入 Fixture。
+5. 故障注入只能作用于临时副本；测试结束后验证未触及真实 Codex Home。
+6. 平台无法执行的场景应明确 Skip 原因，不能伪造 Passed。
+
+## 3. Provider、rollout 与模型
+
+| Fixture ID | 输入语义 | 关键预期 |
+| --- | --- | --- |
+| `default-openai` | 根级显式 `model_provider="openai"`，rollout/SQLite 已对齐 | Status 为 aligned；重复 Sync 幂等；无需改动的字段与 mtime 保持不变 |
+| `implicit-openai` | 根级没有 `model_provider` | 当前 Provider 回退为 `openai` 并标记 implicit；Sync 不凭空写入无关配置 |
+| `custom-provider` | 配置声明自定义 Provider，历史来自其他 Provider | Switch/Sync 只更新允许的 Provider 元数据；Switch 选择未声明的 Provider 时为 `INVALID_INPUT` |
+| `explicit-sync-provider` | `sync --provider ID` 显式给出未在 config 声明的 Provider | v0.5 当前允许直接以该 ID 同步；Public API 提取不得无意增加 Switch 式校验。未来若要收紧，必须独立评估 CLI 兼容性与 SemVer |
+| `mixed-provider` | sessions、archived_sessions 与 SQLite 中存在多个 Provider | Status 分布完整；Sync 统一目标字段但不要求两类 inventory 数量相等 |
+| `archived-sessions` | 只含或混合归档 rollout/SQLite rows | active/archived 作用域保持正确，Restore 能逐字节还原 |
+| `root-model` | 根级 model、Provider section model 与 turn_context model 不同 | Follow/Keep/Explicit 三种 Switch 语义清晰；非目标字段和换行符不变 |
+| `encrypted-content` | rollout 含来自原 Provider 的 `encrypted_content` | 只同步可见性元数据；保留加密内容字节并返回明确 warning |
+| `large-rollout` | 超大 rollout、超过 64 KiB 的行、Unicode 与特殊 model 字符 | 流式处理且目标字段正确；未修改字节、CRLF 与原 mtime 按合同保持 |
+| `malformed-rollout` | 截断、无效 JSONL、文件扫描期间消失等 | 不读取越界、不覆盖无法证明安全的内容；按操作返回 skip/error 并保留原字节 |
+
+## 4. SQLite 与存储布局
+
+| Fixture ID | 输入语义 | 关键预期 |
+| --- | --- | --- |
+| `custom-sqlite-home` | 显式或配置指定外部 SQLite Home，Codex Home 内有陈旧 DB | 只使用权威 SQLite Home；不得回退或修改陈旧 DB |
+| `legacy-state-db` | 默认 `<CodexHome>/sqlite/state_5.sqlite` 缺失，根目录 legacy DB 存在 | 仅默认布局允许 legacy fallback；Backup/Restore 原地对应同一位置 |
+| `dual-state-db-candidates` | 默认与 legacy 两个候选均存在且活跃度不同 | 两个实现必须选择同一权威候选，未选中的 DB Hash 不变 |
+| `sqlite-malformed` | `state_5.sqlite` 不是有效数据库或缺少关键结构 | Status 降级报告 `SQLITE_UNREADABLE`；写操作在 Backup/rollout mutation 前停止 |
+| `sqlite-live-wal` | 数据仍在 WAL，数据库由另一连接保持打开 | 官方 online backup 生成单一可独立打开的 main DB；不把 WAL/SHM 当备份清单文件 |
+| `wsl-unc-unchanged-hash` | Windows 下 SQLite Home 为 `\\wsl.localhost\...` 或 `\\wsl$\...` | Status 只诊断；写操作返回 `SQLITE_UNSUPPORTED_PATH`，配置、rollout、DB、global state 与 backup root 的 Hash/存在性全部不变 |
+
+## 5. 锁、并发与恢复
+
+| Fixture ID | 运行方式 | 关键预期 / 安全门槛 |
+| --- | --- | --- |
+| `locked-rollout` | 平台真实文件锁 | 锁定文件不被写；其他安全目标可形成 Partial Result；返回 `ROLLOUT_LOCKED` 语义并可重试 |
+| `active-rollout-changing` | 扫描后、应用前改变目标 | 变化文件被跳过或 Plan 失效；不覆盖 Codex 新写入，使用 `ROLLOUT_CHANGED`/`PLAN_STALE` |
+| `sqlite-busy` | 真实 SQLite 写锁 | 在 rollout mutation 和 Backup 前阻断，返回 `SQLITE_BUSY`，全部原始 Hash 不变 |
+| `node-dotnet-lock-contention` | 启动真实 Node 与 .NET 进程争用同一 `<CodexHome>/tmp/provider-sync.lock` | 恰有一个写者获得 protocol v2 锁；另一方为 `OPERATION_BUSY`；败方不创建 Backup、不改任何目标 |
+| `shared-sqlite-home-contention` | 两个不同 Codex Home 指向同一 SQLite Home，并发写 | 不能因 Codex Home 锁不同而同时写同一 DB；阶段 1 必须验证/裁决共享资源锁，在通过前不得开放 Electron 写能力 |
+| `lock-unverifiable` | future protocol、损坏 owner、进程启动身份不可读、ABA/目录身份变化 | fail closed，返回 `LOCK_UNVERIFIABLE`；不得误报普通 Busy，不得自动删除不可证明归属的锁 |
+| `pending-journal` | Managed Backup 中存在未终结 Journal | Status 可读并暴露恢复证据；Sync/Switch 被 `PENDING_TRANSACTION`/`RECOVERY_REQUIRED` 阻断。Prune 仍可作为 recovery-safe maintenance 执行，但必须保护所有 Pending Journal 引用的备份 |
+| `foreign-pending-restore` | Node 创建 Pending Journal/Backup 后由 .NET Restore，及反方向 | 两个方向都只按受管清单恢复，清除 Pending 前必须落入合法 terminal；差异需显式裁决 |
+| `restore-mid-failure` | Restore 在某一目标已替换后注入失败 | 不能报告成功；必须完整补偿，或保留可操作证据并返回 `RECOVERY_REQUIRED`，不得留下无 Journal 的半恢复状态 |
+| `bidirectional-backup-roundtrip` | Node Backup→.NET Restore；.NET Backup→Node Restore | 两个方向恢复到等价语义状态；正文和不应变化字段逐字节一致；Metadata v1/v2 兼容边界明确 |
+| `journal-crash-matrix` | 在 prepared/applying/applied/commit/rollback 及 ack 窗口真实终止进程 | durable terminal 优先；非 terminal 阻断后续写；不得对 committed 状态补回滚事件；显式 Restore 可收敛 |
+| `rollback-recovery-required` | mutation 后使自动 rollback 的一个或多个目标失败 | 原始错误与所有 rollback error 均保留；Backup、completed/uncompleted targets 和 `RECOVERY_REQUIRED` 可用于人工恢复 |
+
+真实跨运行时测试不能用 Mock 代替进程争锁。Node 与 .NET 必须在同一临时目标上运行，并以文件/SQLite 最终效果作为独立证据。
+
+## 6. Restore、Backup 与 Prune
+
+| Fixture ID | 输入语义 | 关键预期 |
+| --- | --- | --- |
+| `restore-relocation` | Backup 的 SQLite Home 与当前目标不同 | 默认拒绝；只有显式目标和 relocation 确认才允许，且跨 SQLite Home Restore 不恢复 config |
+| `prune-managed-only` | backup root 同时包含受管备份、普通目录和 Pending Journal 引用 | 只删除超过保留数的受管备份；普通目录和 Pending Journal 所在目录永不删除 |
+| `backup-first-no-mutation` | Backup 期间空间、权限或 snapshot 失败 | 返回 `BACKUP_FAILED`；不存在 Journal/目标 mutation；原始 Hash 不变 |
+
+`bidirectional-backup-roundtrip` 与 `foreign-pending-restore` 是迁移期淘汰 .NET 前的强制门槛，不因单向 Restore 成功而视为通过。
+
+## 7. Workspace 与 History
+
+| Fixture ID | 输入语义 | 关键预期 |
+| --- | --- | --- |
+| `workspace-roots` | global state、rollout cwd 与 SQLite cwd 不一致，含跨平台路径形式 | 只修复合同允许的 workspace/cwd 元数据；路径规范化一致；Backup/Restore 覆盖 global state |
+| `history-safe-content` | user/event/response-item 重复消息、无 thread id、同 id 多 rollout | 列表选择稳定会话；详情只在用户主动读取时返回安全消息；正文不进入日志、诊断包或应用数据库 |
+
+## 8. 未来 Corpus 建议结构
+
+本节只定义目标，不表示目录已经存在：
+
+```text
+packages/test-fixtures/
+├─ schema/
+│  └─ fixture.schema.json
+├─ static/<fixture-id>/
+│  ├─ fixture.json
+│  ├─ input/
+│  └─ expected/
+└─ builders/
+   ├─ sqlite/
+   ├─ locks/
+   └─ crash-hosts/
+```
+
+SQLite live WAL、真实文件锁、跨进程 crash 和 WSL UNC 不能作为静态字节目录伪造，必须由受控 Builder/Harness 在临时目录创建。静态部分只保存最小、无敏感内容、可审计的源输入。
+
+## 9. Node / .NET 对照与差异登记
+
+每个双运行时 Fixture 使用两份相同输入副本：
+
+1. Node 执行并输出规范化结果与最终 Hash；
+2. .NET 执行并输出相同维度证据；
+3. 比较 Status、Plan、目标字段、Backup、Restore、Journal 与 Error Code；
+4. 差异必须记录“Node 行为 / .NET 行为 / 权威选择 / 安全理由 / 对应测试”；
+5. Node 是 vNext 目标核心，但不能以“新实现”为理由静默覆盖更安全的既有行为。
+
+## 10. 阶段 0 验收边界
+
+阶段 0 的完成标志是本文场景、预期和安全门槛获得确认。实际 Corpus、Schema、Builder、跨运行时 Harness 和 CI Matrix 均属于后续阶段；在它们真正通过之前，文档不得宣称行为等价。

--- a/docs/migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md
+++ b/docs/migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md
@@ -1,0 +1,211 @@
+# vNext 升级改造执行索引
+
+> **状态：阶段 0 交付完成（合入 `main` 后生效）**
+>
+> **日期：2026-08-24**
+>
+> **目标：Electron + React + TypeScript + Node 单核心的渐进迁移**
+>
+> **架构基线：[vNext Electron + Node 单核心架构](../VNEXT_ELECTRON_NODE_ARCHITECTURE_ZH.md)**
+
+## 1. 索引职责
+
+本文是迁移工作的执行入口，用于记录阶段状态、PR 依赖、进入条件和退出门槛。它不复制架构正文，也不把目标设计描述成已经实现。
+
+权威顺序：
+
+1. 已发布兼容行为、当前代码与测试；
+2. vNext 架构基线；
+3. Accepted ADR；
+4. [Core 外部行为合同](../architecture/contracts/CORE_EXTERNAL_BEHAVIOR_ZH.md)、[CLI 合同](../architecture/contracts/CLI_CONTRACT_ZH.md)和 [Error Code 合同](../architecture/contracts/ERROR_CODES_ZH.md)；
+5. [行为兼容 Fixture 清单](BEHAVIOR_FIXTURES_ZH.md)；
+6. 本执行索引中的阶段状态。
+
+发生冲突时必须先登记差异并裁决，不能让后提交的新实现自动成为权威。
+
+## 2. 总体状态
+
+| 阶段 | 名称 | 当前状态 | 核心结果 |
+| --- | --- | --- | --- |
+| 0 | 冻结决策与安全合同 | **Completed（合入 `main` 后）** | 架构、ADR、Core/CLI/Error 合同、Fixture 语义和执行索引 |
+| 1 | 提取 Node Core，不改行为 | Pending | `src/public-api.js`，CLI/Web 只经公开入口调用 |
+| 2 | Contracts 与 Core Client | Pending | `packages/core`、`packages/contracts`、`packages/core-client` 与稳定 DTO |
+| 3 | Electron Read-only Alpha | Pending | 三平台只读 Status/Backup/Diagnostics，不开放写能力 |
+| 4 | Sync / Switch Beta | Pending | Prepare/Apply、Progress、Cancel、Partial 与 Restore 验证 |
+| 5 | Restore / Watch / 完整功能 | Pending | Recovery、Restore、Prune、Watch、Update 与诊断能力 |
+| 6 | Electron Stable，替代 .NET | Pending | Electron 成为默认桌面产品，.NET 标记 Legacy |
+| 7 | 清理 Legacy | Pending | 移出重复 .NET 业务代码，保留历史标签、分支和迁移说明 |
+
+状态只能按 `Pending → In Progress → Completed` 前进。PR 分支可以把自身交付标为“合入后 Completed”，但受保护分支上的阶段只有在退出门槛全部满足并完成合并后才正式生效。
+
+## 3. 阶段门槛
+
+### 阶段 0：冻结决策与安全合同
+
+进入条件：
+
+- vNext 架构方向已经确认；
+- 当前 Node、Web、.NET 行为仍由现有代码和测试证明。
+
+退出门槛：
+
+- ADR-0001～ADR-0010 均为 Accepted，历史 v0.4 ADR 不与 vNext 编号混淆；
+- Core 外部行为、CLI、Error Code、Fixture 和本索引可互相导航；
+- 每份文档明确“当前已实现”与“vNext 目标”；
+- 本阶段不修改运行代码、CLI 输出、Error Class 或运行代码目录结构；
+- CI 全绿并完成评审。
+
+### 阶段 1：提取 Node Core，不改行为
+
+进入条件：阶段 0 Completed。
+
+退出门槛：
+
+- 新增 `src/public-api.js`，CLI/Web 不再导入 Core 内部实现；
+- 展示逻辑与业务结果分离，现有用户可见语义不变；
+- PR 2～PR 5 均已完成：Public API、结构化错误、CLI `--json` 与 Prepare/Apply 已分别落地；
+- CLI `--json` 是 opt-in 加法；默认 Human Mode、命令语义和 v0.5 兼容行为保持不变；
+- 原 Node 测试全绿，新增 Public API Contract Test；
+- 真实 Node↔.NET 对同一 Codex Home 的 protocol v2 操作锁争用通过：恰有一个写者，败方无副作用；
+- 锁不确定状态 fail closed，并能区分 `OPERATION_BUSY` 与 `LOCK_UNVERIFIABLE`；
+- 两个 Codex Home 共享同一 SQLite Home 的并发风险已验证并形成明确锁合同。若尚未安全，阶段 1 不得宣称跨入口写入安全，后续 Electron 写能力继续阻断。
+
+### 阶段 2：Contracts 与 Core Client
+
+进入条件：阶段 1 Completed，Public API 已稳定收口。
+
+退出门槛：
+
+- npm workspaces 和 `packages/core` 先包装既有 Public API，不混入业务重写；
+- `packages/contracts` 的 Result/Event/Error/Protocol 可序列化并有版本；
+- `CoreClient`、`HttpCoreClient`、`MockCoreClient` 表达相同业务语义；
+- Legacy Error Adapter 不解析 message，并通过 Error Code Contract Test；
+- 共享 Fixture Schema、临时复制 Runner 和差异登记格式落地；
+- Node/.NET 双向 Backup Round-trip、Foreign Pending Restore 至少在受支持平台形成可重复证据；未通过的差异必须阻断后续写阶段。
+
+### 阶段 3：Electron Read-only Alpha
+
+进入条件：阶段 2 Completed；Core/Client/Protocol 可用。
+
+退出门槛：
+
+- Main、Preload、Renderer 与 Core Utility Process 边界成立；
+- Renderer 无 Node、文件系统或任意 IPC 权限；
+- Windows/macOS/Linux Packaged Build 可启动并完成版本握手；
+- 只开放 Profile、Status、Backup List、Diagnostics 和可选只读 History；
+- Runtime Crash 能拒绝 Pending Request、重启，并在下一次请求检查 Pending Journal；
+- Status 与 CLI/Core 在同一 Fixture 上语义一致；
+- 无 Sync、Switch、Restore、Prune 或 Watch 自动写入口。
+
+### 阶段 4：Sync / Switch Beta
+
+进入条件：阶段 3 Completed；所有写入前置安全门槛通过。
+
+退出门槛：
+
+- Prepare/Confirm/Apply、Revision、Expiry、Single-use 与 Plan Stale 完整实现；
+- Electron 与 CLI 调用同一 Node Core，不解析 CLI 文本；
+- SQLite Busy、locked/changing rollout、Cancel、Partial Result 和 Backup-first 通过 Fault Injection；
+- `shared-sqlite-home-contention` 已证明不会出现并行数据库写者；
+- `wsl-unc-unchanged-hash` 通过，阻断操作不创建 Backup、不改变任何目标；
+- Journal Crash Matrix 覆盖 mutation/commit/ack 关键窗口；
+- 一次 Sync/Switch 后可由受管 Backup 恢复到原状态。
+
+### 阶段 5：Restore / Watch / 完整功能
+
+进入条件：阶段 4 Completed，写操作 Beta 无已知数据破坏问题。
+
+退出门槛：
+
+- Restore、Prune、Watch、Recovery Required、Update 和诊断包完整；
+- `restore-mid-failure` 不产生无证据的半恢复状态；
+- Node Backup→.NET Restore、.NET Backup→Node Restore 双向通过；
+- Foreign Pending Journal 可由兼容入口显式恢复并写入合法 terminal；
+- Pending Journal 保护 Prune，Watch 不抢占用户写操作；
+- 诊断包不含凭据、消息正文或未脱敏敏感路径。
+
+### 阶段 6：Electron Stable，替代 .NET
+
+进入条件：阶段 5 Completed，并完成真实 Beta 用户验证。
+
+退出门槛：
+
+- 三平台安装、启动、SQLite Driver、Sync+Restore、退出和清理 smoke 通过；
+- 无已知数据破坏 Bug，关键功能等价，无 .NET 独占正式能力；
+- Installer、签名、Notarization、更新和 Release 策略明确；
+- README 默认推荐 Electron，.NET 标记 Legacy；
+- 旧 Backup 可由新 CLI/Desktop 恢复；
+- .NET 至少保留两个维护发布周期，不立即删除旧 Release。
+
+### 阶段 7：清理 Legacy
+
+进入条件：阶段 6 的兼容窗口结束，迁移证据与用户反馈满足清理条件。
+
+退出门槛：
+
+- .NET 停止常规 CI 并从 active source tree 移出；
+- legacy tag/branch、历史 ADR、Release 和 Restore 说明仍可访问；
+- 删除的只是重复业务实现，不删除 Node CLI；
+- 仓库文档、依赖图、发布脚本和安全说明不再引用已移除路径。
+
+## 4. 首批 PR 依赖
+
+| PR | 内容 | 依赖 | 关键合入门槛 | 状态 |
+| --- | --- | --- | --- | --- |
+| PR 1 | 冻结架构合同和 ADR | 无 | 仅文档；阶段 0 退出门槛 | **Completed（合入 `main` 后）** |
+| PR 2 | Core Public API | PR 1 | CLI/Web 仅走 Public API；现有测试全绿；锁合同验证 | Pending |
+| PR 3 | 结构化错误 | PR 2 | Canonical/Legacy Adapter、`LOCK_UNVERIFIABLE`、错误合同测试 | Pending |
+| PR 4 | CLI `--json` | PR 2、PR 3 | stdout 单一 JSON、stderr 日志、Exit Code 与 Schema 合同 | Pending |
+| PR 5 | Prepare / Apply | PR 2、PR 3 | Revision/Plan/Apply 下沉；CLI Human Mode 兼容 | Pending |
+| PR 6 | Workspace 与 Core 骨架 | PR 2～PR 5（阶段 1 Completed） | workspaces/Core/Contracts/CoreClient 骨架；不搬 UI、不改算法 | Pending |
+| PR 7 | React UI 分解 | PR 6 | AppShell/Feature/HttpCoreClient；现有 Web UI 可用；阶段 2 退出门槛 | Pending |
+| PR 8 | Electron Skeleton | PR 7（阶段 2 Completed） | Main/Preload/Renderer 安全基线与版本握手；无业务写 | Pending |
+| PR 9 | Core Utility Process | PR 8 | Supervisor、Status、Crash/Protocol Test；Pending Journal 检查 | Pending |
+| PR 10 | Read-only Preview Release | PR 9 | 三平台 package、只读 smoke、使用说明和反馈模板；阶段 3 退出门槛 | Pending |
+
+PR 4 与 PR 5 可在 PR 2/3 后并行开发；两者都完成后才能进入 PR 6。PR 6～PR 10 按阶段门槛顺序推进，不能用“只搭骨架”绕过上一阶段的退出条件。
+
+PR 到阶段的归属固定为：PR 1 完成阶段 0；PR 2～PR 5 完成阶段 1；PR 6～PR 7 完成阶段 2；PR 8～PR 10 完成阶段 3。阶段 4 之后的 PR 编号在 Read-only Preview 证据完成后确定。
+
+阶段 4 之后的写入、Restore/Watch、Stable 与 Legacy 清理 PR，在 Read-only Preview 证据完成后再编号，避免提前承诺不可靠的拆分。
+
+## 5. 跨阶段安全门槛矩阵
+
+| 安全证据 | 最晚完成阶段 | 阻断内容 |
+| --- | --- | --- |
+| 真实 Node↔.NET 同 Codex Home 争锁 | 阶段 1 | 阻断“迁移期入口共享安全锁合同”的声明 |
+| Busy 与不可验证锁的结构化区分 | 阶段 1/PR 3 | 阻断自动重试、自动清锁和 Electron 写入 |
+| 不同 Codex Home 共享 SQLite Home 的互斥 | 阶段 4 进入前 | 阻断所有 Electron 写能力 |
+| 双向 Backup Round-trip | 阶段 2 建证、阶段 5 全通过 | 阻断 .NET Legacy 替代 |
+| Foreign Pending Restore | 阶段 2 建证、阶段 5 全通过 | 阻断跨入口 Recovery 声明 |
+| Windows WSL UNC 全 Hash 不变 | 阶段 4 | 阻断 Windows Sync/Switch Beta |
+| Journal Crash Matrix | 阶段 4 | 阻断写操作 Beta |
+| Restore Mid-failure | 阶段 5 | 阻断 Restore 正式开放 |
+
+## 6. 差异登记规则
+
+Node 与 .NET 在同一 Fixture 上不一致时，PR 必须记录：
+
+- Fixture ID 和复现平台；
+- Node 结果、.NET 结果和逐字节/SQLite 证据；
+- 哪一方成为权威以及安全理由；
+- Error Code、Backup、Journal 和 Restore 是否受影响；
+- 修复 PR、回归测试和兼容说明。
+
+“Node 是目标核心”只决定最终代码所有权，不自动证明任一新行为正确。
+
+## 7. 禁止提前执行
+
+在对应阶段退出门槛通过前，不得：
+
+- 删除或停止维护 .NET；
+- 让 Electron Renderer 访问 Node/文件系统；
+- 在 Main/IPC Handler 复制业务逻辑；
+- 整体把 Node JavaScript 翻译成 TypeScript；
+- 用 Electron 调 CLI 并解析人类文本；
+- 开放未经 Prepare/Apply 和安全 Fixture 验证的写入口；
+- 声称共享 Fixture、跨运行时等价或三平台稳定已经完成。
+
+## 8. 本 PR 完成后的下一步
+
+阶段 0 合入并标记 Completed 后，下一项是 PR 2：新增 `src/public-api.js`，让 CLI 与 Web 经单一公开入口调用现有 Node 行为。该 PR 不移动 Core、不改同步算法，也不同时引入 `--json`、TypeScript 或 Electron。


### PR DESCRIPTION
## Summary

- add Accepted vNext/ADR-0001 through ADR-0010
- freeze the current v0.5 Node Core and CLI compatibility surfaces
- define canonical vNext error codes and legacy adapter mappings
- define behavior-fixture semantics and the staged PR execution index
- record the current cross-runtime lock contract and the unresolved shared-SQLite-Home and Restore transaction safety gaps
- link the phase-0 baseline from README and AGENTS.md

## Scope

Documentation only. This PR does not change runtime code, CLI output, exit codes, error classes, or released behavior.

## Validation

- `git diff --check`
- all local Markdown links resolve
- ADR inventory/metadata check: 10 Accepted vNext ADRs and 5 contract/migration documents
- `npm run web:build`
- focused Node suite: 88 tests, 86 passed, 2 Windows-only skipped
- independent adversarial review: no remaining findings

The full local `npm test` was also attempted. This Work Mode sandbox cannot run `ps -p <pid> -o lstart=` (`fatal library error, lookup self`), so lock-dependent tests fail before their assertions. GitHub CI is the authoritative full-suite gate.