### PR TITLE
docs: 简化 README，更新正式版入口与问题模板

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,8 +13,8 @@ body:
     id: version
     attributes:
       label: codex-provider-sync 版本
-      description: 例如 v0.5.0。GUI 版本请填写 Release 版本；CLI 版本请填写 `npm list -g @dailin521/codex-provider-sync` 或安装来源。
-      placeholder: v0.5.0
+      description: 桌面版请填写 Release 版本（如 v1.0.0）；CLI / Web 请填写 `npm list -g @dailin521/codex-provider-sync` 的版本或源码 commit。桌面与 npm 版本独立发布。
+      placeholder: Windows Electron v1.0.0 / npm CLI v0.5.0
     validations:
       required: true
   - type: dropdown
@@ -22,7 +22,9 @@ body:
     attributes:
       label: 使用方式
       options:
-        - Windows GUI EXE
+        - Windows Electron 桌面版
+        - 本地 Web UI
+        - Legacy .NET 桌面版（Windows / macOS）
         - npm 全局 CLI
         - 仓库源码运行
         - 其它
@@ -47,12 +49,12 @@ body:
     id: steps
     attributes:
       label: 复现步骤
-      description: 从 provider 切换、Refresh、Execute、sync/switch 命令开始写，尽量按时间顺序。
+      description: 从 Provider 切换、刷新、预览或直接同步、sync/switch 命令开始写，尽量按时间顺序。
       placeholder: |
         1. 关闭 Codex Desktop
         2. 切换 provider 到 ...
-        3. 打开 CodexProviderSync.exe，点击 Refresh
-        4. 点击 Execute 后出现 ...
+        3. 打开工具，在概览点击刷新
+        4. 点击直接同步后出现 ...
     validations:
       required: true
   - type: textarea
@@ -71,8 +73,8 @@ body:
   - type: textarea
     id: diagnostics
     attributes:
-      label: status / GUI Refresh 诊断文本
-      description: 优先粘贴完整输出。CLI 可运行 `codex-provider status`；GUI 请复制 Refresh 后状态区文本。
+      label: 概览状态 / CLI status 输出
+      description: CLI 可运行 `codex-provider status`；桌面 / Web 请附刷新后的概览截图或文字。无需为提交问题执行高级修复。请遮盖个人路径等隐私信息。
       render: text
     validations:
       required: true
@@ -80,7 +82,7 @@ body:
     id: logs
     attributes:
       label: 日志或错误堆栈
-      description: Windows GUI 常规问题请贴 `%AppData%\codex-provider-sync\logs\execution-YYYY-MM-DD.log`；EXE 启动问题另请贴 `%AppData%\codex-provider-sync\startup-error.log`；CLI 问题请贴终端完整输出。
+      description: Electron 请附“操作日志”中对应操作的结果、错误码和阶段耗时；CLI / Web 请附终端错误。Legacy .NET Windows 日志位于 `%AppData%\codex-provider-sync\logs`，启动错误为同目录上级的 `startup-error.log`。不要上传 auth.json、凭据、聊天正文、原始数据库或备份。
       render: text
     validations:
       required: false
@@ -89,7 +91,7 @@ body:
     attributes:
       label: 确认事项
       options:
-        - label: 我理解本工具只同步可见性 metadata，不处理登录、认证或 auth.json。
+        - label: 我理解普通同步只对齐 Provider 元数据，不处理登录、认证或 auth.json。
           required: true
         - label: 我理解含 encrypted_content 的历史会话跨 provider/account 后可能不能继续对话。
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,6 @@ body:
     attributes:
       label: 概览状态 / CLI status 输出
       description: CLI 可运行 `codex-provider status`；桌面 / Web 请附刷新后的概览截图或文字。无需为提交问题执行高级修复。请遮盖个人路径等隐私信息。
-      render: text
     validations:
       required: true
   - type: textarea

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,11 @@ An external behavior change must update its contract and add or update a fixture
 
 ## Goal
 
-Restore Codex session visibility after `model_provider` changes by keeping rollout metadata and the resolved SQLite thread index aligned. Do not treat this as an authentication or account-management tool.
+Help reuse Codex sessions affected by `model_provider` metadata mismatches by keeping rollout metadata and the resolved SQLite thread index aligned. This does not guarantee cross-provider continuation or compaction. Do not treat this as an authentication or account-management tool.
 
 ## Choose the interface
 
-- Prefer the Windows GUI for users who want a double-click tool and do not want Node.js.
+- Prefer the Windows Electron desktop app for users who want a double-click tool and do not want Node.js.
 - Prefer the Local Web UI for browser-based or cross-platform use: `codex-provider web`.
 - Use the CLI for explicit command requests, automation, diagnostics, WSL paths, or when a GUI is unavailable.
 - Use `CodexProviderSync.Automation.exe` only for repository development or explicit Automation work. It ships with the v0.4 Windows Release, but protocol 0.4 is experimental and is not a stable public API or a production GUI control port.
@@ -63,7 +63,7 @@ On Windows, `\\wsl.localhost\...` and `\\wsl$\...` SQLite Homes are diagnostic-o
 - Do not change thread `updated_at` or reorder history to force visibility.
 - Preserve Home locking, backup-first, native SQLite transactions, WSL and path boundaries. Ordinary Sync/Switch/Repair use retryable partial outcomes after mutation, not cross-file journals or automatic full rollback. Restore alone retains its durable recovery journal and compensation. Do not reintroduce a Node State DB resource lock.
 - Rollout/SQLite counts may differ briefly because of an active session; Provider distributions are the alignment signal.
-- Metadata synchronization restores visibility only. Another Provider/account may be unable to decrypt existing `encrypted_content`; advise the user to return to the original Provider/account or start a new session if continuation or compact fails.
+- Metadata synchronization only addresses Provider alignment, not every cause of an unusable session. Another Provider/account may be unable to decrypt existing `encrypted_content`; advise the user to return to the original Provider/account or start a new session if continuation or compact fails.
 - Tests and reproduction scripts must use temporary directories or fixtures, never a real user Codex Home.
 
 ## Handle common outcomes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [Unreleased]
 
-后续变更在此记录。
+- 将 Desktop 更新器与构建链的传递依赖 `js-yaml` 从 `4.3.1` 更新至 `4.3.2`，修复空 YAML 合并源绕过处理上限的问题（[GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh)）。不改变 Provider 读写；已发布安装包不会因此自动更新。
 
 ## [1.0.0] - 2026-09-08
 

--- a/README.md
+++ b/README.md
@@ -8,24 +8,42 @@
 [![CLI / Web](https://img.shields.io/npm/v/%40dailin521%2Fcodex-provider-sync?label=CLI%20%2F%20Web)](https://www.npmjs.com/package/@dailin521/codex-provider-sync)
 [![Releases](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync?label=Releases)](https://github.com/Dailin521/codex-provider-sync/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
 **中文** · [English](docs/README_EN.md) · [日本語](docs/README_JA.md) · [한국어](docs/README_KO.md)
 
 </div>
 
+## 它解决什么
+
 切换 Provider 后，旧会话可能仍记录着原来的 Provider。本工具将**会话文件与 SQLite 聊天索引中的 Provider 信息**对齐到当前配置，解决元数据不一致的问题。
 
 **不保证跨 Provider / 账号的旧会话一定能继续或压缩**，也不处理登录、认证或加密内容。信息已对齐时，无需重复同步。
 
+<p align="center">
+  <img src="images/README/provider-metadata-sync-flow.png" alt="Provider 元数据同步示意：保持当前配置不变，将会话文件与 SQLite 索引从 Provider A 对齐到 Provider B" width="760">
+</p>
+
+- **已用 CCSwitch 等工具切换**：同步到当前配置中的 Provider。
+- **希望在本工具中切换**：修改配置后，同步会话文件和索引中的 Provider。
+- **Provider 信息已经一致**：不必重复同步；继续失败时应查看 Codex 的具体报错。
+
+## 核心功能
+
+- **同步与切换**：预览或直接同步，按需开启自动同步。
+- **备份与恢复**：修改前自动备份，支持恢复和清理。
+- **聊天与日志**：按项目浏览会话，查看操作结果和耗时。
+- **存储与修复**：自定义数据位置，按需诊断和专项修复。
+
 ## 下载 Windows 桌面版
 
-当前正式版 **v1.0.0 · Windows x64**，无需安装 Node.js。
+**v1.0.0 · Windows x64**，无需 Node.js。
 
-- [下载安装包（约 100 MiB）](https://github.com/Dailin521/codex-provider-sync/releases/download/v1.0.0/CodexProviderSync-1.0.0-windows-x64-setup.exe)
-- [下载便携 ZIP（约 123 MiB）](https://github.com/Dailin521/codex-provider-sync/releases/download/v1.0.0/CodexProviderSync-1.0.0-windows-x64-portable.zip)：完整解压后运行，不要只复制 EXE。
-- [版本说明与校验文件](https://github.com/Dailin521/codex-provider-sync/releases/tag/v1.0.0)
+[安装版](https://github.com/Dailin521/codex-provider-sync/releases/download/v1.0.0/CodexProviderSync-1.0.0-windows-x64-setup.exe) · [便携 ZIP](https://github.com/Dailin521/codex-provider-sync/releases/download/v1.0.0/CodexProviderSync-1.0.0-windows-x64-portable.zip) · [版本说明与校验](https://github.com/Dailin521/codex-provider-sync/releases/tag/v1.0.0)
 
-此版本未签名，更新需手动安装。旧 .NET 版的更新按钮不能升级到 Electron，请下载完整新版。macOS/Linux Electron 安装包尚未发布；CLI / Web 的 npm 版本独立发布，不等同于桌面版版本号。
+未签名，手动安装更新；便携版须完整解压。旧 .NET 版需重新下载安装，不能通过旧更新按钮迁移。
+
+macOS/Linux Electron 包尚未发布；CLI / Web 的 npm 版本独立发布。
 
 ## 日常使用
 
@@ -33,11 +51,9 @@
 2. 已通过 CCSwitch 等工具切换 Provider：点击“预览同步”查看影响，或“直接同步”立即执行。
 3. 查看结果。部分完成时，结束相关占用会话后重试；需要撤销时进入“备份 / 恢复”。
 
-希望由本工具更改配置？使用概览底部的“单独切换 Provider”。它会**修改配置并同步历史 Provider**，不改历史模型；自定义 Provider 必须已在 `config.toml` 中定义。
+“单独切换 Provider”会修改配置并同步历史 Provider，不改历史模型；自定义 Provider 需预先配置。
 
-有实际修改时先备份，默认保留最近 **2 份**，统一在“备份 / 恢复”设置；无需修改时不创建备份，恢复依赖的受保护备份可能超过数量。
-
-还可按项目浏览聊天、右键复制会话 ID / 继续命令、查看操作日志，以及自定义存储位置。高级诊断与专项修复按需使用，**普通同步不会顺带执行修复**。数据不后台轮询；自动同步 Watch 需主动开启。
+修改前自动备份，默认保留最近 **2 份**，在“备份 / 恢复”中管理；无需修改时不备份，受保护备份不受数量限制。
 
 [桌面完整指南](docs/README_DESKTOP_ZH.md) · [旧版迁移说明](docs/release-notes/v1.0.0-zh.md)
 
@@ -63,21 +79,87 @@ codex-provider sync
 
 CLI 写命令直接执行。切换 Provider、恢复备份、Watch、路径参数及 JSON 退出码见 [CLI 指南](docs/README_CLI_ZH.md)；命令是否可用以安装版本的 `--help` 为准。
 
-## 使用前了解
+## 架构：一个共享核心，多种入口
+
+CLI、Web 与 Electron 共用 **Node Core 的同一套业务用例和存储算法**。桌面版不通过启动 CLI、解析终端文本来执行同步，安装 CLI 也不会额外安装 Electron。
+
+```mermaid
+flowchart TB
+    CLI["CLI / 脚本 / WSL"] --> Adapter["CLI 兼容适配器"]
+    Web["Web 界面"] --> Http["HttpCoreClient · 本地 Web Host"]
+    Desktop["Electron 桌面界面"] --> IPC["DesktopCoreClient · Preload / Main 窄 IPC"]
+    IPC --> Utility["Utility Process"]
+
+    subgraph Core["共享 Node Core"]
+        Facade["CoreFacade · 统一接口"]
+        UseCases["业务用例<br/>状态 / 同步 / 切换 / 备份与恢复<br/>历史 / 诊断与修复 / Watch"]
+        Runtime["OperationRuntime<br/>计划校验 / 并发协调 / 进度与取消"]
+        Storage["存储端口<br/>Config / Sessions / State DB / Global State"]
+        Backup["UndoBackup / RestoreRecovery<br/>备份与恢复基础设施"]
+        Facade --> UseCases
+        UseCases --> Runtime
+        UseCases --> Storage
+        UseCases --> Backup
+    end
+
+    Http --> Facade
+    Utility --> Facade
+    Adapter --> UseCases
+    Storage --> Data["config.toml / 会话文件 / SQLite / 工作区设置"]
+    Backup --> Managed["受管备份 / Restore journal"]
+```
+
+- **界面与 Host** 负责交互、传输和桌面能力，不重复实现 Provider 读写算法。
+- **CoreFacade** 是新版 Web `/api/core` 与 Electron 的入口；CLI 及保留的旧 Web 写路由仍通过兼容适配层调用同一业务用例。
+- **Sync、Repair、Restore 各司其职**：普通同步只对齐 Provider，专项修复需明确选择，恢复独立保留恢复前快照和补偿机制。
+- **旧 .NET Windows/macOS** 是独立的 Legacy 实现，保留构建与兼容维护，不是 Node Core 的另一个分发壳。
+
+模块归属、依赖方向和不可改变的读写约束，以 [当前 Node Core 架构](docs/architecture/NODE_CORE_ARCHITECTURE_ZH.md) 为准；总体路线见 [Electron + Node 架构基线](docs/VNEXT_ELECTRON_NODE_ARCHITECTURE_ZH.md)。
+
+## 同步如何读写，速度取决于什么
+
+普通同步从 `config.toml` 获取当前 Provider，只解析会话首行的 `session_meta`，再对齐会话文件与 SQLite 的 Provider 信息，**不扫描聊天正文来修复其他字段**。
+
+| 文件更新方式 | 适用情况 | 读写行为 |
+| --- | --- | --- |
+| 等长原地替换 | Provider 的 JSON 字面量 UTF-8 字节等长，且定位、身份及占用校验通过 | 定位覆盖 Provider 字节，保持文件身份、大小和正文不变 |
+| 流式替换 | 有效首行不满足原地替换条件，如 Provider 字节长度不同 | 更新首行，逐字节复制正文到临时文件，再原子替换 |
+
+以上策略自动选择，不需要 `--fast`，也不要求用户把 Provider 名称统一成固定长度。原地写失败不会强制退回整文件替换。
+
+**等长不代表整次操作只写几个字节。** 备份、校验、落盘及时间戳恢复仍有开销；大量文件或大体积历史仍可能耗时。概览中的“如何加快同步”提供建议，Windows 操作日志可查看复制、落盘、替换、清理和时间戳恢复的分项耗时。
+
+[工作原理与路径解析](docs/WORKING_PRINCIPLE_ZH.md) · [Provider I/O 不变量](docs/architecture/NODE_CORE_ARCHITECTURE_ZH.md#3-provider-io-不变量必须保持)
+
+## 常见结果与注意事项
 
 - **同步范围**：只对齐 Provider，不修改聊天正文、历史模型或 `threads.updated_at`，不读取或修改 `auth.json`。
-- **速度**：合格的等字节长 Provider 自动原地替换；其他有效首行流式替换，正文保持逐字节一致。备份、落盘检查和时间戳恢复仍保留，不需要手动开启快速模式。
 - **部分完成**：不代表全部失败，也不会自动全量回滚。查看跳过项、失败阶段和备份，再重试或手动恢复。
+- **数据已变化 / 状态待刷新**：手动刷新或重新预览，不要删除锁文件或数据库。
+- **文件数与索引数不同**：不一定是故障，以 Provider 分布和同步状态为准。
 - **仍无法继续**：若为加密内容或模型兼容问题，请回到原 Provider / 账号，或新建会话；同步不能解决这类问题。
 - **存储位置**：以概览实际路径为准。Windows 的 WSL UNC SQLite 路径仅支持诊断；写入需进入对应 WSL 运行 CLI。
 
-## 更多文档
+备份数量在同一应用内统一管理，各 Codex Home 分别保留；桌面、Web 浏览器与 CLI 不共享偏好。保存数量设置不会立即删除备份。
 
+## 文档与开发
+
+- 用户指南：[桌面中文](docs/README_DESKTOP_ZH.md) / [English](docs/README_DESKTOP_EN.md) · [Web](docs/README_WEB_UI_ZH.md) · [CLI](docs/README_CLI_ZH.md)
 - [完整文档索引](docs/README_ZH.md) · [更新日志](CHANGELOG.md) · [反馈问题](https://github.com/Dailin521/codex-provider-sync/issues)
 - [工作原理](docs/WORKING_PRINCIPLE_ZH.md) · [当前 Node Core 架构与读写约束](docs/architecture/NODE_CORE_ARCHITECTURE_ZH.md)
 - [贡献与构建指南](CONTRIBUTING.md) · [迁移与发布门禁](docs/migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md) · [AI / Agent 指南](AGENTS.md)
 
-CLI、Web、Electron 共用 Node Core；安装 CLI 不会安装 Electron。旧 .NET 桌面端是独立的 Legacy 实现，保留构建与兼容维护。
+源码开发使用 Node 24：
+
+```bash
+npm ci
+npm run architecture:check
+npm test
+npm run web:build
+npm run desktop:build
+```
+
+开发时先读当前架构，再查对应合同、ADR 与测试。构建成功不等于完成所有平台的发布验收。
 
 ## 致谢与许可
 

--- a/README.md
+++ b/README.md
@@ -8,181 +8,79 @@
 [![CLI / Web](https://img.shields.io/npm/v/%40dailin521%2Fcodex-provider-sync?label=CLI%20%2F%20Web)](https://www.npmjs.com/package/@dailin521/codex-provider-sync)
 [![Releases](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync?label=Releases)](https://github.com/Dailin521/codex-provider-sync/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
 **中文** · [English](docs/README_EN.md) · [日本語](docs/README_JA.md) · [한국어](docs/README_KO.md)
 
 </div>
 
-## 它解决什么
+切换 Provider 后，旧会话可能仍记录着原来的 Provider。本工具将**会话文件与 SQLite 聊天索引中的 Provider 信息**对齐到当前配置，解决元数据不一致的问题。
 
-**会话能看见，不代表能按当前 Provider 正常继续。** 切换 `model_provider` 后，会话文件和 SQLite 索引中的 Provider 信息可能仍停留在旧值。本工具将两者对齐到当前配置，帮助因 Provider 元数据不一致而无法正常使用的旧会话重新可用。
+**不保证跨 Provider / 账号的旧会话一定能继续或压缩**，也不处理登录、认证或加密内容。信息已对齐时，无需重复同步。
 
-工具的重点是切换后的会话复用，而不是让列表重新显示。有实际修改时先备份，默认保留最近 **2 份**；无需修改时不创建备份。它不负责登录、切换账号、解密或重建消息，也不读取或修改 `auth.json`。**同步不保证跨 Provider / 账号的旧会话一定能继续或压缩**；加密内容与模型兼容问题仍需分别处理。
+## 下载 Windows 桌面版
 
-| Provider 信息 | 同步前（示例） | 同步后 |
-| --- | --- | --- |
-| 当前配置 | Provider B | Provider B（不改） |
-| 会话文件 | Provider A | Provider B |
-| SQLite 聊天索引 | Provider A | Provider B |
+当前正式版 **v1.0.0 · Windows x64**，无需安装 Node.js。
 
-- 已通过 CCSwitch 等工具切换 Provider：使用“同步当前 Provider”。
-- 希望由本工具修改 Provider：使用“单独切换 Provider”，修改配置后同步历史中的 Provider 信息。
-- Provider ID 没变、历史也已对齐：无需重复同步。
-- 已对齐但仍无法继续或压缩：查看 Codex 的具体报错；跨 Provider 的加密内容不兼容不能靠同步解决。
+- [下载安装包（约 100 MiB）](https://github.com/Dailin521/codex-provider-sync/releases/download/v1.0.0/CodexProviderSync-1.0.0-windows-x64-setup.exe)
+- [下载便携 ZIP（约 123 MiB）](https://github.com/Dailin521/codex-provider-sync/releases/download/v1.0.0/CodexProviderSync-1.0.0-windows-x64-portable.zip)：完整解压后运行，不要只复制 EXE。
+- [版本说明与校验文件](https://github.com/Dailin521/codex-provider-sync/releases/tag/v1.0.0)
 
-## 快速开始
+此版本未签名，更新需手动安装。旧 .NET 版的更新按钮不能升级到 Electron，请下载完整新版。macOS/Linux Electron 安装包尚未发布；CLI / Web 的 npm 版本独立发布，不等同于桌面版版本号。
 
-> 本页对应 V1 代码。Electron 是主桌面端，.NET 保留为 Legacy。下载以 [Releases 实际资产](https://github.com/Dailin521/codex-provider-sync/releases) 为准，npm 安装得到已发布版本；本地构建和代码版本号不代表已公开发布、签名或启用更新通道。
+## 日常使用
 
-| 场景 | 入口 |
-| --- | --- |
-| Windows 桌面，无需安装 Node.js | [Electron 桌面版指南](docs/README_DESKTOP_ZH.md) |
-| macOS / Linux 桌面 | [平台与构建说明](docs/README_DESKTOP_ZH.md#程序安装更新与体积)，以对应版本实际资产为准 |
-| 浏览器操作 / 跨平台 | [本地 Web UI](#本地-web-ui) |
-| 命令行、脚本或 WSL | [CLI](#cli) |
+1. 打开“概览”，确认 **Provider、存储路径和同步状态**。
+2. 已通过 CCSwitch 等工具切换 Provider：点击“预览同步”查看影响，或“直接同步”立即执行。
+3. 查看结果。部分完成时，结束相关占用会话后重试；需要撤销时进入“备份 / 恢复”。
 
-### 桌面版
+希望由本工具更改配置？使用概览底部的“单独切换 Provider”。它会**修改配置并同步历史 Provider**，不改历史模型；自定义 Provider 必须已在 `config.toml` 中定义。
 
-安装对应平台包，或解压完整程序目录运行。**不要只复制 Electron 的单个 EXE。**
+有实际修改时先备份，默认保留最近 **2 份**，统一在“备份 / 恢复”设置；无需修改时不创建备份，恢复依赖的受保护备份可能超过数量。
 
-Windows `1.0.0` 的[安装与旧版迁移说明](docs/release-notes/v1.0.0-zh.md)：未签名、手动安装更新；旧 .NET 的单 EXE 更新按钮不能完成迁移。本轮不发布 npm、macOS/Linux 或 Legacy 安装包。
+还可按项目浏览聊天、右键复制会话 ID / 继续命令、查看操作日志，以及自定义存储位置。高级诊断与专项修复按需使用，**普通同步不会顺带执行修复**。数据不后台轮询；自动同步 Watch 需主动开启。
 
-1. 打开“概览”，核对当前 Provider、存储路径和同步状态。
-2. 在存储配置右侧使用“预览同步”查看影响，或“直接同步”立即执行，两者同步范围相同。
-3. 需要修改 Provider 时，在概览底部使用“单独切换 Provider”，选择目标和模型策略，预览后确认。
-4. 查看结果。部分完成时，结束相关占用会话后重新同步；需要撤销时前往“备份 / 恢复”。
+[桌面完整指南](docs/README_DESKTOP_ZH.md) · [旧版迁移说明](docs/release-notes/v1.0.0-zh.md)
 
-“单独切换”不是仅修改配置：它仍会同步历史 Provider，但不修改历史模型。自定义 Provider 必须已在 `config.toml` 中定义；模型策略见[同步与切换说明](docs/README_DESKTOP_ZH.md#同步与切换-provider)。
+## 本地 Web UI
 
-### 本地 Web UI
-
-安装 Node.js `16.20.2+`，然后运行：
+安装 Node.js `16.20.2+` 后运行，获得 npm 当前已发布的 CLI / Web 版本：
 
 ```bash
 npm install -g @dailin521/codex-provider-sync
 codex-provider web
 ```
 
-服务只监听本机 `127.0.0.1:8791`，默认打开浏览器完成配对。日常同步流程与桌面版相同，Web 不提供桌面操作日志和应用更新。
+默认只监听本机 `127.0.0.1:8791`，打开浏览器完成配对。跨设备使用见 [Web 指南与 SSH 用法](docs/README_WEB_UI_ZH.md)。
 
-```bash
-codex-provider web --no-open       # 不自动打开浏览器
-codex-provider web --port 8792     # 指定端口
-codex-provider web --reset-access  # 撤销旧连接并重新配对
-```
+## CLI
 
-[Web 完整指南与 SSH 用法](docs/README_WEB_UI_ZH.md)
-
-### CLI
-
-安装同一个 npm 包后，先检查，再执行：
+安装同一个 npm 包后，先检查，再同步：
 
 ```bash
 codex-provider status
 codex-provider sync
 ```
 
-| 命令 | 用途 |
-| --- | --- |
-| `status` | 检查当前 Provider、存储位置和同步状态 |
-| `sync` | 同步到 config 当前 Provider |
-| `switch <provider-id>` | 修改配置中的 Provider，然后同步 |
-| `diagnostics` | 手动执行一次完整只读诊断 |
-| `repair <targets>` | 显式执行选定的非 Provider 元数据修复 |
-| `restore <backup-dir>` | 恢复受管备份 |
-| `prune-backups --keep N` | 清理较旧受管备份 |
-| `watch` | 主动开启自动同步；按 Ctrl+C 停止 |
+CLI 写命令直接执行。切换 Provider、恢复备份、Watch、路径参数及 JSON 退出码见 [CLI 指南](docs/README_CLI_ZH.md)；命令是否可用以安装版本的 `--help` 为准。
 
-CLI 写命令直接执行，不再弹出交互确认。有限命令支持 `--json`；例如 `codex-provider sync --json`。脚本必须检查 `outcome` 和退出码，部分完成的 JSON 退出码为 `3`。
+## 使用前了解
 
-[CLI 参数、模型策略、路径、备份与 JSON 指南](docs/README_CLI_ZH.md)
+- **同步范围**：只对齐 Provider，不修改聊天正文、历史模型或 `threads.updated_at`，不读取或修改 `auth.json`。
+- **速度**：合格的等字节长 Provider 自动原地替换；其他有效首行流式替换，正文保持逐字节一致。备份、落盘检查和时间戳恢复仍保留，不需要手动开启快速模式。
+- **部分完成**：不代表全部失败，也不会自动全量回滚。查看跳过项、失败阶段和备份，再重试或手动恢复。
+- **仍无法继续**：若为加密内容或模型兼容问题，请回到原 Provider / 账号，或新建会话；同步不能解决这类问题。
+- **存储位置**：以概览实际路径为准。Windows 的 WSL UNC SQLite 路径仅支持诊断；写入需进入对应 WSL 运行 CLI。
 
-## 界面里还可以做什么
+## 更多文档
 
-| 页面 | 用途 |
-| --- | --- |
-| 概览 | 核对路径和两侧 Provider 分布，预览/直接同步，单独切换 Provider |
-| 备份 / 恢复 | 统一设置备份保留数、查看备份、恢复和手动清理 |
-| 聊天记录 | 按项目浏览主会话/子任务，查看消息；右键复制会话 ID、继续命令等 |
-| 操作日志（桌面） | 左侧选操作、右侧看详情，查看目标、结果、数量和阶段耗时 |
-| 存储配置 | 新建具名配置，指定 Codex Home 和可选的 SQLite Home |
-| 高级功能 | 手动诊断、专项修复和独立的历史模型调整 |
-| 设置 | 语言、主题、主动开启的 Watch；桌面端另有更新检查 |
+- [完整文档索引](docs/README_ZH.md) · [更新日志](CHANGELOG.md) · [反馈问题](https://github.com/Dailin521/codex-provider-sync/issues)
+- [工作原理](docs/WORKING_PRINCIPLE_ZH.md) · [当前 Node Core 架构与读写约束](docs/architecture/NODE_CORE_ARCHITECTURE_ZH.md)
+- [贡献与构建指南](CONTRIBUTING.md) · [迁移与发布门禁](docs/migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md) · [AI / Agent 指南](AGENTS.md)
 
-数据首次加载、手动刷新或明确操作后更新，**不后台轮询**。聊天正文只有明确查看/提交正文搜索才加载；手动 Diagnostics 与 Repair 按各自范围扫描。正文不进入日志、诊断包或持久缓存。
+CLI、Web、Electron 共用 Node Core；安装 CLI 不会安装 Electron。旧 .NET 桌面端是独立的 Legacy 实现，保留构建与兼容维护。
 
-备份保留数量统一在“备份 / 恢复”设置：同一应用内各项操作共用，每个 Codex Home 分别保留。保存设置不会立即删除备份；恢复依赖的受保护备份可能超过数量。桌面、Web 浏览器与 CLI 不共享偏好。
+## 致谢与许可
 
-日常同步不需要高级修复。专项修复只处理明确选择的目录/用户消息标记/工作区设置；统一历史模型名称单独放在“高级调整”。当前不提供会话序号改写或历史显示索引重建。
+感谢 [@tangquanwei](https://github.com/tangquanwei) 贡献本地 Web UI、聊天记录浏览和多语言文档基础，并通过 [PR #80](https://github.com/Dailin521/codex-provider-sync/pull/80) 带入 v0.5.0；感谢所有参与贡献和问题调查的朋友。
 
-## 同步速度与读写边界
-
-- **合格的等字节长 Provider** 自动原地更新，只覆盖首行中的 Provider 字节，保留文件身份、大小和正文。
-- **不等长或不满足原地资格** 的有效首行采用临时文件流式替换，正文逐字节复制，不解析聊天正文。
-- 没有 `--fast` 或 `sync --provider` 模式，不要求用户统一 Provider 名称长度。原地写失败不会强制改成整文件替换。
-- 时间戳恢复、备份和落盘检查不会为了提速取消。会话文件很多或正文很大时，复制和落盘仍可能耗时。
-
-概览可展开“如何加快同步”。Windows 新同步/切换日志提供复制、落盘、替换、清理和时间戳恢复的分项耗时；旧日志不补造计时。实测速率取决于数据、磁盘和占用，不以合成样本承诺真实同步耗时。
-
-[工作原理](docs/WORKING_PRINCIPLE_ZH.md) · [开发必守的 Provider I/O 约束](docs/architecture/NODE_CORE_ARCHITECTURE_ZH.md#3-provider-io-不变量必须保持)
-
-## 常见结果与注意事项
-
-| 情况 | 怎么处理 |
-| --- | --- |
-| 会话文件数与索引行数不同 | 不一定是故障，以 Provider 分布和同步状态为准 |
-| 部分完成 / 会话被占用 | 查看跳过项和失败阶段，结束相关占用后重新同步；需要撤销时手动恢复 |
-| 状态待刷新 / 数据已变化 | 手动刷新或重新预览，不要删除锁文件或数据库 |
-| 自定义 Provider 不存在 | 先在配置/常用 Provider 工具中补齐定义；本工具不会擅自切回 OpenAI |
-| SQLite busy | 停止相关 Codex 写入后重试；若已部分写入，先查看结果和备份 |
-| 已同步但旧会话仍无法继续 | 查看具体报错；若为加密内容不兼容，回到原 Provider/账号或新建会话，本工具不能解密旧内容 |
-
-普通 Sync/Switch/Repair 在修改前创建覆盖实际目标的备份；写入后失败报告部分完成，不自动全量回滚。Restore 独立保留恢复前快照、journal 和补偿。所有操作都不会通过修改 `threads.updated_at`、消息顺序或时间来强行刷新历史。
-
-SQLite Home 优先级：显式参数/存储配置 → `config.toml` 的 `sqlite_home` → `CODEX_SQLITE_HOME` → `<Codex Home>/sqlite`。只有默认布局允许回退到旧位置 `<Codex Home>/state_5.sqlite`。Windows 的 WSL UNC SQLite Home 仅诊断；写入须在对应 WSL 内使用 Linux 路径运行 CLI。
-
-## 一个共享核心，多种入口
-
-```text
-CLI → 兼容适配器 ──────────────────────────────┐
-Web UI → HttpCoreClient → Local Web Host → CoreFacade ─┤
-Electron UI → 窄 IPC → Utility Process → CoreFacade ──┤
-                                                    ↓
-                                    同一 Node Core 业务用例
-                                                    ↓
-                              config / 会话文件 / SQLite / 受管备份
-```
-
-CLI 当前保留 `src/public-api.js` 适配层，和 Web/Electron 共用 ProviderSync；UI/Host 不另写同步算法，也不启动 CLI 解析其文本输出。Electron 不进入根 npm 包，安装 CLI 不会额外安装 Electron。
-
-.NET Windows/macOS 是独立的 **Legacy fallback**，保留构建和兼容维护，不是上述 Node Core 的另一个分发壳；它们的旧 journal/自动回滚行为不能套到新核心。
-
-## 文档与开发
-
-- 用户指南：[桌面中文](docs/README_DESKTOP_ZH.md) / [English](docs/README_DESKTOP_EN.md) · [Web](docs/README_WEB_UI_ZH.md) · [CLI](docs/README_CLI_ZH.md)
-- [完整文档索引](docs/README_ZH.md) · [更新日志](CHANGELOG.md) · [贡献指南](CONTRIBUTING.md)
-- 开发先读：[当前 Node Core 架构](docs/architecture/NODE_CORE_ARCHITECTURE_ZH.md) → [总体架构基线](docs/VNEXT_ELECTRON_NODE_ARCHITECTURE_ZH.md) → 对应合同、ADR 和测试
-- [迁移与发布门禁](docs/migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md) · [AI / Agent 指南](AGENTS.md)
-
-工作区构建使用 Node 24；已安装根 CLI 仍支持 Node 16.20.2。
-
-```bash
-npm ci
-npm run architecture:check
-npm test
-npm run web:build
-npm run desktop:build
-```
-
-仅本地改文档不代表完成代码、平台或发布验收。具体验证和发布命令见 [贡献指南](CONTRIBUTING.md)与 [npm 发布维护指南](docs/NPM_PUBLISHING.md)。
-
-## 致谢
-
-感谢 [@tangquanwei](https://github.com/tangquanwei) 提出并实现本地 Web UI，贡献聊天记录浏览和多语言文档基础，并通过 [PR #80](https://github.com/Dailin521/codex-provider-sync/pull/80) 将其带入 v0.5.0；也感谢所有参与代码、文档、测试和问题调查的贡献者。
-
-[贡献者名单](CONTRIBUTORS.md) · [GitHub Contributors](https://github.com/Dailin521/codex-provider-sync/graphs/contributors)
-
-## License
-
-[MIT](LICENSE)
+[贡献者](CONTRIBUTORS.md) · [GitHub Contributors](https://github.com/Dailin521/codex-provider-sync/graphs/contributors) · [LINUX DO 社区](https://linux.do/) · [MIT License](LICENSE)

--- a/apps/desktop/tests/yaml-dependency.test.mjs
+++ b/apps/desktop/tests/yaml-dependency.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+// Exercise the parser resolved by the production updater, not a test-only copy.
+const updaterRequire = createRequire(require.resolve("electron-updater/package.json"));
+const yaml = updaterRequire("js-yaml");
+
+test("updater YAML rejects repeated empty merge sources within a bounded budget", () => {
+  // GHSA-2883-xcg3-v3hh: empty mappings must consume the merge budget too.
+  // Deliberately tiny fixture: proves rejection without a timing-based DoS test.
+  const source = "empty: &empty {}\nvalue:\n  <<: [*empty, *empty, *empty]\n";
+  assert.throws(() => yaml.load(source, { maxTotalMergeKeys: 2 }), /maxTotalMergeKeys/);
+});
+
+test("updater YAML still parses ordinary update metadata and bounded merges", () => {
+  const source = [
+    "defaults: &defaults",
+    "  channel: stable",
+    "version: 1.0.1",
+    "files:",
+    "  - url: fixture-setup.exe",
+    "    sha512: fixture-only",
+    "    size: 123",
+    "release:",
+    "  <<: *defaults",
+    "  name: Fixture release",
+    ""
+  ].join("\n");
+  const parsed = yaml.load(source);
+  assert.equal(parsed.version, "1.0.1");
+  assert.deepEqual(parsed.files, [{ url: "fixture-setup.exe", sha512: "fixture-only", size: 123 }]);
+  assert.deepEqual(parsed.release, { channel: "stable", name: "Fixture release" });
+});

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -8,185 +8,79 @@
 [![CLI / Web](https://img.shields.io/npm/v/%40dailin521%2Fcodex-provider-sync?label=CLI%20%2F%20Web)](https://www.npmjs.com/package/@dailin521/codex-provider-sync)
 [![Releases](https://img.shields.io/github/v/release/Dailin521/codex-provider-sync?label=Releases)](https://github.com/Dailin521/codex-provider-sync/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
-[![Community](https://img.shields.io/badge/community-LINUX%20DO-2ea043.svg)](https://linux.do/)
 
 [中文](../README.md) · **English** · [日本語](README_JA.md) · [한국어](README_KO.md)
 
 </div>
 
-## What it solves
+After a Provider switch, existing sessions may still reference the previous Provider. This tool aligns **Provider metadata in session files and the SQLite chat index** with the current configuration.
 
-**A visible session is not necessarily ready to continue with the current Provider.** After switching `model_provider`, session files and the SQLite index may still reference the previous Provider. This tool aligns that metadata with the current configuration to help reuse sessions affected by a Provider mismatch, rather than focusing on history-list visibility. It does not guarantee cross-provider continuation or compaction; encrypted content and model compatibility remain separate concerns.
+**It does not guarantee cross-provider/account continuation or compaction**, handle authentication, or decrypt content. Already aligned sessions do not need another sync.
 
-This tool aligns Provider metadata in session files and the SQLite index. Actual changes are backed up first, retaining the two most recent managed backups by default; a no-op creates no backup. Desktop/Web manage retention only in Backups / Restore. Operations share the app setting, with a separate pool per Codex Home; Desktop, browsers and CLI do not share preferences. Saving the setting does not immediately delete backups, and recovery-protected backups may exceed the limit. It does not sign in, switch accounts, decrypt or reconstruct messages, or modify `auth.json`.
+## Download for Windows
 
-| Provider metadata | Before (example) | After sync |
-| --- | --- | --- |
-| Current configuration | Provider B | Provider B (unchanged) |
-| Session files | Provider A | Provider B |
-| SQLite chat index | Provider A | Provider B |
+Current stable desktop release: **v1.0.0 · Windows x64**. No Node.js installation required.
 
-### When is synchronization needed?
+- [Installer (about 100 MiB)](https://github.com/Dailin521/codex-provider-sync/releases/download/v1.0.0/CodexProviderSync-1.0.0-windows-x64-setup.exe)
+- [Portable ZIP (about 123 MiB)](https://github.com/Dailin521/codex-provider-sync/releases/download/v1.0.0/CodexProviderSync-1.0.0-windows-x64-portable.zip): extract the entire folder; do not copy only the EXE.
+- [Release notes and checksums](https://github.com/Dailin521/codex-provider-sync/releases/tag/v1.0.0)
 
-- **Typical case:** Switching between official OpenAI and a custom relay. Official OpenAI always uses `openai`, so the Provider ID changes and history needs to be synchronized.
-- **Existing mixed history:** Older sessions already contain different Provider IDs and need to be aligned with the current provider.
-- **No synchronization needed:** Switching only among custom relays that share one Provider ID, or when CCSwitch or another tool has already synchronized history.
+This release is unsigned and requires manual installation for updates. The old .NET updater cannot migrate to Electron; download the full new package. macOS/Linux Electron packages are not yet published. CLI / Web npm versions are released independently and do not match the desktop version automatically.
 
-## Quick Start
+## Everyday use
 
-> This guide describes the V1 code: Electron is its primary desktop interface, with .NET retained as Legacy. A local V1 build does not imply public release, signing, or an enabled update channel. Use only assets actually listed in Releases; npm installs the published version. See [delivery status](migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md).
+1. Open Overview and check the **Provider, storage paths and sync status**.
+2. After switching with CCSwitch or another tool, choose **Preview sync**, or **Sync now** to execute immediately.
+3. Inspect the result. If partially completed, end the relevant session activity and retry; use **Backups / Restore** to undo changes.
 
-| Scenario | Recommended interface |
-| --- | --- |
-| Windows desktop | V1 Electron · [User guide](README_DESKTOP_EN.md) · [Published assets](https://github.com/Dailin521/codex-provider-sync/releases) |
-| macOS / Linux desktop | [Build and platform guide](README_DESKTOP_EN.md); availability depends on actual assets for that version |
-| Browser interface or cross-platform use | [Local Web UI (CLI required)](#local-web-ui) |
-| Scripts, CI, or WSL | [CLI](#cli) |
+To change the configuration in this app, use **Switch Provider separately** at the bottom of Overview. It **changes configuration and synchronizes historical Provider metadata**, not historical models. Custom Providers must already be defined in `config.toml`.
 
-### Desktop app
+Actual changes are backed up first. Retention defaults to the **two most recent backups**, managed in Backups / Restore. No-op operations create no backup; recovery-protected backups may exceed the limit.
 
-Use the complete supplied V1 program folder or an available platform package from [Releases](https://github.com/Dailin521/codex-provider-sync/releases). Do not copy only the Electron EXE:
+You can also browse chats by project, right-click to copy session IDs/resume commands, inspect operation logs and configure storage locations. Advanced diagnostics and repair are optional: **ordinary sync never performs them automatically**. Data is not polled in the background; Watch requires explicit activation.
 
-1. Open Overview and check the current Provider and sync status.
-2. After switching elsewhere, choose Preview sync to review the impact, or Sync now to execute immediately. Both have the same scope.
-3. To change Provider in this app, select the Provider and root-model strategy, review, and confirm.
+[Full desktop guide](README_DESKTOP_EN.md) · [Migration notes (Chinese)](release-notes/v1.0.0-zh.md)
 
-History groups main chats by project with collapsed subtasks and independent Load more controls. Right-click a chat for ID/resume-command actions or a project to set its local display name. The app also provides logs, storage profiles and advanced diagnostics/repair. Data loads initially or after explicit actions, without background polling. Watch must be enabled explicitly. Updates check once on the first launch each day or manually, without automatic installation.
+## Local Web UI
 
-New Windows operation logs break file updates into copying, flushing, replacement, cleanup and timestamp restoration. Old records have no retroactive timings. Performance work retains backup-first, flushes and file timestamps; synthetic benchmark gains are not promises for a real Home.
-
-[Full desktop guide](README_DESKTOP_EN.md)
-
-### Local Web UI
-
-The Local Web UI is provided by the CLI. Install Node.js `16.20.2+`, then install this project's official npm package and start it:
+Install Node.js `16.20.2+`, then get the currently published CLI / Web npm version:
 
 ```bash
 npm install -g @dailin521/codex-provider-sync
 codex-provider web
 ```
 
-Common options:
+By default it listens only on `127.0.0.1:8791` and opens a browser for pairing. See the [Web and SSH guide (Chinese)](README_WEB_UI_ZH.md) for remote access.
+
+## CLI
+
+After installing the same npm package, inspect before syncing:
 
 ```bash
-codex-provider web --no-open       # Do not open a browser automatically
-codex-provider web --port 8792     # Use a specific port
-codex-provider web --reset-access  # Pair a browser again
-```
-
-The Web UI listens on `127.0.0.1` by default and opens a browser to pair automatically. Storage paths are managed by server-side profiles. Sync now authorizes execution on click; Preview sync, Switch, Repair and Restore show a confirmation first. All use Prepare/Apply internally.
-
-#### Synchronize history after switching providers
-
-1. Switch providers with CCSwitch or your usual tool.
-2. Check the current Provider and sync status on Overview.
-3. Choose Preview sync and confirm, or click Sync now.
-4. Inspect the result. For partial completion, end the active session and sync again; skipped records are not updated records.
-
-> **Note:** Metadata sync addresses Provider mismatches, not every cause of an unusable session. When continuing an old session across providers, the target backend may be unable to decrypt its `encrypted_content` reasoning data, causing continuation or compaction to fail.
-
-[Full Web UI guide (Chinese)](README_WEB_UI_ZH.md)
-
-### CLI
-
-The CLI supports Node.js `16.20.2+`. After installing Node.js, install this project's official npm package:
-
-```bash
-npm install -g @dailin521/codex-provider-sync
 codex-provider status
 codex-provider sync
 ```
 
-| Command | Purpose |
-| --- | --- |
-| `codex-provider status` | Inspect provider, rollout, and SQLite state |
-| `codex-provider sync` | Synchronize to the current provider |
-| `codex-provider switch <provider-id>` | Switch provider, then synchronize |
-| `codex-provider diagnostics` | Run one explicit full read-only diagnostic scan |
-| `codex-provider repair <targets>` | Explicitly repair models, cwd, user-event, or workspace roots |
-| `codex-provider restore <backup-dir>` | Restore a backup |
-| `codex-provider watch` | Watch configuration and SQLite changes |
+CLI write commands execute directly. See the [CLI guide (Chinese)](README_CLI_ZH.md) for switching, restore, Watch, paths and JSON exit codes. Check your installed version's `--help` for available commands.
 
-CLI write commands execute without an interactive confirmation. For a review screen, use Desktop or Web. Scripts should use `--json` and inspect the outcome; partial completion exits with code `3`. See the [CLI guide (Chinese)](README_CLI_ZH.md) and [CLI contract](architecture/contracts/CLI_CONTRACT_ZH.md).
+## Before using
 
-By default, `switch` updates the root-level `model` when the target provider section defines one, otherwise preserving it. Use `--keep-root-model` to keep the current value or `--model <name>` to set it explicitly. None of these strategies rewrites historical models; that requires explicit Repair.
-
-`sync` uses the root `model_provider` in `config.toml` (defaulting to `openai`) and only parses rollout headers for its business scan. **Safe Provider IDs with equal-length JSON literal bytes and an unambiguous location are updated in place; other valid headers use streamed temporary replacement.** Both preserve body bytes. Character count is not byte length; users need not rename Providers to a fixed length. There is no `--fast` or `sync --provider` option. See the [Core I/O invariants](architecture/NODE_CORE_ARCHITECTURE_ZH.md#3-provider-io-不变量必须保持).
-
-Models, cwd, user-event flags, workspace roots and encrypted content are outside everyday Sync. Full diagnostics require an explicit read-only `diagnostics` request. `repair` scans only data required by selected `models`, `cwd`, `userEvent` or `workspaceRoots` (which includes cwd). Web/Electron expose these under Advanced features. Sync failures never auto-escalate into diagnostics or repair; record renumbering and history display-index rebuilding are not supported.
-
-SQLite Home resolution order: `--sqlite-home` → root-level `sqlite_home` in `config.toml` → `CODEX_SQLITE_HOME` → `<Codex Home>/sqlite`. Only the default layout falls back to `<Codex Home>/state_5.sqlite`.
-
-## Current Architecture
-
-```mermaid
-flowchart LR
-    CLI["CLI"] --> Adapter["public-api compatibility adapter"]
-    Adapter --> UseCases["Shared Node Core use cases"]
-    Web["Web UI"] --> Host["HttpCoreClient / Local Web Host"]
-    Host --> Facade["CoreFacade"]
-    Electron["Electron UI"] --> IPC["DesktopCoreClient / narrow IPC"]
-    IPC --> Utility["Utility Process"]
-    Utility --> Facade
-    Facade --> UseCases
-    UseCases --> Storage["Node storage ports"]
-    Storage --> Files["config / sessions / SQLite / backups"]
-    Legacy["Legacy .NET desktop"] --> DotNet["Separate .NET Core"]
-    DotNet --> Files
-```
-
-- Web/Electron use CoreFacade; the CLI retains `src/public-api.js` compatibility adapters that run Prepare/Apply in-process. They share the same ProviderSync and do not parse each other's human output.
-- The V1 Electron desktop app uses `DesktopCoreClient → narrow Preload/Main IPC → Utility Process → Node Core`; its Renderer has no Node, arbitrary-path, or generic-IPC access.
-- The Windows GUI calls .NET Core through the Application layer; the macOS GUI currently calls .NET Core directly.
-- .NET is a separate Legacy implementation. Its historical model-repair, journal and automatic rollback behavior must not be attributed to the current Node Core.
-
-Module ownership, Provider I/O invariants and regression gates are defined in the [current Node Core architecture](architecture/NODE_CORE_ARCHITECTURE_ZH.md). .NET remains buildable and testable; release and migration completion are tracked separately in the [execution index](migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md).
-
-## Safety boundaries
-
-- Actual Sync/Switch/Repair changes are backed up under `<Codex Home>/backups_state/provider-sync/<timestamp>`. Default retention is two; no-op operations create no backup.
-- Ordinary writes use the Home lock, native SQLite transactions and UndoBackup, without cross-file journals or automatic full rollback. Post-mutation failure is partial: prepare and retry to converge, or manually Restore. Restore retains its own snapshot, journal and compensation.
-- Does not modify message content, session titles, authentication data, `auth.json`, or `updated_at`.
-- If SQLite is in use, close Codex, Codex App, and app-server, then retry.
-- If an active session locks rollout files, other files continue; sync again after that session ends.
-- When continuing an old session across providers or accounts, the target backend may be unable to decrypt `encrypted_content`, causing continuation or compaction to fail. Return to the original provider/account or start a new session.
-- Windows cannot write directly to a WSL UNC SQLite Home; enter WSL and run the CLI with Linux paths.
+- **Scope:** Sync changes Provider metadata, not message bodies, historical models or `threads.updated_at`. It does not read or modify `auth.json`.
+- **Performance:** Eligible equal-byte-length Providers update in place. Other valid headers use streamed replacement with byte-identical bodies. Backups, flush checks and timestamp restoration remain; no manual fast mode is needed.
+- **Partial results:** Not everything failed, and there is no automatic whole-operation rollback. Inspect skipped items, the failed stage and backup before retrying or restoring.
+- **Still unable to continue:** For encrypted-content or model compatibility errors, return to the original Provider/account or start a new session. Sync cannot fix these.
+- **Storage:** Check the actual paths in Overview. Windows WSL UNC SQLite paths are diagnostic-only; run writes inside the corresponding WSL distribution.
 
 ## Documentation
 
-- [Current Node Core architecture and development constraints](architecture/NODE_CORE_ARCHITECTURE_ZH.md)
-- [AI / Agent Guide](../AGENTS.md)
-- [Legacy .NET Windows GUI guide (Chinese)](README_GUI_ZH.md)
-- [CLI guide (Chinese)](README_CLI_ZH.md)
-- [V1 Electron desktop guide](README_DESKTOP_EN.md)
-- [Web UI guide (Chinese)](README_WEB_UI_ZH.md)
-- [中文](../README.md) · [日本語](README_JA.md) · [한국어](README_KO.md)
-- [Legacy .NET macOS GUI: 中文](README_MAC_GUI_ZH.md) · [English](README_MAC_GUI_EN.md)
-- [How it works (Chinese)](WORKING_PRINCIPLE_ZH.md) · [Changelog](../CHANGELOG.md) · [Contributing](../CONTRIBUTING.md)
+- [Documentation index (Chinese)](README_ZH.md) · [Changelog](../CHANGELOG.md) · [Report an issue](https://github.com/Dailin521/codex-provider-sync/issues)
+- [How it works (Chinese)](WORKING_PRINCIPLE_ZH.md) · [Current Node Core architecture and I/O invariants](architecture/NODE_CORE_ARCHITECTURE_ZH.md)
+- [Contributing and builds](../CONTRIBUTING.md) · [Migration and release gates](migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md) · [AI / Agent guide](../AGENTS.md)
 
-## Development
+CLI, Web and Electron share Node Core; installing the CLI does not install Electron. The .NET desktop apps remain separate Legacy implementations with build and compatibility maintenance.
 
-Full workspace development uses Node 24; the installed root CLI still supports Node 16.20.2.
+## Acknowledgements and license
 
-```bash
-npm ci
-npm run architecture:check
-npm run web:build
-npm run web:start
-npm test
-dotnet test desktop/CodexProviderSync.Core.Tests/CodexProviderSync.Core.Tests.csproj
-```
+Thanks to [@tangquanwei](https://github.com/tangquanwei) for the Local Web UI, history browsing and multilingual documentation foundation, brought into v0.5.0 through [PR #80](https://github.com/Dailin521/codex-provider-sync/pull/80), and to everyone contributing code, documentation and issue investigation.
 
-`architecture:check` reuses workspace/public-boundary checks and Provider in-place/streamed/Windows-worker regressions. CI runs the same command. Intentional Core behavior changes require an ADR, contracts, tests and user-guide updates; relaxing tests is not a substitute.
-
-Maintainers can publish the CLI/Web package independently of Windows GUI releases. See the [npm publishing guide (Chinese)](NPM_PUBLISHING.md).
-
-## Acknowledgements
-
-Thanks to [@tangquanwei](https://github.com/tangquanwei) for proposing and implementing the Local Web UI, contributing history browsing and the multilingual documentation foundation, and bringing it into v0.5.0 through [PR #80](https://github.com/Dailin521/codex-provider-sync/pull/80), and to everyone who has contributed code, documentation, testing, and investigation.
-
-[Contributor list](../CONTRIBUTORS.md) · [GitHub Contributors](https://github.com/Dailin521/codex-provider-sync/graphs/contributors)
-
-## License
-
-[MIT](../LICENSE)
+[Contributors](../CONTRIBUTORS.md) · [GitHub Contributors](https://github.com/Dailin521/codex-provider-sync/graphs/contributors) · [LINUX DO community](https://linux.do/) · [MIT License](../LICENSE)

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -34,7 +34,7 @@
 
 ## クイックスタート
 
-> 本書は V1 コードの説明です。Electron が主デスクトップアプリで、.NET は Legacy 互換版として維持されます。ローカル V1 ビルドは公開リリース、署名、更新チャネルの有効化を意味しません。Releases に実際に掲載されたファイルのみを利用してください。npm は公開済みバージョンをインストールします。[提供状況](migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md)も確認してください。
+> [Windows x64 Electron v1.0.0](https://github.com/Dailin521/codex-provider-sync/releases/tag/v1.0.0) を公開済みです。未署名で、更新は手動インストールです。旧 .NET 更新ボタンでは移行できません。macOS/Linux Electron パッケージは未公開です。CLI / Web の npm バージョンは独立して公開され、デスクトップ版とは一致しません。[ダウンロードと簡潔なガイド（英語）](README_EN.md#download-for-windows)。
 
 | 利用場面 | 推奨する入口 |
 | --- | --- |

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -34,7 +34,7 @@
 
 ## 빠른 시작
 
-> 이 가이드는 V1 코드를 설명합니다. Electron이 기본 데스크톱 앱이며 .NET은 Legacy 호환 버전으로 유지됩니다. 로컬 V1 빌드가 공개 릴리스, 서명 또는 업데이트 채널 활성화를 의미하지는 않습니다. Releases에 실제로 올라온 파일만 사용하세요. npm은 공개된 버전을 설치합니다. [제공 현황](migration/VNEXT_MIGRATION_EXECUTION_INDEX_ZH.md)도 확인하세요.
+> [Windows x64 Electron v1.0.0](https://github.com/Dailin521/codex-provider-sync/releases/tag/v1.0.0)이 공개되었습니다. 미서명 버전이며 업데이트는 수동 설치입니다. 기존 .NET 업데이트 버튼으로는 이전할 수 없습니다. macOS/Linux Electron 패키지는 아직 미공개입니다. CLI / Web npm 버전은 독립적으로 배포되므로 데스크톱 버전과 같지 않습니다. [다운로드 및 간단한 가이드(영문)](README_EN.md#download-for-windows).
 
 | 상황 | 권장 방법 |
 | --- | --- |

--- a/docs/WINDOWS_ELECTRON_RELEASE_ZH.md
+++ b/docs/WINDOWS_ELECTRON_RELEASE_ZH.md
@@ -9,6 +9,8 @@
 3. 处理所有未解决审查，采用 merge commit 合并，禁止 squash、rebase、force-push 或绕过失败门禁。
 4. main 合入后的实际 SHA 必须再次通过 `ci-gate`。所有产物与测试结论记录实际 SHA，不以 PR 分支名代替。
 
+部分重跑：GitHub 的“仅重跑失败 job”会保留本次 workflow 中已成功 job 的产物。C10 可复用同一仓库、同一 `runId`、同一 tested commit 且来自当前或更早正整数 `runAttempt` 的历史 Release 验证证据；拒绝跨运行、跨提交、未来或无效次数。全部 required jobs 仍必须成功，Release 资产/二进制/备份哈希校验不变。新 bundle 的 `workflow.runAttempt` 记录当前次数，`historicalFormalRelease.sourceRunAttempt` 如实记录证据来源次数，不改写源证据；v1 schema 将该新增字段设为可选，仅为兼容历史 bundle。重跑成功不抹去之前失败的记录，也不授权发布。
+
 ## 2. 候选包与独立流程
 
 `.github/workflows/publish-electron-windows.yml` 是独立的手动候选准备流程。现有 `publish.yml` 仍构建 Legacy .NET；`publish-npm.yml` 仍发布 npm。本轮不得运行后两者。

--- a/docs/adr/0014-npm-workspace-and-dependency-boundaries.md
+++ b/docs/adr/0014-npm-workspace-and-dependency-boundaries.md
@@ -63,6 +63,8 @@ C6 的 Electron、electron-vite、electron-builder、Desktop Vite/React plugin �
 
 所有直接 dependency/devDependency/optionalDependency/peerDependency 使用精确版本，不使用 `^`、`~`、`workspace:*`、`file:` 或未锁定 URL。传递依赖由唯一 lockfile 锁定。候选经 `npm audit --omit=dev --audit-level=moderate` 与全树 `npm audit --audit-level=high` 检查；任一不合格候选不得进入 checkpoint。
 
+2026-09-09 安全维护：将 `electron-updater` / `electron-builder` 依赖链中由 lockfile 锁定的 `js-yaml 4.3.1` 更新为 `4.3.2`，修复 [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh)。选择上游现有 `^4.1.0` 范围内的补丁版，不跨到 5.x、不新增根生产依赖，也不改变其余依赖解析。回归测试直接加载 updater 实际解析到的 YAML 模块，覆盖空合并源预算拒绝与正常更新元数据解析；依赖审计和现有构建/产物门禁继续执行，不用版本号断言代替行为验证。本次源码修复不改写已发布 v1.0.0 资产。
+
 Electron、electron-vite 与 electron-builder 已在 C6 按上述规则解析。C9 解析并锁定 Desktop `better-sqlite3`、ASAR/Fuse/PE/plist 审计工具；这些依赖只存在于 private Desktop workspace，不得写入根 manifest、根 production tree 或根 npm tarball。Desktop runtime SBOM 从唯一 lockfile 投影 production closure，必须包含 Electron framework 与 native fallback，但排除 Playwright、builder、Vite、审计工具和 test fixtures。
 
 C8 增加的 `electron-updater` 只能由 `apps/desktop/src/main/updater.ts` 动态加载；Renderer、Preload、Utility、共享 UI 和 Core 不得导入 updater、指定 URL/channel 或接触原始 `UpdateInfo`。安装前由同一 `CoreRuntimeSupervisor` 同步关闭 restart gate，排空已 admission 的写请求，再执行 active Watch 与全部 Profile recovery 复核；失败路径必须重新开放 gate。C8 实现受控状态机与安装门禁，但 `apps/desktop` 版本仍为 `0.0.0` 时发布通道保持 disabled；实际版本注入、签名、更新 metadata 与真实跨版本升级 smoke 属于 C9/C10 发布门禁，不因依赖已接入而视为已发布。

--- a/docs/migration/evidence/C10_EVIDENCE_BUNDLE.v1.schema.json
+++ b/docs/migration/evidence/C10_EVIDENCE_BUNDLE.v1.schema.json
@@ -141,6 +141,7 @@
       ],
       "properties": {
         "evidenceSha256": { "$ref": "#/$defs/hash" },
+        "sourceRunAttempt": { "type": "integer", "minimum": 1 },
         "artifactName": { "const": "historical-formal-release-backup-evidence" },
         "release": {
           "type": "object",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7657,9 +7657,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/scripts/write-c10-evidence-bundle.mjs
+++ b/scripts/write-c10-evidence-bundle.mjs
@@ -258,7 +258,12 @@ export function normalizeFormalReleaseEvidence(
   assertExactKeys(evidence.workflow, ["repository", "runId", "runAttempt", "testedCommit"], "Formal Release workflow binding");
   assert.equal(evidence.workflow.repository, repository);
   assert.equal(evidence.workflow.runId, runId);
-  assert.equal(evidence.workflow.runAttempt, runAttempt);
+  assert.ok(Number.isSafeInteger(runAttempt) && runAttempt >= 1, "Current workflow attempt must be a positive safe integer.");
+  const sourceRunAttempt = evidence.workflow.runAttempt;
+  assert.ok(Number.isSafeInteger(sourceRunAttempt) && sourceRunAttempt >= 1, "Formal Release evidence attempt must be a positive safe integer.");
+  // GitHub partial reruns retain artifacts from successful jobs in earlier attempts.
+  // Repository, run ID and tested commit must still match exactly.
+  assert.ok(sourceRunAttempt <= runAttempt, "Formal Release evidence cannot come from a future attempt.");
   assert.equal(evidence.workflow.testedCommit, evidenceForCommit);
 
   assertExactKeys(evidence.release, [
@@ -324,6 +329,7 @@ export function normalizeFormalReleaseEvidence(
 
   return Object.freeze({
     artifactName: "historical-formal-release-backup-evidence",
+    sourceRunAttempt,
     release: Object.freeze({
       repository: evidence.release.repository,
       releaseId: evidence.release.releaseId,

--- a/test/c10-evidence-bundle.test.js
+++ b/test/c10-evidence-bundle.test.js
@@ -201,6 +201,45 @@ test("C10 formal Release evidence binds the hosted binary and current workflow",
   }
 });
 
+test("C10 partial reruns reuse only same-run, same-commit evidence from non-future attempts", () => {
+  const context = {
+    manifest: formalReleaseManifest,
+    evidenceForCommit: sha,
+    repository: formalReleaseManifest.repository,
+    runId: "42",
+    runAttempt: 3
+  };
+  for (const attempt of [1, 2, 3]) {
+    const evidence = formalReleaseEvidence();
+    evidence.workflow.runAttempt = attempt;
+    const normalized = normalizeFormalReleaseEvidence(evidence, context);
+    assert.equal(normalized.sourceRunAttempt, attempt);
+    assert.equal(evidence.workflow.runAttempt, attempt);
+  }
+  for (const attempt of [0, -1, 1.5, "1", null, undefined, NaN, Infinity, 4, Number.MAX_SAFE_INTEGER + 1]) {
+    const evidence = formalReleaseEvidence();
+    evidence.workflow.runAttempt = attempt;
+    assert.throws(() => normalizeFormalReleaseEvidence(evidence, context), /attempt/i);
+  }
+  for (const attempt of [0, -1, 1.5, "3", null, undefined, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1]) {
+    assert.throws(() => normalizeFormalReleaseEvidence(formalReleaseEvidence(), {
+      ...context, runAttempt: attempt
+    }), /attempt/i);
+  }
+  for (const mutate of [
+    (evidence) => { evidence.workflow.repository = "other/repository"; },
+    (evidence) => { evidence.workflow.runId = "41"; },
+    (evidence) => { evidence.workflow.testedCommit = "c".repeat(40); },
+    (evidence) => { evidence.asset.sha256 = hash; },
+    (evidence) => { evidence.verification.currentNodeRestoreVerified = false; }
+  ]) {
+    const evidence = formalReleaseEvidence();
+    evidence.workflow.runAttempt = 1;
+    mutate(evidence);
+    assert.throws(() => normalizeFormalReleaseEvidence(evidence, context));
+  }
+});
+
 test("C10 redaction rejects protected keys, absolute paths, and credential markers", () => {
   assert.doesNotThrow(() => assertRedacted({ evidencePath: "docs/migration/evidence/C9.md", result: "success" }));
   assert.throws(() => assertRedacted({ token: "redacted" }), /forbidden key class/);
@@ -267,6 +306,30 @@ test("C10 JSON schema compiles in strict mode and rejects an incomplete bundle",
     assertEvidenceSchema({}, rootDir),
     /does not match its JSON Schema/
   );
+});
+
+test("C10 evidence schema validates source attempt and remains compatible with older bundles", {
+  skip: Number(process.versions.node.split(".")[0]) < 24
+}, async () => {
+  const { default: Ajv2020 } = await import("ajv/dist/2020.js");
+  const schema = JSON.parse(fs.readFileSync(path.join(rootDir, "docs", "migration", "evidence", "C10_EVIDENCE_BUNDLE.v1.schema.json"), "utf8"));
+  const validate = new Ajv2020({ strict: true }).compile({
+    $defs: schema.$defs,
+    ...schema.properties.historicalFormalRelease
+  });
+  const evidence = {
+    evidenceSha256: hash,
+    ...normalizeFormalReleaseEvidence(formalReleaseEvidence(), {
+      manifest: formalReleaseManifest, evidenceForCommit: sha,
+      repository: formalReleaseManifest.repository, runId: "42", runAttempt: 4
+    })
+  };
+  assert.equal(validate(evidence), true, JSON.stringify(validate.errors));
+  for (const attempt of [0, -1, 1.5, "3", null]) {
+    assert.equal(validate({ ...evidence, sourceRunAttempt: attempt }), false);
+  }
+  delete evidence.sourceRunAttempt;
+  assert.equal(validate(evidence), true, JSON.stringify(validate.errors));
 });
 
 test("C10 event-base evidence follows the actual Git graph for push and pull-request commits", async () => {


### PR DESCRIPTION
## 改动

- 中文 README 按维护者确认恢复原有同步示意图片、共享 Node Core Mermaid 架构图、读写策略与开发入口；核心功能、Windows 下载和日常说明保持简洁。英文入口保留此前精简。
- 明确 Windows v1.0.0 已发布、未签名和手动更新；旧 .NET updater 不能迁移；npm / Web 版本独立，macOS/Linux Electron 包未发布。
- 保留等字节长原地写、正文不变、备份、时间戳和跨 Provider 不能保证继续等用户边界，不修改应用业务代码。
- 更新日/韩文发布提示；统一 AGENTS 的 Provider 元数据定位；Bug 模板区分 Electron、Web、CLI 和 Legacy，使用当前界面/日志说明。

## 验证

- `git diff --check` 通过。
- 首轮 92 个相对链接目标存在；最终 README 的 25 个相对链接及锚点重新检查通过，原图片文件存在。
- Bug 模板 YAML 解析通过，10 个字段 ID 无重复。
- `node --test apps/desktop/tests/release-candidate.test.mjs`：14/14 通过。
- 独立只读文档复核无阻塞项。
- 最终 head `874e9de` 本地 `npm test`：490 通过、54 跳过、0 失败，使用 D 盘临时夹具；未将跳过或旧安装包人工测试算作通过。打包/跨平台以当前 head 完整 CI 为准。

## 获授权追加的独立依赖补丁

- `733c900` 将 updater / builder 的传递依赖 `js-yaml 4.3.1` 锁定为兼容补丁版 `4.3.2`，修复 GHSA-2883-xcg3-v3hh；lockfile 仅此条目变更，无根生产依赖新增。
- 新测试直接加载 updater 实际使用的 YAML：旧版空合并源预算测试失败，新版通过；普通更新 YAML 和正常锚点合并仍正确。
- `npm ci`、生产树 / 全树 audit：0 漏洞；独立依赖复核无阻塞。
- `desktop:test`：161 通过、1 跳过、0 失败；漏洞与发布测试 16/16 通过。
- `desktop:build`、`desktop:verify-production-bundle` 通过。
- 旧 head `9956b2c` 的 run 34305698687 有 audit 失败与 Linux packaged CDP 连接超时；不将旧结果视为新 head 通过证据，不放宽门禁。后续 `d38fbfb` 的 run 34306306686 在 Linux 重跑通过后暴露证据 runAttempt 校验问题，保留其失败记录。完整门禁以最终 head `874e9de` 的 run 34309233966 为准。
- 补充 Unreleased / ADR 维护说明，不改已发布 v1.0.0 安装包。

- 审查项另由 `d38fbfb` 修复：移除 diagnostics 字段的 `render: text`，允许概览截图附件；YAML 验证字段仍必填、日志字段保留纯文本，已回复并解决该审查线程。

## 获授权追加的 CI 部分重跑修复

- `874e9de` 允许同仓库、同 runId、同 tested commit 的当前或更早安全正整数 attempt 证据；其余来源、哈希、验证结果及 required-job 门禁不变。
- 新 bundle 保留 sourceRunAttempt；自身 workflow.runAttempt 仍记录当前次数；v1 schema 兼容旧 bundle。
- 回归先复现错误，修复后证据测试 9/9；另有发布/YAML 测试 16/16；独立只读复核无阻塞。
- 同步 Windows 发布操作文档；不改变 Core、版本或公开发布资产。

## 配套仓库整理（已完成，不由本 PR 关闭 Issue）

- #73 已被 #80/#81 接替；#50/#54 不适配当前合同且原审查阻断项未解决，逐条说明后关闭，贡献及外部 fork 保留。
- #45 的窗口位置修复已发布，附原机未复测说明后关闭。
- #28、#77、#89 未有充分解决证据，保持开放。
- 删除已完整合入 main 的 V1 本地/远端分支；提交历史及 v1.0.0 标签均保留。

维护者已确认最终 README 并授权合并；最终 head `874e9de` 的 run 34309233966 首次运行 26/26 jobs 全部通过，审查已解决。已采用 merge commit `0dd0263c36843a332dd73632c30ce7930cdba889` 合入 main，全部提交历史保留。本地 main 已同步，已合并的 cleanup 分支已清理。main 合入后的复验 run 34310532555 attempt 2 已完成，26/26 jobs 成功；当前 attempt 2 正确复用同 SHA 的 attempt 1 源证据，已核对 C10 JSON 与 SHA256。首次三个测试失败及诊断限制保留在 PR 后续评论，不宣称其根因全部修复。不改版本号、不重新发布。